### PR TITLE
Optimize MonetaryAmount constructor from string

### DIFF
--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -239,4 +239,17 @@ TEST(MonetaryAmountTest, Truncate) {
   EXPECT_TRUE(a.isZero());
 }
 
+TEST(MonetaryAmountTest, PositiveAmountStr) {
+  EXPECT_EQ(MonetaryAmount("7").amountStr(), "7");
+  EXPECT_EQ(MonetaryAmount("9204.1260").amountStr(), "9204.126");
+  EXPECT_EQ(MonetaryAmount("0.709").amountStr(), "0.709");
+  EXPECT_EQ(MonetaryAmount("0.0").amountStr(), "0");
+}
+
+TEST(MonetaryAmountTest, NegativeAmountStr) {
+  EXPECT_EQ(MonetaryAmount("-3.4950EUR").amountStr(), "-3.495");
+  EXPECT_EQ(MonetaryAmount("-0.0034090").amountStr(), "-0.003409");
+  EXPECT_EQ(MonetaryAmount("-0.0").amountStr(), "0");
+}
+
 }  // namespace cct

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -3,8 +3,8 @@
 #include <curl/curl.h>
 #include <gtest/gtest.h>
 
-#include "cct_proxy.hpp"
 #include "cct_log.hpp"
+#include "cct_proxy.hpp"
 
 // #define DEBUG
 /* URL available to test HTTPS, cf
@@ -46,7 +46,8 @@ TEST_F(CurlSetup, Queries) {
 #endif
     log::set_level(log::level::trace);
     std::string s = handle.query("https://api.kraken.com/0/public/SystemStatus", opts);
-    EXPECT_TRUE(s.find("online") != std::string::npos);
+    EXPECT_TRUE(s.find("online") != std::string::npos || s.find("maintenance") != std::string::npos ||
+                s.find("cancel_only") != std::string::npos || s.find("post_only") != std::string::npos);
   }
 }
 


### PR DESCRIPTION
Avoid construction of a `std::string` and allocations in constructor of `MonetaryAmount` from string, thanks to C++17 [std::from_chars](https://en.cppreference.com/w/cpp/utility/from_chars)
And fix warning with MSVC in variadictable.