### PR TITLE
Structured command line options

### DIFF
--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -4,13 +4,10 @@
 #include <string>
 #include <utility>
 
-#include "cct_smallvector.hpp"
 #include "commandlineoptionsparser.hpp"
 #include "currencycode.hpp"
-#include "exchangename.hpp"
-#include "market.hpp"
-#include "monetaryamount.hpp"
 #include "tradeoptionsapi.hpp"
+#include "wallet.hpp"
 
 namespace cct {
 
@@ -18,8 +15,6 @@ struct CoincenterCmdLineOptions {
   void setLogLevel() const;
 
   void setLogFile() const;
-
-  static void PrintUsage(const char* programName, const char* error = nullptr);
 
   static void PrintVersion(const char* programName);
 
@@ -49,29 +44,73 @@ struct CoincenterCmdLineOptions {
   std::string withdraw{};
 };
 
-inline CoincenterCmdLineOptions ParseCoincenterCmdLineOptions(const vector<std::string_view>& vargv) {
-  auto parser = CmdOpts<CoincenterCmdLineOptions>::Create(
-      {{"--help", &CoincenterCmdLineOptions::help},
-       {"--version", &CoincenterCmdLineOptions::version},
-       {"--loglevel", &CoincenterCmdLineOptions::logLevel},
-       {"--logfile", &CoincenterCmdLineOptions::logFile},
+template <class OptValueType>
+inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser() {
+  constexpr int64_t defaultTradeTimeout =
+      std::chrono::duration_cast<std::chrono::seconds>(api::TradeOptions::kDefaultTradeDuration).count();
+  constexpr int64_t emergencyBufferTime =
+      std::chrono::duration_cast<std::chrono::milliseconds>(api::TradeOptions::kDefaultEmergencyTime).count();
+  constexpr int64_t minUpdatePriceTime =
+      std::chrono::duration_cast<std::chrono::milliseconds>(api::TradeOptions::kDefaultMinTimeBetweenPriceUpdates)
+          .count();
+  const bool isSimulationModeByDefault = api::TradeOptions().simulation();
 
-       {"--orderbook", &CoincenterCmdLineOptions::orderbook},
-       {"--orderbook-depth", &CoincenterCmdLineOptions::orderbook_depth},
-       {"--orderbook-cur", &CoincenterCmdLineOptions::orderbook_cur},
+  // clang-format off
+  return CommandLineOptionsParser<OptValueType>(
+      {{{{"General", 1}, "--help", 'h', "", "Display this information"}, &OptValueType::help},
+       {{{"General", 1}, "--version", "", "Display program version"}, &OptValueType::version},
+       {{{"General", 1}, "--loglevel", "<levelname>", "Sets the log level during all execution. "
+                                                      "Possible values are: trace|debug|info|warning|error|critical|off"}, 
+                                                      &OptValueType::logLevel},
+       {{{"General", 1}, "--logfile", "", "Log to rotating files instead of stdout / stderr"}, &OptValueType::logFile},
 
-       {"--balance", &CoincenterCmdLineOptions::balance},
-       {"--balance-cur", &CoincenterCmdLineOptions::balance_cur},
+       {{{"Public queries", 2}, "--orderbook", 'o', "<cur1-cur2,exch1,...>", "Print order book of currency pair on a list of exchanges"}, 
+                                                                             &OptValueType::orderbook},
+       {{{"Public queries", 2}, "--orderbook-depth", "", "Override default depth of order book"}, &OptValueType::orderbook_depth},
+       {{{"Public queries", 2}, "--orderbook-cur", "<cur code>", "If conversion of cur2 into cur is possible on exch1, "
+                                                                 "prints additional column converted to given asset"}, 
+                                                                 &OptValueType::orderbook_cur},
 
-       {"--trade", &CoincenterCmdLineOptions::trade},
-       {"--trade-strategy", &CoincenterCmdLineOptions::trade_strategy},
-       {"--trade-timeout", &CoincenterCmdLineOptions::trade_timeout_s},
-       {"--trade-emergency", &CoincenterCmdLineOptions::trade_emergency_ms},
-       {"--trade-updateprice", &CoincenterCmdLineOptions::trade_updateprice_ms},
-       {"--trade-sim", &CoincenterCmdLineOptions::trade_sim},
+       {{{"Private queries", 3}, "--balance", 'b', "<exch1,...|all>", "Prints available balance on given exchanges. "
+                                                                      "If 'all' is specified, sums all available private exchange accounts"}, 
+                                                                      &OptValueType::balance},
+       {{{"Private queries", 3}, "--balance-cur", "<cur code>", "Print additional information with each asset "
+                                                                "converted to given currency, plus a total summary"}, 
+                                                                &OptValueType::balance_cur},
 
-       {"--withdraw", &CoincenterCmdLineOptions::withdraw}});
-  return parser.parse(vargv);
+       {{{"Trade", 4}, "--trade", 't', "<amt cur1-cur2,exchange>", "Single trade from given start amount on an exchange. "
+                                                                   "Order will be placed at limit price by default"}, &OptValueType::trade},
+       {{{"Trade", 4}, "--trade-strategy", "<maker|taker|adapt>", "Customize the strategy of the trade\n"
+                                                                  " - 'maker': order placed at limit price (default), continuously "
+                                                                  "adjusted to limit price\n"
+                                                                  " - 'taker': order placed at market price should be matched directly\n"
+                                                                  " - 'adapt': same as maker, except that order will be updated"
+                                                                  " at market price before the timeout to make it eventually completely matched"}, 
+                                                                  &OptValueType::trade_strategy},
+       {{{"Trade", 4}, "--trade-timeout", "<s>", std::string("Adjust trade timeout (default: ")
+                                                .append(std::to_string(defaultTradeTimeout))
+                                                .append("). Remaining orders will be cancelled after the timeout.")}, 
+                                                &OptValueType::trade_timeout_s},
+       {{{"Trade", 4}, "--trade-emergency", "<ms>", std::string("Adjust emergency buffer for the 'adapt' strategy (default: ")
+                                                    .append(std::to_string(emergencyBufferTime))
+                                                    .append("). Remaining order will be switched from limit to market price "
+                                                    "after 'timeout - emergency' time to force completion of the trade")}, 
+                                                    &OptValueType::trade_emergency_ms},
+       {{{"Trade", 4}, "--trade-updateprice", "<ms>", std::string("Set the min time allowed between two limit price updates (default: ")
+                                                     .append(std::to_string(minUpdatePriceTime))
+                                                     .append("). Avoids cancelling / placing new orders too often with high volumes "
+                                                     "which can be counter productive sometimes.")}, &OptValueType::trade_updateprice_ms},
+       {{{"Trade", 4}, "--trade-sim", "", std::string("Activates simulation mode only (default: ")
+                                         .append(isSimulationModeByDefault ? "true" : "false")
+                                         .append("). For some exchanges, API can even be queried in this "
+                                         "mode to ensure deeper and more realistic trading inputs")}, &OptValueType::trade_sim},
+
+       {{{"Withdraw crypto", 5}, "--withdraw", 'w', "<amt cur,from-to>", std::string("Withdraw amount from exchange 'from' to exchange 'to'."
+                                                                         " Amount is gross, including fees. Address and tag will be "
+                                                                         "retrieved automatically from '")
+                                                                        .append(Wallet::kDepositAddressesFilename)
+                                                                        .append(".json' file. Make sure that values are up to date (and "
+                                                                        "correct of course!)")}, &OptValueType::withdraw}});
+  // clang-format on
 }
-
 }  // namespace cct

--- a/src/engine/src/coincenteroptions.cpp
+++ b/src/engine/src/coincenteroptions.cpp
@@ -7,83 +7,8 @@
 #include "cct_const.hpp"
 #include "cct_log.hpp"
 #include "stringoptionparser.hpp"
-#include "tradeoptionsapi.hpp"
-#include "wallet.hpp"
 
 namespace cct {
-
-void CoincenterCmdLineOptions::PrintUsage(const char* programName, const char* error) {
-  if (error) {
-    std::cerr << error << std::endl;
-  }
-  std::cout << "usage: " << programName << " [options]" << std::endl;
-  std::cout << "Options:" << std::endl;
-
-  std::cout << " General" << std::endl;
-  std::cout << "  --help                    Display this information." << std::endl;
-  std::cout << "  --version                 Display trade program version." << std::endl;
-  std::cout << "  --loglevel <levelname>    Sets the log level during all execution." << std::endl;
-  std::cout << "                            Possible values are: trace|debug|info|warning|error|critical|off"
-            << std::endl;
-  std::cout << "  --logfile                 Log to rotating files instead of stdout / stderr." << std::endl;
-
-  std::cout << std::endl;
-  // clang-format off
-  std::cout << " Public queries" << std::endl;
-  std::cout << std::endl;
-  std::cout << "  --orderbook <cur1-cur2,exch1,...>  Print order book of currency pair on a list of exchanges." << std::endl;
-  std::cout << "  --orderbook-depth <d>              Override default depth of order book" << std::endl;
-  std::cout << "  --orderbook-cur <cur code>         If conversion of cur2 into cur is possible on exch1," << std::endl;
-  std::cout << "                                     prints additional column converted to given asset" << std::endl;
-  std::cout << std::endl;
-
-  std::cout << " Private queries" << std::endl;
-  std::cout << std::endl;
-  std::cout << "  --balance <exch1,...|all>          Prints available balance on given exchanges" << std::endl;
-  std::cout << "                                     If 'all' is specified, sums all available private exchange accounts" << std::endl;
-  std::cout << "  --balance-cur <cur code>           Print additional information with each asset" << std::endl;
-  std::cout << "                                     converted to given currency, plus a total summary" << std::endl;
-  std::cout << std::endl;
-
-  std::cout << " Trade" << std::endl;
-  std::cout << std::endl;
-  std::cout << "  --trade <amt cur1-cur2,exchange>   Single trade from given start amount on an exchange" << std::endl;
-  std::cout << "                                     Order will be placed at limit price by default" << std::endl;
-  std::cout << "  --trade-strategy <strategy>        Customize the strategy of the trade." << std::endl;
-  std::cout << "                                     Possible values are: maker|taker|adapt" << std::endl;
-  std::cout << "                                      - maker: order placed at limit price (default)" << std::endl;
-  std::cout << "                                               price is continuously adjusted to limit price" << std::endl;
-  std::cout << "                                      - taker: order placed at market price" << std::endl;
-  std::cout << "                                               should be matched directly" << std::endl;
-  std::cout << "                                      - adapt: same as maker, except that order will be " << std::endl;
-  std::cout << "                                               updated at market price before the timeout" << std::endl;
-  std::cout << "                                               to make it eventually completely matched" << std::endl;
-  api::TradeOptions tradeOptionsDefault;
-  constexpr int64_t defaultTradeTimeout = std::chrono::duration_cast<std::chrono::seconds>(api::TradeOptions::kDefaultTradeDuration).count();
-  std::cout << "  --trade-timeout <s>                Adjust trade timeout (default: " << defaultTradeTimeout << ")" << std::endl;
-  std::cout << "                                     Remaining orders will be cancelled after the timeout." << std::endl;
-  constexpr int64_t emergencyBufferTime = std::chrono::duration_cast<std::chrono::milliseconds>(api::TradeOptions::kDefaultEmergencyTime).count();
-  std::cout << "  --trade-emergency <ms>             Adjust emergency buffer for the 'adapt' strategy (default: " << emergencyBufferTime << ")" << std::endl;
-  std::cout << "                                     Remaining order will be switched from limit to market price" << std::endl;
-  std::cout << "                                     after 'timeout - emergency' time to force completion of the trade" << std::endl;
-  constexpr int64_t minUpdatePriceTime = std::chrono::duration_cast<std::chrono::milliseconds>(api::TradeOptions::kDefaultMinTimeBetweenPriceUpdates).count();
-  std::cout << "  --trade-updateprice <ms>           Set the min time allowed between two limit price updates (default: " << minUpdatePriceTime << ")" << std::endl;
-  std::cout << "                                     Avoids cancelling / placing new orders too often with high volumes," << std::endl;
-  std::cout << "                                     which can be counter productive sometimes." << std::endl;
-  const bool isSimulationModeByDefault = tradeOptionsDefault.simulation();
-  std::cout << "  --trade-sim                        Activates simulation mode only (default: " << (isSimulationModeByDefault ? "true" : "false") << ")" << std::endl;
-  std::cout << "                                     For some exchanges (Kraken) API can even be queried in this mode" << std::endl;
-  std::cout << "                                     to ensure deeper and more realistic trading inputs." << std::endl;
-  std::cout << std::endl;
-  std::cout << " Withdraw crypto" << std::endl;
-  std::cout << std::endl;
-  std::cout << "  --withdraw <amt cur,from-to>       Withdraw amount from exchange 'from' to exchange 'to'" << std::endl;
-  std::cout << "                                     Amount is gross, including fees. Address and tag will be retrieved " << std::endl;
-  std::cout << "                                     automatically from '" << Wallet::kDepositAddressesFilename << ".json' file. Make sure" << std::endl;
-  std::cout << "                                     that values are up to date (and correct of course!). " << std::endl;
-  // clang-format on
-  std::cout << std::endl;
-}
 
 void CoincenterCmdLineOptions::PrintVersion(const char* programName) {
   std::cout << programName << " version " << kVersion << std::endl;

--- a/src/engine/src/main.cpp
+++ b/src/engine/src/main.cpp
@@ -26,7 +26,7 @@
 namespace cct {
 namespace {
 
-int main(int argc, char* argv[]) {
+int main(int argc, const char* argv[]) {
   MonetaryAmount startTradeAmount;
   CurrencyCode toTradeCurrency;
   PrivateExchangeName tradePrivateExchangeName;
@@ -44,10 +44,11 @@ int main(int argc, char* argv[]) {
   PrivateExchangeName withdrawFromExchangeName, withdrawToExchangeName;
 
   try {
-    CoincenterCmdLineOptions cmdLineOptions =
-        ParseCoincenterCmdLineOptions(vector<std::string_view>(argv, argv + argc));
+    CommandLineOptionsParser<CoincenterCmdLineOptions> coincenterCommandLineOptionsParser =
+        CreateCoincenterCommandLineOptionsParser<CoincenterCmdLineOptions>();
+    CoincenterCmdLineOptions cmdLineOptions = coincenterCommandLineOptionsParser.parse(argc, argv);
     if (cmdLineOptions.help) {
-      CoincenterCmdLineOptions::PrintUsage(argv[0]);
+      coincenterCommandLineOptionsParser.displayHelp(argv[0], std::cout);
       return EXIT_SUCCESS;
     }
     if (cmdLineOptions.version) {
@@ -93,7 +94,7 @@ int main(int argc, char* argv[]) {
     }
 
   } catch (const InvalidArgumentException& e) {
-    CoincenterCmdLineOptions::PrintUsage(argv[0], e.what());
+    std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -210,4 +211,4 @@ int main(int argc, char* argv[]) {
 }  // namespace
 }  // namespace cct
 
-int main(int argc, char* argv[]) { return cct::main(argc, argv); }
+int main(int argc, const char* argv[]) { return cct::main(argc, argv); }

--- a/src/tools/include/commandlineoptionsparser.hpp
+++ b/src/tools/include/commandlineoptionsparser.hpp
@@ -4,83 +4,278 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <span>
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <variant>
 
 #include "cct_flatset.hpp"
-#include "cct_vector.hpp"
 
 namespace cct {
 using InvalidArgumentException = std::invalid_argument;
 
-/// Simple Command line options parser.
-/// Base taken from https://www.codeproject.com/Tips/5261900/Cplusplus-Lightweight-Parsing-Command-Line-Argumen
-/// with some modifications. All credits to the original author.
-/// License can be retrieved here: https://www.codeproject.com/info/cpol10.aspx
-template <class Opts>
-class CmdOpts : Opts {
+/// Description of a command line option.
+class CommandLineOption {
  public:
-  using MyProp = std::variant<std::string Opts::*, int Opts::*, double Opts::*, bool Opts::*>;
-  using MyArg = std::pair<std::string, MyProp>;
+  using GroupNameAndPrio = std::pair<std::string_view, int>;
 
-  Opts parse(int argc, char* argv[]) { return parse(vector<std::string_view>(argv, argv + argc)); }
+  CommandLineOption(GroupNameAndPrio optionGroupName, std::string_view fullName, char shortName,
+                    std::string_view valueDescription, std::string_view description)
+      : _optionGroupName(optionGroupName.first),
+        _fullName(fullName),
+        _valueDescription(valueDescription),
+        _description(description),
+        _prio(optionGroupName.second),
+        _shortName(shortName) {}
 
-  Opts parse(const vector<std::string_view>& vargv) {
-    int nbArgs = vargv.size();
-    for (int idx = 0; idx < nbArgs; ++idx) {
-      if (vargv[idx].starts_with('-') && !optionNames.contains(std::string(vargv[idx]))) {
-        throw std::invalid_argument("unrecognized command-line option '" + std::string(vargv[idx]) + "'");
-      }
-      for (auto& cbk : callbacks) {
-        cbk.second(idx, vargv);
-      }
+  CommandLineOption(GroupNameAndPrio optionGroupName, std::string_view fullName, std::string_view valueDescription,
+                    std::string_view description)
+      : CommandLineOption(optionGroupName, fullName, '\0', valueDescription, description) {}
+
+  bool matches(std::string_view optName) const {
+    if (optName.size() == 2 && optName.front() == '-' && optName.back() == _shortName) {
+      return true;
     }
-    return static_cast<Opts>(*this);
+    return optName == _fullName;
   }
 
-  static CmdOpts Create(std::initializer_list<MyArg> args) {
-    CmdOpts cmdOpts;
-    for (auto arg : args) {
-      cmdOpts.register_callback(arg.first, arg.second);
-      cmdOpts.optionNames.insert(arg.first);
+  const std::string& optionGroupName() const { return _optionGroupName; }
+  const std::string& fullName() const { return _fullName; }
+  const std::string& description() const { return _description; }
+  const std::string& valueDescription() const { return _valueDescription; }
+
+  std::string shortName() const {
+    std::string ret;
+    if (_shortName != '\0') {
+      ret.push_back('-');
+      ret.push_back(_shortName);
     }
-    return cmdOpts;
+    return ret;
+  }
+
+  bool operator<(const CommandLineOption& o) const {
+    if (_prio != o._prio) {
+      return _prio < o._prio;
+    }
+    if (_optionGroupName != o._optionGroupName) {
+      return _optionGroupName < o._optionGroupName;
+    }
+    return _fullName < o._fullName;
   }
 
  private:
-  using callback_t = std::function<void(int, const vector<std::string_view>&)>;
-  std::map<std::string, callback_t> callbacks;
-  FlatSet<std::string> optionNames;
+  std::string _optionGroupName;
+  std::string _fullName;
+  std::string _valueDescription;
+  std::string _description;
+  int _prio;
+  char _shortName;
+};
 
-  CmdOpts() = default;
+class CommandLineOptions {
+ private:
+  using OptionsSet = FlatSet<CommandLineOption>;
 
-  CmdOpts(const CmdOpts&) = delete;
-  CmdOpts(CmdOpts&&) = default;
-  CmdOpts& operator=(const CmdOpts&) = delete;
-  CmdOpts& operator=(CmdOpts&&) = default;
+ public:
+  using const_iterator = OptionsSet::const_iterator;
+  using value_type = CommandLineOption;
 
-  void register_callback(std::string name, MyProp prop) {
-    callbacks[name] = [this, name, prop](int idx, const vector<std::string_view>& argv) {
-      if (argv[idx] == name) {
+  CommandLineOptions() = default;
+
+  CommandLineOptions(std::initializer_list<CommandLineOption> init) : _opts(init.begin(), init.end()) {}
+
+  CommandLineOptions(std::span<const CommandLineOption> init) : _opts(init.begin(), init.end()) {}
+
+  const_iterator begin() const { return _opts.begin(); }
+  const_iterator end() const { return _opts.end(); }
+
+  void insert(const CommandLineOption& o) { _opts.insert(o); }
+  void insert(CommandLineOption&& o) { _opts.insert(std::move(o)); }
+
+  const_iterator insert(const_iterator hint, const CommandLineOption& o) { return _opts.insert(hint, o); }
+  const_iterator insert(const_iterator hint, CommandLineOption&& o) { return _opts.insert(hint, std::move(o)); }
+
+  void merge(const CommandLineOptions& o) { _opts.insert(o.begin(), o.end()); }
+
+  template <typename StreamType>
+  void print(StreamType& stream) const {
+    if (_opts.empty()) {
+      return;
+    }
+    int lenFirstRows = 0;
+    constexpr int kMaxCharLine = 140;
+    for (const CommandLineOption& opt : _opts) {
+      int lenRows = opt.fullName().size() + opt.valueDescription().size() + 1;
+      int shortNameSize = opt.shortName().size();
+      if (shortNameSize > 0) {
+        lenRows += shortNameSize + 2;
+      }
+      lenFirstRows = std::max(lenFirstRows, lenRows);
+    }
+    std::string_view currentGroup, previousGroup;
+    for (const CommandLineOption& opt : _opts) {
+      currentGroup = opt.optionGroupName();
+      if (currentGroup != previousGroup) {
+        stream << std::endl << ' ' << currentGroup << std::endl;
+      }
+      std::string firstRowsStr = opt.fullName();
+      std::string shortName = opt.shortName();
+      if (!shortName.empty()) {
+        firstRowsStr.push_back(',');
+        firstRowsStr.push_back(' ');
+        firstRowsStr.append(shortName);
+      }
+      firstRowsStr.push_back(' ');
+      firstRowsStr.append(opt.valueDescription());
+      firstRowsStr.insert(firstRowsStr.end(), lenFirstRows - firstRowsStr.size(), ' ');
+      stream << "  " << firstRowsStr << ' ';
+
+      std::string_view descr = opt.description();
+      int linePos = lenFirstRows + 3;
+      std::string spaces(linePos, ' ');
+      while (!descr.empty()) {
+        if (linePos + descr.size() <= kMaxCharLine) {
+          stream << descr << std::endl;
+          break;
+        }
+        std::size_t breakPos = descr.find_first_of(" \n");
+        if (breakPos == std::string_view::npos) {
+          stream << std::endl << spaces << descr << std::endl;
+          break;
+        }
+        if (linePos + breakPos > kMaxCharLine) {
+          stream << std::endl << spaces;
+          linePos = lenFirstRows + 3;
+        }
+        stream << std::string_view(descr.begin(), descr.begin() + breakPos + 1);
+        if (descr[breakPos] == '\n') {
+          stream << spaces;
+          linePos = lenFirstRows + 3;
+        }
+
+        linePos += breakPos + 1;
+        descr.remove_prefix(breakPos + 1);
+      }
+
+      previousGroup = currentGroup;
+    }
+
+    stream << std::endl;
+  }
+
+ private:
+  OptionsSet _opts;
+};
+
+/// Simple Command line options parser.
+/// Base taken from https://www.codeproject.com/Tips/5261900/Cplusplus-Lightweight-Parsing-Command-Line-Argumen
+/// with enhancements.
+/// Original code license can be retrieved here: https://www.codeproject.com/info/cpol10.aspx
+template <class Opts>
+class CommandLineOptionsParser : Opts {
+ public:
+  using OptionType = std::variant<std::string Opts::*, int Opts::*, bool Opts::*>;
+  using CommandLineOptionWithValue = std::pair<CommandLineOption, OptionType>;
+
+  CommandLineOptionsParser(std::initializer_list<CommandLineOptionWithValue> init)
+      : _commandLineOptionsWithValues(init.begin(), init.end()) {}
+
+  explicit CommandLineOptionsParser(std::span<const CommandLineOptionWithValue> options)
+      : _commandLineOptionsWithValues(options.begin(), options.end()) {}
+
+  CommandLineOptionsParser(const CommandLineOptionsParser&) = delete;
+  CommandLineOptionsParser(CommandLineOptionsParser&&) = default;
+  CommandLineOptionsParser& operator=(const CommandLineOptionsParser&) = delete;
+  CommandLineOptionsParser& operator=(CommandLineOptionsParser&&) = default;
+
+  void insert(const CommandLineOptionWithValue& commandLineOptionWithValue) {
+    _commandLineOptionsWithValues.insert(commandLineOptionWithValue);
+  }
+  void insert(CommandLineOptionWithValue&& commandLineOptionWithValue) {
+    _commandLineOptionsWithValues.insert(std::move(commandLineOptionWithValue));
+  }
+
+  void merge(const CommandLineOptionsParser& o) {
+    _commandLineOptionsWithValues.insert(o._commandLineOptionsWithValues.begin(),
+                                         o._commandLineOptionsWithValues.end());
+  }
+
+  Opts parse(std::span<const char*> vargv) {
+    // First register the callbacks
+    for (const CommandLineOptionWithValue& arg : _commandLineOptionsWithValues) {
+      register_callback(arg.first, arg.second);
+    }
+
+    int idxOpt = 0;
+    for (const char* argStr : vargv) {
+      if (argStr[0] == '-') {
+        const bool knownOption = std::any_of(_commandLineOptionsWithValues.begin(), _commandLineOptionsWithValues.end(),
+                                             [argStr](const auto& opt) { return opt.first.matches(argStr); });
+        if (!knownOption) {
+          throw InvalidArgumentException("unrecognized command-line option '" + std::string(argStr) + "'");
+        }
+      }
+      for (auto& cbk : _callbacks) {
+        cbk.second(idxOpt, vargv);
+      }
+      ++idxOpt;
+    }
+
+    return static_cast<Opts>(*this);
+  }
+
+  Opts parse(int argc, const char* argv[]) { return parse(std::span(argv, argc)); }
+
+  template <typename StreamType>
+  void displayHelp(const char* programName, StreamType& stream) const {
+    stream << "usage: " << programName << " [options]" << std::endl;
+    stream << "Options:" << std::endl;
+
+    CommandLineOptions commandLineOptions;
+    std::transform(_commandLineOptionsWithValues.begin(), _commandLineOptionsWithValues.end(),
+                   std::inserter(commandLineOptions, commandLineOptions.end()),
+                   [](const CommandLineOptionWithValue& arg) { return arg.first; });
+
+    commandLineOptions.print(stream);
+  }
+
+ private:
+  using callback_t = std::function<void(int, std::span<const char*>)>;
+
+  struct CompareCommandLineOptionWithValue {
+    bool operator()(const CommandLineOptionWithValue& lhs, const CommandLineOptionWithValue& rhs) const {
+      return lhs.first < rhs.first;
+    }
+  };
+
+  using CommandLineOptionsWithValuesSet = FlatSet<CommandLineOptionWithValue, CompareCommandLineOptionWithValue>;
+
+  CommandLineOptionsWithValuesSet _commandLineOptionsWithValues;
+  std::map<CommandLineOption, callback_t> _callbacks;
+
+  void register_callback(const CommandLineOption& commandLineOption, OptionType prop) {
+    _callbacks[commandLineOption] = [this, &commandLineOption, prop](int idx, std::span<const char*> argv) {
+      if (commandLineOption.matches(argv[idx])) {
         visit(
-            [this, idx, &argv, &name](auto&& arg) {
+            [this, idx, argv, &commandLineOption](auto&& arg) {
               using T = std::decay_t<decltype(arg)>;
               if constexpr (std::is_same_v<T, bool Opts::*>) {
                 this->*arg = true;
               } else if constexpr (std::is_same_v<T, std::string Opts::*>) {
-                if (idx + 1U < argv.size() && !argv[idx + 1].starts_with('-')) {
+                if (idx + 1U < argv.size() && argv[idx + 1][0] != '-') {
                   this->*arg = argv[idx + 1];
                 } else {
-                  throw std::invalid_argument("Expecting a value for option '" + name + "'");
+                  throw InvalidArgumentException("Expecting a value for option '" + commandLineOption.fullName() + "'");
                 }
-              } else if (idx + 1 < static_cast<int>(argv.size())) {
-                std::stringstream value;
-                value << argv[idx + 1];
-                value >> this->*arg;
               } else {
-                throw std::invalid_argument("Expecting a value for option '" + name + "'");
+                if (idx + 1 < static_cast<int>(argv.size())) {
+                  std::stringstream value;
+                  value << argv[idx + 1];
+                  value >> this->*arg;
+                } else {
+                  throw InvalidArgumentException("Expecting a value for option '" + commandLineOption.fullName() + "'");
+                }
               }
             },
             prop);

--- a/src/tools/test/commandlineoptionsparser_test.cpp
+++ b/src/tools/test/commandlineoptionsparser_test.cpp
@@ -3,33 +3,58 @@
 
 #include <gtest/gtest.h>
 
+#include "cct_vector.hpp"
+
 namespace cct {
-TEST(CommandLineOptionsParser, Basic) {
+
+class CommandLineOptionsParserTest : public ::testing::Test {
+ public:
   struct Opts {
     std::string stringOpt{};
     int intOpt{};
+    int int2Opt{};
     bool boolOpt{};
   };
 
-  CmdOpts parser =
-      CmdOpts<Opts>::Create({{"--opt1", &Opts::stringOpt}, {"--opt2", &Opts::intOpt}, {"--opt3", &Opts::boolOpt}});
+  using ParserType = CommandLineOptionsParser<Opts>;
 
-  Opts options = parser.parse({"coincenter", "--opt1", "toto", "--opt3"});
+  CommandLineOptionsParserTest()
+      : _parser({{{{"General", 1}, "--opt1", 'o', "<myValue>", "Opt1 descr"}, &Opts::stringOpt},
+                 {{{"General", 1}, "--opt2", "", "Opt2 descr"}, &Opts::intOpt},
+                 {{{"Other", 2}, "--opt3", "", "Opt3 descr"}, &Opts::int2Opt},
+                 {{{"General", 1}, "--help", 'h', "", "Help descr"}, &Opts::boolOpt}}) {}
+
+ protected:
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+
+  ParserType _parser;
+};
+
+TEST_F(CommandLineOptionsParserTest, Basic) {
+  cct::vector<const char *> opts1 = {"coincenter", "--opt1", "toto", "--help"};
+  Opts options = _parser.parse(opts1);
   EXPECT_EQ(options.stringOpt, "toto");
   EXPECT_TRUE(options.boolOpt);
 
-  EXPECT_THROW(parser.parse({"coincenter", "--opt1", "toto", "--opt3", "--opt2"}), std::invalid_argument);
-  EXPECT_THROW(parser.parse({"coincenter", "--opt1", "toto", "--opts3", "--opt2", "3"}), std::invalid_argument);
+  cct::vector<const char *> opts2 = {"coincenter", "--opt1", "toto", "--opt3", "--opt2"};
+  EXPECT_THROW(_parser.parse(opts2), std::invalid_argument);
+  cct::vector<const char *> opts3 = {"coincenter", "--opt1", "toto", "--opts3", "--opt2", "3"};
+  EXPECT_THROW(_parser.parse(opts3), std::invalid_argument);
 }
 
-TEST(CommandLineOptionsParser, String) {
-  struct Opts {
-    std::string stringOpt{};
-  };
-
-  CmdOpts parser = CmdOpts<Opts>::Create({{"--opt1", &Opts::stringOpt}});
-
-  Opts options = parser.parse({"coincenter", "--opt1", "2000 EUR, kraken"});
+TEST_F(CommandLineOptionsParserTest, String) {
+  cct::vector<const char *> opts = {"coincenter", "--opt1", "2000 EUR, kraken"};
+  Opts options = _parser.parse(opts);
   EXPECT_EQ(options.stringOpt, "2000 EUR, kraken");
 }
+
+TEST_F(CommandLineOptionsParserTest, AlternativeOptionName) {
+  cct::vector<const char *> opts = {"coincenter", "-h"};
+  Opts options = _parser.parse(opts);
+  EXPECT_TRUE(options.boolOpt);
+  cct::vector<const char *> opts2 = {"coincenter", "-j"};
+  EXPECT_THROW(_parser.parse(opts2), std::invalid_argument);
+}
+
 }  // namespace cct


### PR DESCRIPTION
Describe command line options in a structured manner, with a dynamic `--help` print method to avoid code duplication.
Also improves the parser by giving possibility to alias options with single chars (for instance, `-t` instead of `--trade`).