### PR TITLE
Protect against failure of Fiat Currency Converter

### DIFF
--- a/src/objects/include/fiatconverter.hpp
+++ b/src/objects/include/fiatconverter.hpp
@@ -44,7 +44,7 @@ class FiatConverter {
     TimePoint lastUpdatedTime;
   };
 
-  double queryCurrencyRate(Market m);
+  std::optional<double> queryCurrencyRate(Market m);
 
   using PricesMap = std::unordered_map<Market, PriceTimedValue>;
 


### PR DESCRIPTION
It is possible that fiat currency converter is not available. Rely on old data stored in the cache in this case if available to avoid aborting the program.