### PR TITLE
Allow query of withdrawal fee with private account when exchange supports it

### DIFF
--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -25,6 +25,8 @@ class TradeOptions;
 
 class ExchangePrivate : public ExchangeBase {
  public:
+  using WithdrawalFeeMap = ExchangePublic::WithdrawalFeeMap;
+
   ExchangePrivate(const ExchangePrivate &) = delete;
   ExchangePrivate &operator=(const ExchangePrivate &) = delete;
 
@@ -70,6 +72,16 @@ class ExchangePrivate : public ExchangeBase {
   /// @param targetExchange private exchange to which we should deliver the transfer
   /// @return information about the withdraw
   WithdrawInfo withdraw(MonetaryAmount grossAmount, ExchangePrivate &targetExchange);
+
+  /// Retrieve the fixed withdrawal fees per currency.
+  /// Some exchanges provide this service in the public REST API but not all, hence this private API flavor.
+  virtual WithdrawalFeeMap queryWithdrawalFees() { return _exchangePublic.queryWithdrawalFees(); }
+
+  /// Retrieve the withdrawal fee of a Currency only
+  /// Some exchanges provide this service in the public REST API but not all, hence this private API flavor.
+  virtual MonetaryAmount queryWithdrawalFee(CurrencyCode currencyCode) {
+    return _exchangePublic.queryWithdrawalFee(currencyCode);
+  }
 
  protected:
   ExchangePrivate(ExchangePublic &exchangePublic, const CoincenterInfo &config, const APIKey &apiKey)

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -25,6 +25,10 @@ class BinancePrivate : public ExchangePrivate {
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 
+  WithdrawalFeeMap queryWithdrawalFees() override { return _allWithdrawFeesCache.get(); }
+
+  MonetaryAmount queryWithdrawalFee(CurrencyCode currencyCode) override { return _withdrawFeesCache.get(currencyCode); }
+
  protected:
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
@@ -62,8 +66,32 @@ class BinancePrivate : public ExchangePrivate {
     BinancePublic& _public;
   };
 
+  struct AllWithdrawFeesFunc {
+    AllWithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& exchangePublic)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+
+    WithdrawalFeeMap operator()();
+
+    CurlHandle& _curlHandle;
+    const APIKey& _apiKey;
+    BinancePublic& _exchangePublic;
+  };
+
+  struct WithdrawFeesFunc {
+    WithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& exchangePublic)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+
+    MonetaryAmount operator()(CurrencyCode currencyCode);
+
+    CurlHandle& _curlHandle;
+    const APIKey& _apiKey;
+    BinancePublic& _exchangePublic;
+  };
+
   CurlHandle _curlHandle;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;
+  CachedResult<AllWithdrawFeesFunc> _allWithdrawFeesCache;
+  CachedResult<WithdrawFeesFunc, CurrencyCode> _withdrawFeesCache;
 };
 }  // namespace api
 }  // namespace cct

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -27,6 +27,10 @@ class UpbitPrivate : public ExchangePrivate {
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 
+  MonetaryAmount queryWithdrawalFee(CurrencyCode currencyCode) override {
+    return _withdrawalFeesCache.get(currencyCode);
+  }
+
  protected:
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
@@ -65,7 +69,16 @@ class UpbitPrivate : public ExchangePrivate {
     UpbitPublic& _exchangePublic;
   };
 
-  json withdrawalInformation(CurrencyCode currencyCode);
+  struct WithdrawFeesFunc {
+    WithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+
+    MonetaryAmount operator()(CurrencyCode currencyCode);
+
+    CurlHandle& _curlHandle;
+    const APIKey& _apiKey;
+    UpbitPublic& _exchangePublic;
+  };
 
   OrderInfo parseOrderJson(const json& orderJson, CurrencyCode fromCurrencyCode, Market m) const;
 
@@ -75,6 +88,7 @@ class UpbitPrivate : public ExchangePrivate {
   CurlHandle _curlHandle;
   CachedResult<TradableCurrenciesFunc> _tradableCurrenciesCache;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;
+  CachedResult<WithdrawFeesFunc, CurrencyCode> _withdrawalFeesCache;
 };
 }  // namespace api
 }  // namespace cct

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -70,7 +70,7 @@ CurrencyExchangeFlatSet UpbitPublic::TradableCurrenciesFunc::operator()() {
     currencies.insert(CurrencyExchange(m.quote(), m.quote(), m.quote()));
   }
   log::info("Retrieved {} Upbit currencies with partial information", currencies.size());
-  log::warn("Use Upbit private API to get full withdrawal and deposit statuses");
+  log::debug("Use Upbit private API to get full withdrawal and deposit statuses");
   return currencies;
 }
 

--- a/src/api/exchanges/test/binanceapi_test.cpp
+++ b/src/api/exchanges/test/binanceapi_test.cpp
@@ -37,7 +37,7 @@ void PublicTest(BinancePublic &binancePublic) {
   EXPECT_NO_THROW(binancePublic.queryTradableMarkets());
 }
 
