### PR TITLE
Withdraw fee option in command line

### DIFF
--- a/src/api/common/include/exchangepublicapi.hpp
+++ b/src/api/common/include/exchangepublicapi.hpp
@@ -77,9 +77,9 @@ class ExchangePublic : public ExchangeBase {
   using Currencies = cct::SmallVector<CurrencyCode, 6>;
 
   /// Retrieve the fastest conversion path (fastest in terms of number of conversions)
-  /// of 'from' towards 'to' currency code
+  /// of 'm.base()' towards 'm.quote()' currency code
   /// @return ordered list of currency code, or empty list if conversion is not possible
-  Currencies findFastestConversionPath(CurrencyCode from, CurrencyCode to, bool considerStableCoinsAsFiats = false);
+  Currencies findFastestConversionPath(Market conversionMarket, bool considerStableCoinsAsFiats = false);
 
   MonetaryAmount computeLimitOrderPrice(Market m, MonetaryAmount from);
 

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -7,7 +7,7 @@
 namespace cct {
 namespace api {
 std::optional<MonetaryAmount> ExchangePublic::convertAtAveragePrice(MonetaryAmount a, CurrencyCode toCurrencyCode) {
-  Currencies currencies = findFastestConversionPath(a.currencyCode(), toCurrencyCode, true);
+  Currencies currencies = findFastestConversionPath(Market(a.currencyCode(), toCurrencyCode), true);
   if (currencies.empty()) {
     return std::nullopt;
   }
@@ -50,9 +50,10 @@ std::optional<MonetaryAmount> ExchangePublic::convertAtAveragePrice(MonetaryAmou
   return a;
 }
 
-ExchangePublic::Currencies ExchangePublic::findFastestConversionPath(CurrencyCode fromCurrencyCode,
-                                                                     CurrencyCode toCurrencyCode,
+ExchangePublic::Currencies ExchangePublic::findFastestConversionPath(Market conversionMarket,
                                                                      bool considerStableCoinsAsFiats) {
+  CurrencyCode fromCurrencyCode(conversionMarket.base());
+  CurrencyCode toCurrencyCode(conversionMarket.quote());
   std::optional<CurrencyCode> optFiatFromStableCoin =
       considerStableCoinsAsFiats ? _coincenterInfo.fiatCurrencyIfStableCoin(toCurrencyCode) : std::nullopt;
   const bool isToFiatLike = optFiatFromStableCoin || _cryptowatchApi.queryIsCurrencyCodeFiat(toCurrencyCode);

--- a/src/api/common/test/exchangepublicapi_test.cpp
+++ b/src/api/common/test/exchangepublicapi_test.cpp
@@ -38,21 +38,25 @@ class ExchangePublicTest : public ::testing::Test {
   MockExchangePublic exchangePublic;
 };
 
+namespace {
+using Currencies = ExchangePublic::Currencies;
+using MarketSet = ExchangePublic::MarketSet;
+}  // namespace
+
 TEST_F(ExchangePublicTest, FindFastestConversionPath) {
   EXPECT_CALL(exchangePublic, queryTradableMarkets())
       .Times(4)
-      .WillRepeatedly(
-          ::testing::Return(ExchangePublic::MarketSet{{"BTC", "EUR"}, {"XLM", "EUR"}, {"ETH", "EUR"}, {"ETH", "BTC"}}));
-  EXPECT_EQ(exchangePublic.findFastestConversionPath("BTC", "XLM"), ExchangePublic::Currencies({"BTC", "EUR", "XLM"}));
-  EXPECT_EQ(exchangePublic.findFastestConversionPath("XLM", "ETH"), ExchangePublic::Currencies({"XLM", "EUR", "ETH"}));
-  EXPECT_EQ(exchangePublic.findFastestConversionPath("ETH", "KRW"), ExchangePublic::Currencies({"ETH", "EUR", "KRW"}));
-  EXPECT_EQ(exchangePublic.findFastestConversionPath("EOS", "KRW"), ExchangePublic::Currencies());
+      .WillRepeatedly(::testing::Return(MarketSet{{"BTC", "EUR"}, {"XLM", "EUR"}, {"ETH", "EUR"}, {"ETH", "BTC"}}));
+  EXPECT_EQ(exchangePublic.findFastestConversionPath(Market("BTC", "XLM")), Currencies({"BTC", "EUR", "XLM"}));
+  EXPECT_EQ(exchangePublic.findFastestConversionPath(Market("XLM", "ETH")), Currencies({"XLM", "EUR", "ETH"}));
+  EXPECT_EQ(exchangePublic.findFastestConversionPath(Market("ETH", "KRW")), Currencies({"ETH", "EUR", "KRW"}));
+  EXPECT_EQ(exchangePublic.findFastestConversionPath(Market("EOS", "KRW")), Currencies());
 }
 
 TEST_F(ExchangePublicTest, RetriveMarket) {
   EXPECT_CALL(exchangePublic, queryTradableMarkets())
       .Times(3)
-      .WillRepeatedly(::testing::Return(ExchangePublic::MarketSet{{"BTC", "KRW"}, {"XLM", "KRW"}, {"USD", "EOS"}}));
+      .WillRepeatedly(::testing::Return(MarketSet{{"BTC", "KRW"}, {"XLM", "KRW"}, {"USD", "EOS"}}));
 
   EXPECT_EQ(exchangePublic.retrieveMarket("BTC", "KRW"), Market("BTC", "KRW"));
   EXPECT_EQ(exchangePublic.retrieveMarket("KRW", "BTC"), Market("BTC", "KRW"));

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,3 +25,12 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
   set_property(TARGET coincenter PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
   message(STATUS "Activate LTO for coincenter")
 endif(CMAKE_BUILD_TYPE STREQUAL "Release")
+
+add_unit_test(
+    stringoptionparser_test
+    src/stringoptionparser.cpp
+    test/stringoptionparser_test.cpp
+    LIBRARIES
+    coincenter_objects
+    coincenter_tools
+)

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -41,7 +41,7 @@ class TradeOptions;
 
 class Coincenter {
  public:
-  using MarketOrderBookConversionRate = std::pair<MarketOrderBook, std::optional<MonetaryAmount>>;
+  using MarketOrderBookConversionRate = std::tuple<std::string_view, MarketOrderBook, std::optional<MonetaryAmount>>;
   using MarketOrderBookConversionRates = cct::FixedCapacityVector<MarketOrderBookConversionRate, kNbSupportedExchanges>;
 
   explicit Coincenter(settings::RunMode runMode = settings::RunMode::kProd);
@@ -55,10 +55,6 @@ class Coincenter {
   void process(const CoincenterParsedOptions &opts);
 
   /// Retrieve market order book of market for given exchanges
-  MarketOrderBooks getMarketOrderBooks(Market m, std::span<const PublicExchangeName> exchangeNames,
-                                       std::optional<int> depth = std::nullopt);
-
-  /// Retrieve market order book of market for given exchanges
   /// Also adds the conversion rate of each Exchange bundled with the market order book.
   MarketOrderBookConversionRates getMarketOrderBooks(Market m, std::span<const PublicExchangeName> exchangeNames,
                                                      CurrencyCode equiCurrencyCode,
@@ -70,8 +66,7 @@ class Coincenter {
 
   void printBalance(const PrivateExchangeNames &privateExchangeNames, CurrencyCode balanceCurrencyCode);
 
-  void printConversionPath(std::span<const PublicExchangeName> exchangeNames, CurrencyCode fromCurrencyCode,
-                           CurrencyCode toCurrencyCode);
+  void printConversionPath(std::span<const PublicExchangeName> exchangeNames, Market m);
 
   /// Single trade from 'startAmount' into 'toCurrency', on exchange named 'exchangeName'.
   /// Options should be wisely chosen here to avoid mistakes.
@@ -81,6 +76,8 @@ class Coincenter {
   /// Single withdraw of 'grossAmount' from 'fromExchangeName' to 'toExchangeName'
   WithdrawInfo withdraw(MonetaryAmount grossAmount, const PrivateExchangeName &fromPrivateExchangeName,
                         const PrivateExchangeName &toPrivateExchangeName);
+
+  void printWithdrawFees(CurrencyCode currencyCode, std::span<const PublicExchangeName> exchangeNames);
 
   PublicExchangeNames getPublicExchangeNames() const;
 
@@ -106,9 +103,6 @@ class Coincenter {
   using CurrencyExchangeSets = cct::vector<CurrencyExchangeFlatSet>;
   using WithdrawalFeeMapPerExchange = cct::vector<api::ExchangePublic::WithdrawalFeeMap>;
   using MarketsOrderBookPerExchange = cct::vector<api::ExchangePublic::MarketOrderBookMap>;
-
-  static SelectedExchanges RetrieveSelectedExchanges(std::span<const PublicExchangeName> exchangeNames,
-                                                     std::span<Exchange> exchanges);
 
   CurlInitRAII _curlInitRAII;
   CoincenterInfo _coincenterInfo;

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -43,7 +43,8 @@ struct CoincenterCmdLineOptions {
           .count())};
   bool trade_sim{api::TradeOptions().isSimulation()};
 
-  std::string withdraw{};
+  std::string withdraw;
+  std::string withdraw_fee;
 };
 
 template <class OptValueType>
@@ -66,16 +67,18 @@ inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptions
                                                       &OptValueType::logLevel},
        {{{"General", 1}, "--logfile", "", "Log to rotating files instead of stdout / stderr"}, &OptValueType::logFile},
 
-       {{{"Public queries", 2}, "--orderbook", 'o', "<cur1-cur2,exch1,...>", "Print order book of currency pair for given exchanges"}, 
-                                                                             &OptValueType::orderbook},
+       {{{"Public queries", 2}, "--orderbook", 'o', "<cur1-cur2[,exch1,...]>", "Print order book of currency pair for all exchanges offering "
+                                                                               " this market, or only for specified exchanges."}, 
+                                                                               &OptValueType::orderbook},
        {{{"Public queries", 2}, "--orderbook-depth", "", "Override default depth of order book"}, &OptValueType::orderbook_depth},
-       {{{"Public queries", 2}, "--orderbook-cur", "<cur code>", "If conversion of cur2 into cur is possible on exch1, "
-                                                                 "prints additional column converted to given asset"}, 
+       {{{"Public queries", 2}, "--orderbook-cur", "<cur>", "If conversion of cur2 into cur is possible (for each exchange), "
+                                                            "prints additional column converted to given asset"}, 
                                                                  &OptValueType::orderbook_cur},
-       {{{"Public queries", 2}, "--conversion-path", 'c', "<cur1-cur2,exch1,...>", "Print fastest conversion path of 'cur1' to 'cur2' for given exchanges if possible"}, 
+       {{{"Public queries", 2}, "--conversion-path", 'c', "<cur1-cur2[,exch1,...]>", "Print fastest conversion path of 'cur1' to 'cur2' "
+                                                                                     "for given exchanges if possible"}, 
                                                           &OptValueType::conversion_path},
 
-       {{{"Private queries", 3}, "--balance", 'b', "<exch1,...>", "Prints sum of available balance for all private accounts if no value is given, "
+       {{{"Private queries", 3}, "--balance", 'b', "[exch1,...]", "Prints sum of available balance for all private accounts if no value is given, "
                                                                   "or only for specified ones separated by commas"}, 
                                                                   &OptValueType::balance},
        {{{"Private queries", 3}, "--balance-cur", "<cur code>", "Print additional information with each asset "
@@ -111,11 +114,13 @@ inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptions
                                          "mode to ensure deeper and more realistic trading inputs")}, &OptValueType::trade_sim},
 
        {{{"Withdraw crypto", 5}, "--withdraw", 'w', "<amt cur,from-to>", std::string("Withdraw amount from exchange 'from' to exchange 'to'."
-                                                                         " Amount is gross, including fees. Address and tag will be "
-                                                                         "retrieved automatically from '")
+                                                                         " Amount is gross, including fees. Address and tag will be retrieved"
+                                                                         " automatically from destination exchange and should match an entry in '")
                                                                         .append(Wallet::kDepositAddressesFilename)
-                                                                        .append(".json' file. Make sure that values are up to date (and "
-                                                                        "correct of course!)")}, &OptValueType::withdraw}});
+                                                                        .append("' file.")}, &OptValueType::withdraw},
+       {{{"Withdraw crypto", 5}, "--withdraw-fee", "<cur[,exch1,...]>", std::string("Prints withdraw fees of given currency on all supported exchanges,"
+                                                                         " or only for the list of specified ones if provided (comma separated).")}, 
+                                                                &OptValueType::withdraw_fee}});
   // clang-format on
 }
 }  // namespace cct

--- a/src/engine/include/coincenterparsedoptions.hpp
+++ b/src/engine/include/coincenterparsedoptions.hpp
@@ -35,6 +35,8 @@ class CoincenterParsedOptions {
 
   MonetaryAmount amountToWithdraw;
   PrivateExchangeName withdrawFromExchangeName, withdrawToExchangeName;
+  CurrencyCode withdrawFeeCur;
+  PublicExchangeNames withdrawFeeExchanges;
 
   bool noProcess{};
 

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -11,15 +11,16 @@
 #include "monetaryamount.hpp"
 
 namespace cct {
-class AnyParser {
+class StringOptionParser {
  public:
   using MarketExchanges = std::pair<Market, PublicExchangeNames>;
   using MonetaryAmountExchanges = std::pair<MonetaryAmount, PublicExchangeNames>;
   using MonetaryAmountCurrencyCodePrivateExchange = std::tuple<MonetaryAmount, CurrencyCode, PrivateExchangeName>;
   using MonetaryAmountFromToPrivateExchange = std::tuple<MonetaryAmount, PrivateExchangeName, PrivateExchangeName>;
   using MonetaryAmountFromToPublicExchangeToCurrency = std::tuple<MonetaryAmount, PublicExchangeNames, CurrencyCode>;
+  using CurrencyCodePublicExchanges = std::pair<CurrencyCode, PublicExchangeNames>;
 
-  explicit AnyParser(std::string_view optFullStr) : _opt(optFullStr) {}
+  explicit StringOptionParser(std::string_view optFullStr) : _opt(optFullStr) {}
 
   PublicExchangeNames getExchanges() const;
 
@@ -33,7 +34,7 @@ class AnyParser {
 
   MonetaryAmountFromToPrivateExchange getMonetaryAmountFromToPrivateExchange() const;
 
-  MonetaryAmountFromToPublicExchangeToCurrency getMonetaryAmountFromToPublicExchangeToCurrency() const;
+  CurrencyCodePublicExchanges getCurrencyCodePublicExchanges() const;
 
  private:
   std::size_t getNextCommaPos(std::size_t startPos = 0, bool throwIfNone = true) const;

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -38,7 +38,7 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
   cmdLineOptions.setLogFile();
 
   if (!cmdLineOptions.orderbook.empty()) {
-    AnyParser anyParser(cmdLineOptions.orderbook);
+    StringOptionParser anyParser(cmdLineOptions.orderbook);
     std::tie(marketForOrderBook, orderBookExchanges) = anyParser.getMarketExchanges();
 
     orderbookDepth = cmdLineOptions.orderbook_depth;
@@ -46,22 +46,19 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
   }
 
   if (!cmdLineOptions.conversion_path.empty()) {
-    AnyParser anyParser(cmdLineOptions.conversion_path);
+    StringOptionParser anyParser(cmdLineOptions.conversion_path);
     std::tie(marketForConversionPath, conversionPathExchanges) = anyParser.getMarketExchanges();
   }
 
   if (cmdLineOptions.balance) {
-    if (cmdLineOptions.balance->empty()) {
-      balanceForAll = true;
-    } else {
-      AnyParser anyParser(*cmdLineOptions.balance);
-      balancePrivateExchanges = anyParser.getPrivateExchanges();
-    }
+    StringOptionParser anyParser(*cmdLineOptions.balance);
+    balancePrivateExchanges = anyParser.getPrivateExchanges();
+    balanceForAll = balancePrivateExchanges.empty();
     balanceCurrencyCode = CurrencyCode(cmdLineOptions.balance_cur);
   }
 
   if (!cmdLineOptions.trade.empty()) {
-    AnyParser anyParser(cmdLineOptions.trade);
+    StringOptionParser anyParser(cmdLineOptions.trade);
     std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeName) =
         anyParser.getMonetaryAmountCurrencyCodePrivateExchange();
 
@@ -73,9 +70,14 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
   }
 
   if (!cmdLineOptions.withdraw.empty()) {
-    AnyParser anyParser(cmdLineOptions.withdraw);
+    StringOptionParser anyParser(cmdLineOptions.withdraw);
     std::tie(amountToWithdraw, withdrawFromExchangeName, withdrawToExchangeName) =
         anyParser.getMonetaryAmountFromToPrivateExchange();
+  }
+
+  if (!cmdLineOptions.withdraw_fee.empty()) {
+    StringOptionParser anyParser(cmdLineOptions.withdraw_fee);
+    std::tie(withdrawFeeCur, withdrawFeeExchanges) = anyParser.getCurrencyCodePublicExchanges();
   }
 }
 }  // namespace cct

--- a/src/engine/test/stringoptionparser_test.cpp
+++ b/src/engine/test/stringoptionparser_test.cpp
@@ -1,0 +1,70 @@
+#include "stringoptionparser.hpp"
+
+#include <gtest/gtest.h>
+
+namespace cct {
+
+TEST(StringOptionParserTest, GetExchanges) {
+  EXPECT_EQ(StringOptionParser("").getExchanges(), PublicExchangeNames());
+  EXPECT_EQ(StringOptionParser("kraken,upbit").getExchanges(), PublicExchangeNames({"kraken", "upbit"}));
+  EXPECT_EQ(StringOptionParser("huobi_user1").getExchanges(), PublicExchangeNames({"huobi_user1"}));
+}
+
+TEST(StringOptionParserTest, GetPrivateExchanges) {
+  EXPECT_EQ(StringOptionParser("").getPrivateExchanges(), PrivateExchangeNames());
+  EXPECT_EQ(StringOptionParser("bithumb,binance_user1").getPrivateExchanges(),
+            PrivateExchangeNames({PrivateExchangeName("bithumb"), PrivateExchangeName("binance", "user1")}));
+  EXPECT_EQ(StringOptionParser("binance_user2,bithumb,binance_user1").getPrivateExchanges(),
+            PrivateExchangeNames({PrivateExchangeName("binance", "user2"), PrivateExchangeName("bithumb"),
+                                  PrivateExchangeName("binance", "user1")}));
+}
+
+TEST(StringOptionParserTest, GetMarketExchanges) {
+  EXPECT_EQ(StringOptionParser("eth-eur").getMarketExchanges(),
+            StringOptionParser::MarketExchanges(Market("ETH", "EUR"), PublicExchangeNames()));
+  EXPECT_EQ(StringOptionParser("dash-krw,bithumb,upbit").getMarketExchanges(),
+            StringOptionParser::MarketExchanges(Market("DASH", "KRW"), PublicExchangeNames({"bithumb", "upbit"})));
+}
+
+TEST(StringOptionParserTest, GetMonetaryAmountExchanges) {
+  EXPECT_EQ(StringOptionParser("45.09ADA").getMonetaryAmountExchanges(),
+            StringOptionParser::MonetaryAmountExchanges(MonetaryAmount("45.09ADA"), PublicExchangeNames()));
+  EXPECT_EQ(StringOptionParser("-0.6509btc,kraken").getMonetaryAmountExchanges(),
+            StringOptionParser::MonetaryAmountExchanges(MonetaryAmount("-0.6509BTC"), PublicExchangeNames({"kraken"})));
+}
+
+TEST(StringOptionParserTest, GetMonetaryAmountCurrencyCodePrivateExchange) {
+  EXPECT_EQ(StringOptionParser("45.09ADA-eur,bithumb").getMonetaryAmountCurrencyCodePrivateExchange(),
+            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange(
+                MonetaryAmount("45.09ADA"), CurrencyCode("EUR"), PrivateExchangeName("bithumb")));
+  EXPECT_EQ(StringOptionParser("0.02btc-xlm,upbit_user1").getMonetaryAmountCurrencyCodePrivateExchange(),
+            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange(
+                MonetaryAmount("0.02BTC"), CurrencyCode("XLM"), PrivateExchangeName("upbit", "user1")));
+}
+
+TEST(StringOptionParserTest, GetMonetaryAmountFromToPrivateExchange) {
+  EXPECT_EQ(StringOptionParser("0.102btc,huobi-kraken").getMonetaryAmountFromToPrivateExchange(),
+            StringOptionParser::MonetaryAmountFromToPrivateExchange(
+                MonetaryAmount("0.102BTC"), PrivateExchangeName("huobi"), PrivateExchangeName("kraken")));
+  EXPECT_EQ(
+      StringOptionParser("3795541.90XLM,bithumb_user1-binance").getMonetaryAmountFromToPrivateExchange(),
+      StringOptionParser::MonetaryAmountFromToPrivateExchange(
+          MonetaryAmount("3795541.90XLM"), PrivateExchangeName("bithumb", "user1"), PrivateExchangeName("binance")));
+  EXPECT_EQ(
+      StringOptionParser("4.106eth,kraken_user2-huobi_user3").getMonetaryAmountFromToPrivateExchange(),
+      StringOptionParser::MonetaryAmountFromToPrivateExchange(
+          MonetaryAmount("4.106ETH"), PrivateExchangeName("kraken", "user2"), PrivateExchangeName("huobi", "user3")));
+}
+
+TEST(StringOptionParserTest, GetCurrencyCodePublicExchanges) {
+  EXPECT_EQ(StringOptionParser("btc").getCurrencyCodePublicExchanges(),
+            StringOptionParser::CurrencyCodePublicExchanges(CurrencyCode("BTC"), PublicExchangeNames()));
+  EXPECT_EQ(
+      StringOptionParser("eur,kraken_user1").getCurrencyCodePublicExchanges(),
+      StringOptionParser::CurrencyCodePublicExchanges(CurrencyCode("EUR"), PublicExchangeNames({"kraken_user1"})));
+  EXPECT_EQ(
+      StringOptionParser("eur,binance,huobi").getCurrencyCodePublicExchanges(),
+      StringOptionParser::CurrencyCodePublicExchanges(CurrencyCode("EUR"), PublicExchangeNames({"binance", "huobi"})));
+}
+
+}  // namespace cct

--- a/src/objects/include/marketorderbook.hpp
+++ b/src/objects/include/marketorderbook.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <ostream>
 #include <span>
+#include <string_view>
 
 #include "cct_smallvector.hpp"
 #include "market.hpp"
@@ -124,7 +125,7 @@ class MarketOrderBook {
   /// Print the market order book to given stream.
   /// @param conversionPriceRate prices will be multiplied to given amount to display an additional column of equivalent
   ///                            currency
-  void print(std::ostream& os, MonetaryAmount conversionPriceRate) const;
+  void print(std::ostream& os, std::string_view exchangeName, MonetaryAmount conversionPriceRate) const;
 
  private:
   /// Represents a total amount of waiting orders at a given price.

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -390,11 +390,14 @@ void MarketOrderBook::print(std::ostream& os) const {
   vt.print(os);
 }
 
-void MarketOrderBook::print(std::ostream& os, MonetaryAmount conversionPriceRate) const {
+void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName, MonetaryAmount conversionPriceRate) const {
   cct::FixedCapacityVector<std::string, 4> cols;
   cols.emplace_back("Sellers of ").append(_market.base().str()).append(" (asks)");
-  cols.emplace_back(_market.base().str()).append(" price in ").append(_market.quote().str());
-  cols.emplace_back(_market.base().str()).append(" price in ").append(conversionPriceRate.currencyCode().str());
+  cols.emplace_back(exchangeName).append(_market.base().str()).append(" price in ").append(_market.quote().str());
+  cols.emplace_back(exchangeName)
+      .append(_market.base().str())
+      .append(" price in ")
+      .append(conversionPriceRate.currencyCode().str());
   cols.emplace_back("Buyers of ").append(_market.base().str()).append(" (bids)");
   VariadicTable<std::string, std::string, std::string, std::string> vt(std::move(cols));
   for (int op = _orders.size(); op > 0; --op) {


### PR DESCRIPTION
`coincenter --withdraw-fee eth` prints all possible withdraw fees for Ethereum for supported exchanges.
It is possible to specify a list of comma separated exchanges to print only these ones:
`coincenter --withdraw-fee xlm,binance,huobi`
Example of output:
```
---------------------------
| Exchange | Withdraw fee |
---------------------------
| binance  | 0.5 XLM      |
| bithumb  | 0.01 XLM     |
| huobi    | 0.01 XLM     |
| kraken   | 0.00002 XLM  |
| upbit    | 0.01 XLM     |
---------------------------
```

Bonus: exchanges in market order book option are now optional, if not specified, print for all that support queried market.
Addition of `stringoptionsparser` unit test