### PR TITLE
Adds possibility to use custom free currency converter key to avoid reaching limits of hardcoded one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,6 @@
 .ycm_extra_conf.py*
 *-ut
 cscope*
-**/secret.json
+**/*secret.json
 data/.*
 config/.*

--- a/data/.ratescache.json
+++ b/data/.ratescache.json
@@ -1,0 +1,146 @@
+{
+  "AUD-EUR": {
+    "rate": 0.644277,
+    "timeepoch": 1618851165
+  },
+  "AUD-KRW": {
+    "rate": 863.609615,
+    "timeepoch": 1618647357
+  },
+  "AUD-USD": {
+    "rate": 0.7755,
+    "timeepoch": 1621886385
+  },
+  "EUR-AUD": {
+    "rate": 1.5521274234529558,
+    "timeepoch": 1618851165
+  },
+  "EUR-GBP": {
+    "rate": 0.8607148236610505,
+    "timeepoch": 1618851165
+  },
+  "EUR-KRW": {
+    "rate": 1358.695652173913,
+    "timeepoch": 1622706657
+  },
+  "EUR-NGN": {
+    "rate": 460.6172270842929,
+    "timeepoch": 1619465034
+  },
+  "EUR-RUB": {
+    "rate": 91.77679882525698,
+    "timeepoch": 1618851164
+  },
+  "EUR-UAH": {
+    "rate": 33.6802398033074,
+    "timeepoch": 1618851165
+  },
+  "EUR-USD": {
+    "rate": 1.2189398879794242,
+    "timeepoch": 1622706412
+  },
+  "GBP-EUR": {
+    "rate": 1.161825,
+    "timeepoch": 1618851165
+  },
+  "GBP-KRW": {
+    "rate": 1544.71829,
+    "timeepoch": 1618760277
+  },
+  "GBP-USD": {
+    "rate": 1.415749,
+    "timeepoch": 1621886384
+  },
+  "KRW-AUD": {
+    "rate": 0.001157930600390548,
+    "timeepoch": 1618647357
+  },
+  "KRW-EUR": {
+    "rate": 0.000736,
+    "timeepoch": 1622706657
+  },
+  "KRW-GBP": {
+    "rate": 0.0006473672296584252,
+    "timeepoch": 1618760277
+  },
+  "KRW-NGN": {
+    "rate": 0.3407546283849287,
+    "timeepoch": 1618760278
+  },
+  "KRW-RUB": {
+    "rate": 0.06771045492758773,
+    "timeepoch": 1618760277
+  },
+  "KRW-UAH": {
+    "rate": 0.025079805823114587,
+    "timeepoch": 1618760276
+  },
+  "KRW-USD": {
+    "rate": 0.00089,
+    "timeepoch": 1621886387
+  },
+  "NGN-EUR": {
+    "rate": 0.002171,
+    "timeepoch": 1619465034
+  },
+  "NGN-KRW": {
+    "rate": 2.934663,
+    "timeepoch": 1618760278
+  },
+  "NGN-USD": {
+    "rate": 0.002625,
+    "timeepoch": 1618525896
+  },
+  "RUB-EUR": {
+    "rate": 0.010896,
+    "timeepoch": 1618851164
+  },
+  "RUB-KRW": {
+    "rate": 14.768768,
+    "timeepoch": 1618760277
+  },
+  "RUB-USD": {
+    "rate": 0.013607,
+    "timeepoch": 1621886384
+  },
+  "UAH-EUR": {
+    "rate": 0.029691,
+    "timeepoch": 1618851165
+  },
+  "UAH-KRW": {
+    "rate": 39.872717,
+    "timeepoch": 1618760276
+  },
+  "UAH-USD": {
+    "rate": 0.035774,
+    "timeepoch": 1618518807
+  },
+  "USD-AUD": {
+    "rate": 1.2894906511927788,
+    "timeepoch": 1621886385
+  },
+  "USD-EUR": {
+    "rate": 0.820385,
+    "timeepoch": 1622706412
+  },
+  "USD-GBP": {
+    "rate": 0.7063398949955112,
+    "timeepoch": 1621886384
+  },
+  "USD-KRW": {
+    "rate": 1123.5955056179776,
+    "timeepoch": 1621886387
+  },
+  "USD-NGN": {
+    "rate": 380.9523809523809,
+    "timeepoch": 1618525896
+  },
+  "USD-RUB": {
+    "rate": 73.49158521349305,
+    "timeepoch": 1621886384
+  },
+  "USD-UAH": {
+    "rate": 27.953262145692403,
+    "timeepoch": 1618518807
+  }
+}

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -84,7 +84,7 @@ BalancePortfolio HuobiPrivate::queryAccountBalance(CurrencyCode equiCurrency) {
     if (typeStr == "trade") {
       this->addBalance(ret, amount, equiCurrency);
     } else {
-      log::warn("Do not consider {} as it is {} on {}", amount.str(), typeStr, _exchangePublic.name());
+      log::debug("Do not consider {} as it is {} on {}", amount.str(), typeStr, _exchangePublic.name());
     }
   }
   return ret;

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -82,6 +82,7 @@ class Coincenter {
 
   PublicExchangeNames getPublicExchangeNames() const;
 
+  /// Dumps the content of all file caches in data directory to save cURL queries.
   void updateFileCaches() const;
 
   std::span<Exchange> exchanges() { return _exchanges; }

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -42,6 +42,7 @@ Exchange &RetrieveUniqueCandidate(PrivateExchangeName privateExchangeName, std::
 Coincenter::Coincenter(settings::RunMode runMode)
     : _coincenterInfo(runMode),
       _cryptowatchAPI(runMode),
+      _fiatConverter(std::chrono::hours(8)),
       _apiKeyProvider(runMode),
       _binancePublic(_coincenterInfo, _fiatConverter, _cryptowatchAPI),
       _bithumbPublic(_coincenterInfo, _fiatConverter, _cryptowatchAPI),
@@ -283,6 +284,7 @@ PublicExchangeNames Coincenter::getPublicExchangeNames() const {
 }
 
 void Coincenter::updateFileCaches() const {
+  log::debug("Store all cache files");
   _cryptowatchAPI.updateCacheFile();
   _fiatConverter.updateCacheFile();
   std::for_each(_exchanges.begin(), _exchanges.end(), [](const Exchange &e) { e.updateCacheFile(); });

--- a/src/objects/src/apikeysprovider.cpp
+++ b/src/objects/src/apikeysprovider.cpp
@@ -65,7 +65,7 @@ APIKeysProvider::APIKeysMap APIKeysProvider::ParseAPIKeys(settings::RunMode runM
   json jsonData = OpenJsonFile(GetSecretFileName(runMode), FileNotFoundMode::kNoThrow, FileType::kConfig);
   for (const auto& [platform, keyObj] : jsonData.items()) {
     for (const auto& [name, keySecretObj] : keyObj.items()) {
-      log::warn("Found key '{}' for platform {}", name, platform);
+      log::info("Found key '{}' for platform {}", name, platform);
       map[platform].emplace_back(platform, name, keySecretObj["key"], keySecretObj["private"]);
     }
   }

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -9,13 +9,29 @@ namespace cct {
 namespace {
 constexpr char kRatesFileName[] = ".ratescache.json";
 constexpr char kCurrencyConverterBaseUrl[] = "https://free.currconv.com/api/v7";
-constexpr char kAPIKey[] = "b25453de7984135a084b";
-// example http://free.currconv.com/api/v7/currencies?apiKey=b25453de7984135a084b
+constexpr char kFiatConverterJsonKeyFile[] = "thirdparty_secret.json";
+
+std::string LoadCurrencyConverterAPIKey() {
+  constexpr char kDefaultCommunityKey[] = "b25453de7984135a084b";
+  // example http://free.currconv.com/api/v7/currencies?apiKey=b25453de7984135a084b
+
+  json data = OpenJsonFile(kFiatConverterJsonKeyFile, FileNotFoundMode::kNoThrow, FileType::kConfig);
+  if (data.empty() || data["freecurrencyconverter"].get<std::string_view>() == kDefaultCommunityKey) {
+    log::warn("Unable to find custom Free Currency Converter key in {}", kFiatConverterJsonKeyFile);
+    log::warn("If you want to use extensively coincenter, please create your own key by going to");
+    log::warn("https://free.currencyconverterapi.com/free-api-key and place it in");
+    log::warn("'config/thirdparty_secret.json' like this:");
+    log::warn("  {\"freecurrencyconverter\": \"<YourKey>\"}");
+    log::warn("Using default key provided as a demo to the community");
+    return kDefaultCommunityKey;
+  }
+  return std::string(data["freecurrencyconverter"].get<std::string_view>());
+}
 
 }  // namespace
 
 FiatConverter::FiatConverter(Clock::duration ratesUpdateFrequency, bool loadFromFileCacheAtInit)
-    : _ratesUpdateFrequency(ratesUpdateFrequency) {
+    : _ratesUpdateFrequency(ratesUpdateFrequency), _apiKey(LoadCurrencyConverterAPIKey()) {
   if (loadFromFileCacheAtInit) {
     json data = OpenJsonFile(kRatesFileName, FileNotFoundMode::kNoThrow, FileType::kData);
     _pricesMap.reserve(data.size());
@@ -23,9 +39,10 @@ FiatConverter::FiatConverter(Clock::duration ratesUpdateFrequency, bool loadFrom
       Market m(marketStr, '-');
       double rate = rateAndTimeData["rate"];
       int64_t timeepoch = rateAndTimeData["timeepoch"];
-      log::debug("Stored rate {} for market {} from cache file", rate, marketStr);
+      log::trace("Stored rate {} for market {} from {}", rate, marketStr, kRatesFileName);
       _pricesMap.insert_or_assign(m, PriceTimedValue{rate, TimePoint(std::chrono::seconds(timeepoch))});
     }
+    log::debug("Loaded {} fiat currency rates from {}", _pricesMap.size(), kRatesFileName);
   }
 }
 
@@ -47,7 +64,7 @@ std::optional<double> FiatConverter::queryCurrencyRate(Market m) {
   CurlOptions opts(CurlOptions::RequestType::kGet);
   std::string qStr(m.assetsPairStr('_'));
   opts.postdata.append("q", qStr);
-  opts.postdata.append("apiKey", kAPIKey);
+  opts.postdata.append("apiKey", _apiKey);
 
   url.append(opts.postdata.c_str());
   opts.postdata.clear();
@@ -83,9 +100,12 @@ double FiatConverter::convert(double amount, CurrencyCode from, CurrencyCode to)
   double rate;
   std::lock_guard<std::mutex> guard(_pricesMutex);
   auto it = _pricesMap.find(m);
-  if (it != _pricesMap.end() && Clock::now() < it->second.lastUpdatedTime + _ratesUpdateFrequency) {
+  if (it != _pricesMap.end() && Clock::now() - it->second.lastUpdatedTime < _ratesUpdateFrequency) {
     rate = it->second.rate;
   } else {
+    if (_ratesUpdateFrequency == Clock::duration::max()) {
+      throw exception("Unable to query fiat currency rates and no rate found in cache");
+    }
     std::optional<double> queriedRate = queryCurrencyRate(m);
     if (queriedRate) {
       rate = *queriedRate;

--- a/src/objects/test/fiatconverter_test.cpp
+++ b/src/objects/test/fiatconverter_test.cpp
@@ -68,7 +68,7 @@ std::string CurlHandle::query(std::string_view url, const CurlOptions &) {
 CurlHandle::~CurlHandle() {}
 
 TEST(FiatConverterTest, DirectConversion) {
-  FiatConverter converter(std::chrono::hours(2), false);
+  FiatConverter converter(std::chrono::milliseconds(1), false);
   double amount = 10;
   EXPECT_TRUE(AreDoubleEqual(converter.convert(amount, "KRW", "KRW"), amount));
   EXPECT_TRUE(AreDoubleEqual(converter.convert(amount, "EUR", "KRW"), amount * kKRW));
@@ -78,7 +78,7 @@ TEST(FiatConverterTest, DirectConversion) {
 }
 
 TEST(FiatConverterTest, DoubleConversion) {
-  FiatConverter converter(std::chrono::hours(2), false);
+  FiatConverter converter(std::chrono::milliseconds(1), false);
   double amount = 20'000'000;
   EXPECT_TRUE(AreDoubleEqual(converter.convert(amount, "KRW", "EUR"), amount / kKRW));
   EXPECT_TRUE(AreDoubleEqual(converter.convert(amount, "KRW", "USD"), (amount / kKRW) * kUSD));


### PR DESCRIPTION
FiatConverter's default constructor now cannot query the free converter and loads rates cache instead, useful for unit tests to avoid querying the real service.

Possibility to add custom key for the user in 'config/thirdparty_secret.json' such that default hardcoded key is not saturated if a lot of clients use it. If no such custom key is present, log will print a warning inviting client to do so.