### PR TITLE
Better match currency code main chain on Huobi

### DIFF
--- a/src/api/exchanges/test/binanceapi_test.cpp
+++ b/src/api/exchanges/test/binanceapi_test.cpp
@@ -29,8 +29,11 @@ namespace {
 void PublicTest(BinancePublic &binancePublic) {
   EXPECT_NO_THROW(binancePublic.queryOrderBook(Market("BTC", "USDT")));
   EXPECT_GT(binancePublic.queryAllApproximatedOrderBooks().size(), 20U);
-  EXPECT_NO_THROW(binancePublic.queryTradableCurrencies());
-  EXPECT_NO_THROW(binancePublic.queryWithdrawalFees());
+  ExchangePublic::WithdrawalFeeMap withdrawFees = binancePublic.queryWithdrawalFees();
+  EXPECT_FALSE(withdrawFees.empty());
+  for (const CurrencyExchange &curEx : binancePublic.queryTradableCurrencies()) {
+    EXPECT_TRUE(withdrawFees.contains(curEx.standardCode()));
+  }
   EXPECT_NO_THROW(binancePublic.queryTradableMarkets());
 }
 

--- a/src/api/exchanges/test/huobiapi_test.cpp
+++ b/src/api/exchanges/test/huobiapi_test.cpp
@@ -29,8 +29,11 @@ namespace {
 void PublicTest(HuobiPublic &huobiPublic) {
   EXPECT_NO_THROW(huobiPublic.queryOrderBook(Market("BTC", "USDT")));
   EXPECT_GT(huobiPublic.queryAllApproximatedOrderBooks().size(), 20U);
-  EXPECT_NO_THROW(huobiPublic.queryTradableCurrencies());
-  EXPECT_NO_THROW(huobiPublic.queryWithdrawalFees());
+  ExchangePublic::WithdrawalFeeMap withdrawFees = huobiPublic.queryWithdrawalFees();
+  EXPECT_FALSE(withdrawFees.empty());
+  for (const CurrencyExchange &curEx : huobiPublic.queryTradableCurrencies()) {
+    EXPECT_TRUE(withdrawFees.contains(curEx.standardCode()));
+  }
   EXPECT_NO_THROW(huobiPublic.queryTradableMarkets());
 }
 


### PR DESCRIPTION
`./coincenter --withdraw-fee eos,huobi` failed because eos main chain name in Huobi is `eos1`. Let's compare as well to 'displayName' json field to retrieve a tradable currency.

Also update unit tests accordingly