### PR TITLE
Get deposit / withdrawal statuses from Upbit private API as public API does not give this information

### DIFF
--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -7,6 +7,7 @@
 #include "cachedresultvault.hpp"
 #include "cct_flatset.hpp"
 #include "curlhandle.hpp"
+#include "currencyexchangeflatset.hpp"
 #include "exchangebase.hpp"
 #include "market.hpp"
 #include "wallet.hpp"
@@ -31,6 +32,10 @@ class ExchangePrivate : public ExchangeBase {
   virtual ~ExchangePrivate() {}
 
   std::string_view keyName() const { return _apiKey.name(); }
+
+  /// Retrieve the possible currencies known by current exchange.
+  /// Information should be fully set with private key.
+  virtual CurrencyExchangeFlatSet queryTradableCurrencies() = 0;
 
   /// Get a fast overview of the available assets on this exchange.
   /// @param equiCurrency (optional) if provided, attempt to convert each asset to given currency as an

--- a/src/api/common/include/exchangeprivatedefaultapi.hpp
+++ b/src/api/common/include/exchangeprivatedefaultapi.hpp
@@ -12,6 +12,8 @@ class ExchangePrivateDefault : public ExchangePrivate {
  public:
   ExchangePrivateDefault() : ExchangePrivate(APIKey("default", "", "xxx", "xxx")) {}
 
+  CurrencyExchangeFlatSet queryTradableCurrencies() override { throw exception("Cannot use default private exchange"); }
+
   BalancePortfolio queryAccountBalance(CurrencyCode) override {
     throw exception("Cannot use default private exchange");
   }

--- a/src/api/common/include/exchangepublicapi.hpp
+++ b/src/api/common/include/exchangepublicapi.hpp
@@ -40,6 +40,7 @@ class ExchangePublic : public ExchangeBase {
   virtual ~ExchangePublic() {}
 
   /// Retrieve the possible currencies known by current exchange.
+  /// If some information is not known without any private key, information can be returned partially.
   virtual CurrencyExchangeFlatSet queryTradableCurrencies() = 0;
 
   virtual CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) = 0;

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -19,6 +19,8 @@ class BinancePrivate : public ExchangePrivate {
  public:
   BinancePrivate(CoincenterInfo& config, BinancePublic& binancePublic, const APIKey& apiKey);
 
+  CurrencyExchangeFlatSet queryTradableCurrencies() override;
+
   BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }

--- a/src/api/exchanges/include/bithumbprivateapi.hpp
+++ b/src/api/exchanges/include/bithumbprivateapi.hpp
@@ -31,6 +31,8 @@ class BithumbPrivate : public ExchangePrivate {
 
   BithumbPrivate(CoincenterInfo& config, BithumbPublic& bithumbPublic, const APIKey& apiKey);
 
+  CurrencyExchangeFlatSet queryTradableCurrencies() override;
+
   BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) override {
     return _balanceCache.get(equiCurrency);
   }

--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -17,10 +17,10 @@ class BithumbPublic : public ExchangePublic {
  public:
   BithumbPublic(CoincenterInfo& config, FiatConverter& fiatConverter, api::CryptowatchAPI& cryptowatchAPI);
 
-  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _currenciesCache.get(); }
+  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) override {
-    return _currenciesCache.get().getOrThrow(currencyCode);
+    return _tradableCurrenciesCache.get().getOrThrow(currencyCode);
   }
 
   MarketSet queryTradableMarkets() override;
@@ -43,8 +43,8 @@ class BithumbPublic : public ExchangePublic {
  private:
   friend class BithumbPrivate;
 
-  struct CurrenciesFunc {
-    CurrenciesFunc(CoincenterInfo& config, CurlHandle& curlHandle) : _config(config), _curlHandle(curlHandle) {}
+  struct TradableCurrenciesFunc {
+    TradableCurrenciesFunc(CoincenterInfo& config, CurlHandle& curlHandle) : _config(config), _curlHandle(curlHandle) {}
 
     CurrencyExchangeFlatSet operator()();
 
@@ -81,7 +81,7 @@ class BithumbPublic : public ExchangePublic {
   };
 
   CurlHandle _curlHandle;
-  CachedResult<CurrenciesFunc> _currenciesCache;
+  CachedResult<TradableCurrenciesFunc> _tradableCurrenciesCache;
   CachedResult<WithdrawalFeesFunc> _withdrawalFeesCache;
   CachedResult<AllOrderBooksFunc, int> _allOrderBooksCache;
   CachedResult<OrderBookFunc, Market, int> _orderbookCache;

--- a/src/api/exchanges/include/krakenprivateapi.hpp
+++ b/src/api/exchanges/include/krakenprivateapi.hpp
@@ -21,6 +21,8 @@ class KrakenPrivate : public ExchangePrivate {
  public:
   KrakenPrivate(CoincenterInfo& config, KrakenPublic& krakenPublic, const APIKey& apiKey);
 
+  CurrencyExchangeFlatSet queryTradableCurrencies() override;
+
   BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) override {
     return _balanceCache.get(equiCurrency);
   }

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -21,6 +21,8 @@ class UpbitPrivate : public ExchangePrivate {
  public:
   UpbitPrivate(CoincenterInfo& config, UpbitPublic& upbitPublic, const APIKey& apiKey);
 
+  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
+
   BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) override {
     return _balanceCache.get(equiCurrency);
   }
@@ -32,6 +34,17 @@ class UpbitPrivate : public ExchangePrivate {
   WithdrawInfo withdraw(MonetaryAmount, ExchangePrivate&) override { throw std::runtime_error(""); }
 
  private:
+  struct TradableCurrenciesFunc {
+    TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& upbitPublic)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _upbitPublic(upbitPublic) {}
+
+    CurrencyExchangeFlatSet operator()();
+
+    CurlHandle& _curlHandle;
+    const APIKey& _apiKey;
+    UpbitPublic& _upbitPublic;
+  };
+
   struct AccountBalanceFunc {
     AccountBalanceFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& upbitPublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _upbitPublic(upbitPublic) {}
@@ -59,6 +72,7 @@ class UpbitPrivate : public ExchangePrivate {
   CurlHandle _curlHandle;
   CoincenterInfo& _config;
   UpbitPublic& _upbitPublic;
+  CachedResult<TradableCurrenciesFunc> _tradableCurrenciesCache;
   CachedResult<AccountBalanceFunc, CurrencyCode> _balanceCache;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;
 };

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -17,10 +17,10 @@ class UpbitPublic : public ExchangePublic {
  public:
   UpbitPublic(CoincenterInfo& config, FiatConverter& fiatConverter, CryptowatchAPI& cryptowatchAPI);
 
-  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _currenciesCache.get(); }
+  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) override {
-    return _currenciesCache.get().getOrThrow(currencyCode);
+    return _tradableCurrenciesCache.get().getOrThrow(currencyCode);
   }
 
   MarketSet queryTradableMarkets() override { return _marketsCache.get(); }
@@ -53,8 +53,8 @@ class UpbitPublic : public ExchangePublic {
     const ExchangeInfo& _exchangeInfo;
   };
 
-  struct CurrenciesFunc {
-    CurrenciesFunc(CurlHandle& curlHandle, CachedResult<MarketsFunc>& marketsCache)
+  struct TradableCurrenciesFunc {
+    TradableCurrenciesFunc(CurlHandle& curlHandle, CachedResult<MarketsFunc>& marketsCache)
         : _curlHandle(curlHandle), _marketsCache(marketsCache) {}
 
     CurrencyExchangeFlatSet operator()();
@@ -95,7 +95,7 @@ class UpbitPublic : public ExchangePublic {
 
   CurlHandle _curlHandle;
   CachedResult<MarketsFunc> _marketsCache;
-  CachedResult<CurrenciesFunc> _currenciesCache;
+  CachedResult<TradableCurrenciesFunc> _tradableCurrenciesCache;
   CachedResult<WithdrawalFeesFunc> _withdrawalFeesCache;
   CachedResult<AllOrderBooksFunc, int> _allOrderBooksCache;
   CachedResult<OrderBookFunc, Market, int> _orderbookCache;

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -179,6 +179,8 @@ BithumbPrivate::BithumbPrivate(CoincenterInfo& config, BithumbPublic& bithumbPub
   }
 }
 
+CurrencyExchangeFlatSet BithumbPrivate::queryTradableCurrencies() { return _bithumbPublic.queryTradableCurrencies(); }
+
 BalancePortfolio BithumbPrivate::AccountBalanceFunc::operator()(CurrencyCode equiCurrency) {
   json result = PrivateQuery(_curlHandle, _apiKey, "info/balance", _maxNbDecimalsUnitMap, {{"currency", "all"}});
   BalancePortfolio ret;

--- a/src/api/exchanges/src/bithumbpublicapi.cpp
+++ b/src/api/exchanges/src/bithumbpublicapi.cpp
@@ -54,7 +54,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurrencyCode
 BithumbPublic::BithumbPublic(CoincenterInfo& config, FiatConverter& fiatConverter, api::CryptowatchAPI& cryptowatchAPI)
     : ExchangePublic("bithumb", fiatConverter, cryptowatchAPI),
       _curlHandle(config.exchangeInfo(_name).minPublicQueryDelay(), config.getRunMode()),
-      _currenciesCache(
+      _tradableCurrenciesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kCurrencies), _cachedResultVault), config,
           _curlHandle),
       _withdrawalFeesCache(
@@ -117,7 +117,7 @@ ExchangePublic::WithdrawalFeeMap BithumbPublic::WithdrawalFeesFunc::operator()()
   return ret;
 }
 
-CurrencyExchangeFlatSet BithumbPublic::CurrenciesFunc::operator()() {
+CurrencyExchangeFlatSet BithumbPublic::TradableCurrenciesFunc::operator()() {
   json result = PublicQuery(_curlHandle, "assetsstatus", "all");
   CurrencyExchangeFlatSet currencies;
   currencies.reserve(result.size() + 1);

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -93,6 +93,8 @@ KrakenPrivate::KrakenPrivate(CoincenterInfo& config, KrakenPublic& krakenPublic,
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kDepositWallet), _cachedResultVault),
           _curlHandle, _apiKey, krakenPublic) {}
 
+CurrencyExchangeFlatSet KrakenPrivate::queryTradableCurrencies() { return _krakenPublic.queryTradableCurrencies(); }
+
 BalancePortfolio KrakenPrivate::AccountBalanceFunc::operator()(CurrencyCode equiCurrency) {
   BalancePortfolio ret;
   json res = PrivateQuery(_curlHandle, _apiKey, "Balance");

--- a/src/api/exchanges/test/upbitapi_test.cpp
+++ b/src/api/exchanges/test/upbitapi_test.cpp
@@ -42,18 +42,16 @@ void PublicTest(UpbitPublic &upbitPublic) {
   EXPECT_TRUE(marketPriceMap.contains(*markets.begin()));
   EXPECT_TRUE(marketPriceMap.contains(*std::next(markets.begin())));
 
-  // ExchangePublic::WithdrawalFeeMap withdrawalFees = upbitPublic.queryWithdrawalFees();
-  // EXPECT_GT(withdrawalFees.size(), 10);
-  // EXPECT_TRUE(withdrawalFees.contains(markets.begin()->base()));
-  // EXPECT_TRUE(withdrawalFees.contains(std::next(markets.begin(), 1)->base()));
-  // const CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
-  // for (CurrencyCode code : kCurrencyCodesToTest) {
-  //   if (currencies.contains(code) && currencies.find(code)->canWithdraw()) {
-  //     EXPECT_FALSE(withdrawalFees.find(code)->second.isZero());
-  //   }
-  // }
-
-  log::set_level(log::level::trace);
+  ExchangePublic::WithdrawalFeeMap withdrawalFees = upbitPublic.queryWithdrawalFees();
+  EXPECT_GT(withdrawalFees.size(), 10);
+  EXPECT_TRUE(withdrawalFees.contains(markets.begin()->base()));
+  EXPECT_TRUE(withdrawalFees.contains(std::next(markets.begin(), 1)->base()));
+  const CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
+  for (CurrencyCode code : kCurrencyCodesToTest) {
+    if (currencies.contains(code) && currencies.find(code)->canWithdraw()) {
+      EXPECT_FALSE(withdrawalFees.find(code)->second.isZero());
+    }
+  }
 
   MarketOrderBook marketOrderBook = upbitPublic.queryOrderBook(*std::next(markets.begin(), 2));
   EXPECT_LT(marketOrderBook.highestBidPrice(), marketOrderBook.lowestAskPrice());
@@ -63,6 +61,7 @@ void PrivateTest(UpbitPrivate &upbitPrivate) {
   // We cannot expect anything from the balance, it may be empty if you are poor and this is a valid response.
   EXPECT_NO_THROW(upbitPrivate.queryAccountBalance());
   EXPECT_NO_THROW(upbitPrivate.queryDepositWallet("ETH"));
+  EXPECT_NO_THROW(upbitPrivate.queryTradableCurrencies());
 }
 
 }  // namespace

--- a/src/api/interface/include/exchange.hpp
+++ b/src/api/interface/include/exchange.hpp
@@ -28,6 +28,8 @@ class Exchange {
 
   bool hasPrivateAPI() const;
 
+  CurrencyExchangeFlatSet queryTradableCurrencies();
+
   bool canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const;
 
   bool canDeposit(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const;

--- a/src/api/interface/src/exchange.cpp
+++ b/src/api/interface/src/exchange.cpp
@@ -22,6 +22,10 @@ bool Exchange::hasPrivateAPI() const {
   return std::addressof(gExchangePrivateDefault) != std::addressof(_exchangePrivate);
 }
 
+CurrencyExchangeFlatSet Exchange::queryTradableCurrencies() {
+  return hasPrivateAPI() ? _exchangePrivate.queryTradableCurrencies() : _exchangePublic.queryTradableCurrencies();
+}
+
 bool Exchange::canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const {
   if (_exchangeInfo.excludedCurrenciesWithdrawal().contains(currencyCode)) {
     return false;

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -111,7 +111,7 @@ WithdrawInfo Coincenter::withdraw(MonetaryAmount grossAmount, const PrivateExcha
   const std::array<Exchange *, 2> exchangePair = {std::addressof(fromExchange), std::addressof(toExchange)};
   cct::vector<CurrencyExchangeFlatSet> currencyExchangeSets(2);
   std::transform(std::execution::par, exchangePair.begin(), exchangePair.end(), currencyExchangeSets.begin(),
-                 [](Exchange *e) { return e->apiPublic().queryTradableCurrencies(); });
+                 [](Exchange *e) { return e->queryTradableCurrencies(); });
 
   const CurrencyCode currencyCode = grossAmount.currencyCode();
   if (!fromExchange.canWithdraw(currencyCode, currencyExchangeSets.front())) {

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -13,7 +13,10 @@ class CurrencyExchange {
   enum class Deposit { kAvailable, kUnavailable };  // use scoped enums to ensure type checks and increase readability
   enum class Withdraw { kAvailable, kUnavailable };
 
-  /// Constructs a CurrencyExchange with up to two alternative codes.
+  /// Constructs a CurrencyExchange with up to two alternative codes, with unknown withdrawal / deposit statuses
+  CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode);
+
+  /// Constructs a CurrencyExchange with up to two alternative codes, with known withdrawal / deposit statuses
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode, Deposit deposit,
                    Withdraw withdraw);
 
@@ -30,6 +33,8 @@ class CurrencyExchange {
   bool canDeposit() const { return _canDeposit; }
   bool canWithdraw() const { return _canWithdraw; }
 
+  bool unknownDepositWithdrawalStatus() const { return _unknownDepositWithdrawalStatus; }
+
   bool operator<(const CurrencyExchange &o) const { return _standardCode < o._standardCode; }
   bool operator==(const CurrencyExchange &o) const { return _standardCode == o._standardCode; }
   bool operator!=(const CurrencyExchange &o) const { return !(*this == o); }
@@ -40,6 +45,7 @@ class CurrencyExchange {
   CurrencyCode _altCode;
   bool _canDeposit;
   bool _canWithdraw;
+  bool _unknownDepositWithdrawalStatus;
 };
 
 }  // namespace cct

--- a/src/objects/src/currencyexchange.cpp
+++ b/src/objects/src/currencyexchange.cpp
@@ -2,13 +2,22 @@
 
 namespace cct {
 
+CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode)
+    : _standardCode(standardCode),
+      _exchangeCode(exchangeCode),
+      _altCode(altCode),
+      _canDeposit(false),
+      _canWithdraw(false),
+      _unknownDepositWithdrawalStatus(true) {}
+
 CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode,
                                    Deposit deposit, Withdraw withdraw)
     : _standardCode(standardCode),
       _exchangeCode(exchangeCode),
       _altCode(altCode),
       _canDeposit(deposit == Deposit::kAvailable),
-      _canWithdraw(withdraw == Withdraw::kAvailable) {}
+      _canWithdraw(withdraw == Withdraw::kAvailable),
+      _unknownDepositWithdrawalStatus(false) {}
 
 std::string CurrencyExchange::str() const {
   std::string ret(_standardCode.str());


### PR DESCRIPTION
The idea of this PR is to add `queryTradableCurrencies` to private API interface as well, such that exchanges which need private key to get additional information from currencies can retrieve full information. For exchanges that give full information without private key, simply use implementation of the public API.

Documentation of the endpoint for Upbit [here](https://docs.upbit.com/reference#%EC%9E%85%EC%B6%9C%EA%B8%88-%ED%98%84%ED%99%A9)