### PR TITLE
Addition of time unit support in command line parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Then, locate where curl is installed (by default, should be in `C:\ProgramData\c
 ## As an executable (CLI tool)
 
 **coincenter** can be used as a stand-alone project which provides an executable able to perform most common exchange operations on supported exchanges:
- - Balance
+ - Market
  - Orderbook
+ - Balance
  - Trade
  - Withdraw
 
@@ -189,7 +190,7 @@ Possible strategies:
 Example: "Trade 0.5 BTC to euros on Kraken, in simulated mode (no real order will be placed, useful for tests), with the 'adapt' strategy (maker then taker),
           an emergency mode triggered before 2 seconds of the timeout of 15 seconds."
 ```
-./coincenter --trade 0.5btc-eur,kraken --trade-sim --trade-strategy adapt --trade-emergency 2 --trade-timeout 15
+./coincenter --trade 0.5btc-eur,kraken --trade-sim --trade-strategy adapt --trade-emergency 2s --trade-timeout 15s
 ```
 
 ### Trade simulation
@@ -237,12 +238,12 @@ You can exclude currencies in the exchange configuration file (for instance: som
 
 ## Trade 1000 euros to XRP on kraken with a maker strategy
 ```
-./coincenter --trade "1000eur-xrp,kraken" --trade-strategy maker --trade-timeout 60
+./coincenter --trade "1000eur-xrp,kraken" --trade-strategy maker --trade-timeout 60s
 ```
 
 ### Trade 1000 euros to XRP on kraken with a maker strategy in simulation mode
 ```
-./coincenter --trade "1000eur-xrp,kraken" --trade-strategy maker --trade-timeout 60 --trade-sim
+./coincenter --trade "1000eur-xrp,kraken" --trade-strategy maker --trade-timeout 1min --trade-sim
 ```
 
 #### Possible output

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -12,6 +12,8 @@
 namespace cct {
 
 struct CoincenterCmdLineOptions {
+  using Duration = api::TradeOptions::Clock::duration;
+
   void setLogLevel() const;
 
   void setLogFile() const;
@@ -36,12 +38,9 @@ struct CoincenterCmdLineOptions {
 
   std::string trade;
   std::string trade_strategy{api::TradeOptions().strategyStr()};
-  int trade_timeout_s{static_cast<int>(
-      std::chrono::duration_cast<std::chrono::seconds>(api::TradeOptions::kDefaultTradeDuration).count())};
-  int trade_emergency_s{static_cast<int>(
-      std::chrono::duration_cast<std::chrono::seconds>(api::TradeOptions::kDefaultEmergencyTime).count())};
-  int trade_updateprice_s{static_cast<int>(
-      std::chrono::duration_cast<std::chrono::seconds>(api::TradeOptions::kDefaultMinTimeBetweenPriceUpdates).count())};
+  Duration trade_timeout{api::TradeOptions::kDefaultTradeDuration};
+  Duration trade_emergency{api::TradeOptions::kDefaultEmergencyTime};
+  Duration trade_updateprice{api::TradeOptions::kDefaultMinTimeBetweenPriceUpdates};
   bool trade_sim{api::TradeOptions().isSimulation()};
 
   std::string withdraw;
@@ -98,19 +97,19 @@ inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptions
                                                                   " at market price before the timeout to make it eventually completely matched. "
                                                                   "Useful for exchanges proposing cheaper maker than taker fees."}, 
                                                                   &OptValueType::trade_strategy},
-       {{{"Trade", 4}, "--trade-timeout", "<s>", std::string("Adjust trade timeout (default: ")
+       {{{"Trade", 4}, "--trade-timeout", "<time>", std::string("Adjust trade timeout (default: ")
                                                 .append(std::to_string(defaultTradeTimeout))
-                                                .append(" s). Remaining orders will be cancelled after the timeout.")}, 
-                                                &OptValueType::trade_timeout_s},
-       {{{"Trade", 4}, "--trade-emergency", "<s>", std::string("Adjust emergency buffer for the 'adapt' strategy (default: ")
+                                                .append("s). Remaining orders will be cancelled after the timeout.")}, 
+                                                &OptValueType::trade_timeout},
+       {{{"Trade", 4}, "--trade-emergency", "<time>", std::string("Adjust emergency buffer for the 'adapt' strategy (default: ")
                                                    .append(std::to_string(emergencyBufferTime))
-                                                   .append(" s). Remaining order will be switched from limit to market price "
+                                                   .append("s). Remaining order will be switched from limit to market price "
                                                    "after 'timeout - emergency' time to force completion of the trade")}, 
-                                                   &OptValueType::trade_emergency_s},
-       {{{"Trade", 4}, "--trade-updateprice", "<s>", std::string("Set the min time allowed between two limit price updates (default: ")
+                                                   &OptValueType::trade_emergency},
+       {{{"Trade", 4}, "--trade-updateprice", "<time>", std::string("Set the min time allowed between two limit price updates (default: ")
                                                     .append(std::to_string(minUpdatePriceTime))
-                                                    .append(" s). Avoids cancelling / placing new orders too often with high volumes "
-                                                    "which can be counter productive sometimes.")}, &OptValueType::trade_updateprice_s},
+                                                    .append("s). Avoids cancelling / placing new orders too often with high volumes "
+                                                    "which can be counter productive sometimes.")}, &OptValueType::trade_updateprice},
        {{{"Trade", 4}, "--trade-sim", "", std::string("Activates simulation mode only (default: ")
                                          .append(isSimulationModeByDefault ? "true" : "false")
                                          .append("). For some exchanges, API can even be queried in this "

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -69,8 +69,7 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
 
     tradeOptions = api::TradeOptions(
         cmdLineOptions.trade_strategy, cmdLineOptions.trade_sim ? api::TradeMode::kSimulation : api::TradeMode::kReal,
-        std::chrono::seconds(cmdLineOptions.trade_timeout_s), std::chrono::seconds(cmdLineOptions.trade_emergency_s),
-        std::chrono::seconds(cmdLineOptions.trade_updateprice_s));
+        cmdLineOptions.trade_timeout, cmdLineOptions.trade_emergency, cmdLineOptions.trade_updateprice);
   }
 
   if (!cmdLineOptions.withdraw.empty()) {

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -27,6 +27,7 @@ add_unit_test(
 
 add_unit_test(
     commandlineoptionsparser_test
+    src/commandlineoption.cpp
     test/commandlineoptionsparser_test.cpp
 )
 

--- a/src/tools/include/commandlineoption.hpp
+++ b/src/tools/include/commandlineoption.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace cct {
+using InvalidArgumentException = std::invalid_argument;
+
+/// Description of a command line option.
+class CommandLineOption {
+ public:
+  using GroupNameAndPrio = std::pair<std::string_view, int>;
+  using Clock = std::chrono::high_resolution_clock;
+  using TimePoint = std::chrono::time_point<Clock>;
+  using Duration = Clock::duration;
+
+  CommandLineOption(GroupNameAndPrio optionGroupName, std::string_view fullName, char shortName,
+                    std::string_view valueDescription, std::string_view description);
+
+  CommandLineOption(GroupNameAndPrio optionGroupName, std::string_view fullName, std::string_view valueDescription,
+                    std::string_view description)
+      : CommandLineOption(optionGroupName, fullName, '\0', valueDescription, description) {}
+
+  static Duration ParseDuration(std::string_view durationStr);
+
+  bool matches(std::string_view optName) const;
+
+  const std::string& optionGroupName() const { return _optionGroupName; }
+  const std::string& fullName() const { return _fullName; }
+  const std::string& description() const { return _description; }
+  const std::string& valueDescription() const { return _valueDescription; }
+
+  std::string shortName() const;
+
+  bool operator<(const CommandLineOption& o) const;
+
+ private:
+  std::string _optionGroupName;
+  std::string _fullName;
+  std::string _valueDescription;
+  std::string _description;
+  int _prio;
+  char _shortName;
+};
+
+}  // namespace cct

--- a/src/tools/src/commandlineoption.cpp
+++ b/src/tools/src/commandlineoption.cpp
@@ -1,0 +1,76 @@
+#include "commandlineoption.hpp"
+
+#include <charconv>
+
+namespace cct {
+CommandLineOption::CommandLineOption(GroupNameAndPrio optionGroupName, std::string_view fullName, char shortName,
+                                     std::string_view valueDescription, std::string_view description)
+    : _optionGroupName(optionGroupName.first),
+      _fullName(fullName),
+      _valueDescription(valueDescription),
+      _description(description),
+      _prio(optionGroupName.second),
+      _shortName(shortName) {}
+
+CommandLineOption::Duration CommandLineOption::ParseDuration(std::string_view durationStr) {
+  if (durationStr.find('.') != std::string_view::npos) {
+    throw InvalidArgumentException("Time amount should be an integral value");
+  }
+  std::size_t endAmountPos = durationStr.find_first_of("hmnsu ");
+  std::size_t startTimeUnit = durationStr.find_first_of("hmnsu");
+  constexpr char kInvalidTimeDurationUnitMsg[] =
+      "Cannot parse time duration. Accepted time units are 'h (hours), min (minutes), s (seconds), ms "
+      "(milliseconds), us "
+      "(microseconds) and ns "
+      "(nanoseconds)'";
+  if (endAmountPos == std::string_view::npos || startTimeUnit == std::string_view::npos) {
+    throw InvalidArgumentException(kInvalidTimeDurationUnitMsg);
+  }
+  std::string_view timeAmountStr(durationStr.begin(), durationStr.begin() + endAmountPos);
+  int64_t timeAmount{};
+  std::from_chars(timeAmountStr.data(), timeAmountStr.data() + timeAmountStr.size(), timeAmount);
+  std::string_view timeUnitStr(durationStr.begin() + startTimeUnit, durationStr.end());
+  if (timeUnitStr == "h") {
+    return std::chrono::hours(timeAmount);
+  } else if (timeUnitStr == "min") {
+    return std::chrono::minutes(timeAmount);
+  } else if (timeUnitStr == "s") {
+    return std::chrono::seconds(timeAmount);
+  } else if (timeUnitStr == "ms") {
+    return std::chrono::milliseconds(timeAmount);
+  } else if (timeUnitStr == "us") {
+    return std::chrono::microseconds(timeAmount);
+  } else if (timeUnitStr == "ns") {
+    return std::chrono::nanoseconds(timeAmount);
+  } else {
+    throw InvalidArgumentException(kInvalidTimeDurationUnitMsg);
+  }
+}
+
+bool CommandLineOption::matches(std::string_view optName) const {
+  if (optName.size() == 2 && optName.front() == '-' && optName.back() == _shortName) {
+    return true;
+  }
+  return optName == _fullName;
+}
+
+std::string CommandLineOption::shortName() const {
+  std::string ret;
+  if (_shortName != '\0') {
+    ret.push_back('-');
+    ret.push_back(_shortName);
+  }
+  return ret;
+}
+
+bool CommandLineOption::operator<(const CommandLineOption& o) const {
+  if (_prio != o._prio) {
+    return _prio < o._prio;
+  }
+  if (_optionGroupName != o._optionGroupName) {
+    return _optionGroupName < o._optionGroupName;
+  }
+  return _fullName < o._fullName;
+}
+
+}  // namespace cct


### PR DESCRIPTION
Time unit should now be specified in the command line option parsing time:

Example:
```
./coincenter --trade 250eur-xrp,kraken --trade-timeout 45s --trade-emergency 2500ms
```