### PR TITLE
Dynamically choose best Binance base URL based on periodic pings to each

### DIFF
--- a/src/api/common/src/exchangeprivateapi.cpp
+++ b/src/api/common/src/exchangeprivateapi.cpp
@@ -9,7 +9,7 @@ namespace api {
 void ExchangePrivate::addBalance(BalancePortfolio &balancePortfolio, MonetaryAmount amount, CurrencyCode equiCurrency) {
   if (!amount.isZero()) {
     if (equiCurrency == CurrencyCode::kNeutral) {
-      log::info("{} Balance {}", _exchangePublic.name(), amount.str());
+      log::debug("{} Balance {}", _exchangePublic.name(), amount.str());
       balancePortfolio.add(amount);
     } else {
       std::optional<MonetaryAmount> optConvertedAmountEquiCurrency =
@@ -22,7 +22,7 @@ void ExchangePrivate::addBalance(BalancePortfolio &balancePortfolio, MonetaryAmo
       } else {
         equivalentInMainCurrency = *optConvertedAmountEquiCurrency;
       }
-      log::info("{} Balance {} (eq. {})", _exchangePublic.name(), amount.str(), equivalentInMainCurrency.str());
+      log::debug("{} Balance {} (eq. {})", _exchangePublic.name(), amount.str(), equivalentInMainCurrency.str());
       balancePortfolio.add(amount, equivalentInMainCurrency);
     }
   }

--- a/src/objects/include/balanceportfolio.hpp
+++ b/src/objects/include/balanceportfolio.hpp
@@ -38,7 +38,8 @@ class BalancePortfolio {
 
   void print(std::ostream &os) const;
 
-  bool empty() const { return _monetaryAmountSet.empty(); }
+  bool empty() const noexcept { return _monetaryAmountSet.empty(); }
+  MonetaryAmountSet::size_type size() const noexcept { return _monetaryAmountSet.size(); }
 
  private:
   using MonetaryAmountVec = cct::vector<MonetaryAmountWithEquivalent>;

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -42,7 +42,7 @@ class CurrencyCode {
   constexpr CurrencyCode(std::string_view acronym) {
     if (CCT_UNLIKELY(_data.size() < acronym.size())) {
       if (!std::is_constant_evaluated()) {
-        log::warn("Acronym {} is too long, truncating to {}", acronym, acronym.substr(0, _data.size()));
+        log::debug("Acronym {} is too long, truncating to {}", acronym, acronym.substr(0, _data.size()));
       }
       acronym.remove_suffix(acronym.size() - _data.size());
     }

--- a/src/objects/src/apikeysprovider.cpp
+++ b/src/objects/src/apikeysprovider.cpp
@@ -65,7 +65,7 @@ APIKeysProvider::APIKeysMap APIKeysProvider::ParseAPIKeys(settings::RunMode runM
   json jsonData = OpenJsonFile(GetSecretFileName(runMode), FileNotFoundMode::kNoThrow, FileType::kConfig);
   for (const auto& [platform, keyObj] : jsonData.items()) {
     for (const auto& [name, keySecretObj] : keyObj.items()) {
-      log::warn("Found key '{}' for platform {}", name, platform);
+      log::info("Found key '{}' for platform {}", name, platform);
       map[platform].emplace_back(platform, name, keySecretObj["key"], keySecretObj["private"]);
     }
   }

--- a/src/tools/include/curlhandle.hpp
+++ b/src/tools/include/curlhandle.hpp
@@ -21,6 +21,9 @@ class CurlHandle {
   using Clock = std::chrono::high_resolution_clock;
   using TimePoint = std::chrono::time_point<Clock>;
 
+  // CurlHandle is trivially relocatable
+  using trivially_relocatable = std::true_type;
+
   /// Constructs a new CurlHandle.
   /// @param minDurationBetweenQueries delay query 'n + 1' in case query 'n' was too close
   explicit CurlHandle(Clock::duration minDurationBetweenQueries = Clock::duration::zero(),


### PR DESCRIPTION
Binance proposes up to 4 base URLs in case of issues for some of these. We can dynamically query them and select the one which provides the lowest ping to optimize response time for the client.

Also lower severity of some logs.

Finally, also check the synchronization of Binance system time and if not synchronized with client time, log an error message.