-void PrivateTest(BinancePrivate &binancePrivate) {
+void PrivateTest(BinancePrivate &binancePrivate, BinancePublic &binancePublic) {
   // We cannot expect anything from the balance, it may be empty and this is a valid response.
   EXPECT_NO_THROW(binancePrivate.queryAccountBalance());
   EXPECT_TRUE(binancePrivate.queryDepositWallet("XLM").hasDestinationTag());
@@ -47,6 +47,7 @@ void PrivateTest(BinancePrivate &binancePrivate) {
   MonetaryAmount bigFrom("13567.1234BNB");
   EXPECT_NO_THROW(binancePrivate.trade(bigFrom, "ADA", tradeOptions));
   EXPECT_LT(bigFrom, MonetaryAmount("13567.1234BNB"));
+  EXPECT_EQ(binancePrivate.queryWithdrawalFee("ETH"), binancePublic.queryWithdrawalFee("ETH"));
 }
 }  // namespace
 
@@ -65,7 +66,7 @@ TEST_F(BinanceAPI, Main) {
 
   BinancePrivate binancePrivate(coincenterInfo, binancePublic, firstAPIKey);
 
-  PrivateTest(binancePrivate);
+  PrivateTest(binancePrivate, binancePublic);
 }
 
 }  // namespace api

--- a/src/api/exchanges/test/upbitapi_test.cpp
+++ b/src/api/exchanges/test/upbitapi_test.cpp
@@ -46,7 +46,7 @@ void PublicTest(UpbitPublic &upbitPublic) {
   EXPECT_GT(withdrawalFees.size(), 10U);
   EXPECT_TRUE(withdrawalFees.contains(markets.begin()->base()));
   EXPECT_TRUE(withdrawalFees.contains(std::next(markets.begin(), 1)->base()));
-  const CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
+  constexpr CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
   for (CurrencyCode code : kCurrencyCodesToTest) {
     if (currencies.contains(code) && currencies.find(code)->canWithdraw()) {
       EXPECT_FALSE(withdrawalFees.find(code)->second.isZero());
@@ -57,11 +57,12 @@ void PublicTest(UpbitPublic &upbitPublic) {
   EXPECT_LT(marketOrderBook.highestBidPrice(), marketOrderBook.lowestAskPrice());
 }
 
-void PrivateTest(UpbitPrivate &upbitPrivate) {
+void PrivateTest(UpbitPrivate &upbitPrivate, UpbitPublic &upbitPublic) {
   // We cannot expect anything from the balance, it may be empty if you are poor and this is a valid response.
   EXPECT_NO_THROW(upbitPrivate.queryAccountBalance());
   EXPECT_TRUE(upbitPrivate.queryDepositWallet("XRP").hasDestinationTag());
   EXPECT_NO_THROW(upbitPrivate.queryTradableCurrencies());
+  EXPECT_EQ(upbitPrivate.queryWithdrawalFee("ADA"), upbitPublic.queryWithdrawalFee("ADA"));
 }
 
 }  // namespace
@@ -82,7 +83,7 @@ TEST_F(UpbitAPI, Public) {
   // The following test will target the proxy
   // To avoid matching the test case, you can simply provide production keys
   UpbitPrivate upbitPrivate(coincenterInfo, upbitPublic, firstAPIKey);
-  PrivateTest(upbitPrivate);
+  PrivateTest(upbitPrivate, upbitPublic);
 }
 
 }  // namespace api

--- a/src/api/interface/include/exchange.hpp
+++ b/src/api/interface/include/exchange.hpp
@@ -12,6 +12,8 @@
 namespace cct {
 class Exchange {
  public:
+  using WithdrawalFeeMap = api::ExchangePublic::WithdrawalFeeMap;
+
   /// Builds a Exchange without private exchange. All private requests will be forbidden.
   Exchange(const ExchangeInfo &exchangeInfo, api::ExchangePublic &exchangePublic);
 
@@ -44,6 +46,10 @@ class Exchange {
   bool hasPrivateAPI() const { return _pExchangePrivate; }
 
   CurrencyExchangeFlatSet queryTradableCurrencies();
+
+  WithdrawalFeeMap queryWithdrawalFees();
+
+  MonetaryAmount queryWithdrawalFee(CurrencyCode currencyCode);
 
   bool canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const;
 

--- a/src/api/interface/src/exchange.cpp
+++ b/src/api/interface/src/exchange.cpp
@@ -19,6 +19,15 @@ CurrencyExchangeFlatSet Exchange::queryTradableCurrencies() {
   return hasPrivateAPI() ? _pExchangePrivate->queryTradableCurrencies() : _exchangePublic.queryTradableCurrencies();
 }
 
+Exchange::WithdrawalFeeMap Exchange::queryWithdrawalFees() {
+  return hasPrivateAPI() ? _pExchangePrivate->queryWithdrawalFees() : _exchangePublic.queryWithdrawalFees();
+}
+
+MonetaryAmount Exchange::queryWithdrawalFee(CurrencyCode currencyCode) {
+  return hasPrivateAPI() ? _pExchangePrivate->queryWithdrawalFee(currencyCode)
+                         : _exchangePublic.queryWithdrawalFee(currencyCode);
+}
+
 bool Exchange::canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const {
   if (_exchangeInfo.excludedCurrenciesWithdrawal().contains(currencyCode)) {
     return false;


### PR DESCRIPTION
Implement private query withdrawal fees for `Upbit` (only for one currency code) and `Binance`. 
Indeed, the public withdrawal fees queries from them are non official (and slow for Binance, hardcoded from a json file for Upbit).

Also fix retrieval of Binance withdrawal fees from the `depositFee` URL, taking the maximum of all network lists (for instance, Ethereum withdrawal fees were not correct for the main net).