### PR TITLE
Addition of option --nosecrets

### DIFF
--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -48,7 +48,11 @@ class Coincenter {
   using UniquePublicSelectedExchanges = ExchangeRetriever::UniquePublicSelectedExchanges;
   using MonetaryAmountPerExchange = FixedCapacityVector<MonetaryAmount, kNbSupportedExchanges>;
 
-  explicit Coincenter(settings::RunMode runMode = settings::RunMode::kProd);
+  explicit Coincenter(settings::RunMode runMode = settings::RunMode::kProd)
+      : Coincenter(PublicExchangeNames(), false, runMode) {}
+
+  Coincenter(const PublicExchangeNames &exchangesWithoutSecrets, bool allExchangesWithoutSecrets,
+             settings::RunMode runMode = settings::RunMode::kProd);
 
   Coincenter(const Coincenter &) = delete;
   Coincenter &operator=(const Coincenter &) = delete;

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -22,9 +22,10 @@ struct CoincenterCmdLineOptions {
   static void PrintVersion(const char* programName);
 
   std::string logLevel;
-  bool help{};
-  bool version{};
-  bool logFile{};
+  bool help = false;
+  bool version = false;
+  bool logFile = false;
+  std::optional<std::string> nosecrets;
 
   std::string markets;
 
@@ -69,6 +70,9 @@ inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptions
                                                       "Possible values are: trace|debug|info|warning|error|critical|off"}, 
                                                       &OptValueType::logLevel},
        {{{"General", 1}, "--logfile", "", "Log to rotating files instead of stdout / stderr"}, &OptValueType::logFile},
+       {{{"General", 1}, "--nosecrets", "[exch1,...]", "Even if present, do not load secrets and do not use private exchanges.\n"
+                                                       "If empty list of exchanges, it skips secrets load for all private exchanges"}, 
+                                                       &OptValueType::nosecrets},
 
        {{{"Public queries", 2}, "--markets", 'm', "<cur[,exch1,...]>", "Print markets involving given currency for all exchanges, or only the specified ones."}, 
                                                                        &OptValueType::markets},

--- a/src/engine/include/coincenterparsedoptions.hpp
+++ b/src/engine/include/coincenterparsedoptions.hpp
@@ -32,9 +32,12 @@ class CoincenterParsedOptions {
   Market marketForConversionPath;
   PublicExchangeNames conversionPathExchanges;
 
-  bool balanceForAll{};
+  bool balanceForAll = false;
   PrivateExchangeNames balancePrivateExchanges;
   CurrencyCode balanceCurrencyCode;
+
+  bool noSecretsForAll = false;
+  PublicExchangeNames noSecretsExchanges;
 
   MonetaryAmount amountToWithdraw;
   PrivateExchangeName withdrawFromExchangeName, withdrawToExchangeName;
@@ -47,7 +50,7 @@ class CoincenterParsedOptions {
   Market lastPriceMarket;
   PublicExchangeNames lastPriceExchanges;
 
-  bool noProcess{};
+  bool noProcess = false;
 
  protected:
   void setFromOptions(const CoincenterCmdLineOptions &cmdLineOptions, const char *programName);

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -34,11 +34,12 @@ std::string ConstructAccumulatedExchangeNames(std::span<const ExchangeNameT> exc
 }
 }  // namespace
 
-Coincenter::Coincenter(settings::RunMode runMode)
+Coincenter::Coincenter(const PublicExchangeNames &exchangesWithoutSecrets, bool allExchangesWithoutSecrets,
+                       settings::RunMode runMode)
     : _coincenterInfo(runMode),
       _cryptowatchAPI(runMode),
       _fiatConverter(std::chrono::hours(8)),
-      _apiKeyProvider(runMode),
+      _apiKeyProvider(exchangesWithoutSecrets, allExchangesWithoutSecrets, runMode),
       _binancePublic(_coincenterInfo, _fiatConverter, _cryptowatchAPI),
       _bithumbPublic(_coincenterInfo, _fiatConverter, _cryptowatchAPI),
       _huobiPublic(_coincenterInfo, _fiatConverter, _cryptowatchAPI),

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -62,6 +62,12 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
     balanceCurrencyCode = CurrencyCode(cmdLineOptions.balance_cur);
   }
 
+  if (cmdLineOptions.nosecrets) {
+    StringOptionParser anyParser(*cmdLineOptions.nosecrets);
+    noSecretsExchanges = anyParser.getExchanges();
+    noSecretsForAll = noSecretsExchanges.empty();
+  }
+
   if (!cmdLineOptions.trade.empty()) {
     StringOptionParser anyParser(cmdLineOptions.trade);
     std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeName) =

--- a/src/engine/src/main.cpp
+++ b/src/engine/src/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, const char* argv[]) {
       return EXIT_SUCCESS;
     }
 
-    cct::Coincenter coincenter;
+    cct::Coincenter coincenter(opts.noSecretsExchanges, opts.noSecretsForAll);
     coincenter.process(opts);
   } catch (...) {
     return EXIT_FAILURE;

--- a/src/objects/include/apikeysprovider.hpp
+++ b/src/objects/include/apikeysprovider.hpp
@@ -9,17 +9,20 @@
 #include "cct_run_modes.hpp"
 #include "cct_smallvector.hpp"
 #include "cct_vector.hpp"
+#include "exchangename.hpp"
 
 namespace cct {
-
-class PrivateExchangeName;
-
 namespace api {
 class APIKeysProvider {
  public:
   using KeyNames = SmallVector<std::string, kTypicalNbPrivateAccounts>;
 
-  explicit APIKeysProvider(settings::RunMode runMode = settings::RunMode::kProd) : _apiKeysMap(ParseAPIKeys(runMode)) {}
+  explicit APIKeysProvider(settings::RunMode runMode = settings::RunMode::kProd)
+      : APIKeysProvider(PublicExchangeNames(), false, runMode) {}
+
+  APIKeysProvider(const PublicExchangeNames &exchangesWithoutSecrets, bool allExchangesWithoutSecrets,
+                  settings::RunMode runMode = settings::RunMode::kProd)
+      : _apiKeysMap(ParseAPIKeys(exchangesWithoutSecrets, allExchangesWithoutSecrets, runMode)) {}
 
   APIKeysProvider(const APIKeysProvider &) = delete;
   APIKeysProvider &operator=(const APIKeysProvider &) = delete;
@@ -37,7 +40,8 @@ class APIKeysProvider {
   using APIKeys = vector<APIKey>;
   using APIKeysMap = std::map<std::string, APIKeys, std::less<>>;
 
-  static APIKeysMap ParseAPIKeys(settings::RunMode runMode);
+  static APIKeysMap ParseAPIKeys(const PublicExchangeNames &exchangesWithoutSecrets, bool allExchangesWithoutSecrets,
+                                 settings::RunMode runMode);
 
   APIKeysMap _apiKeysMap;
 };


### PR DESCRIPTION
Option `--nosecrets` avoids loading and usage of private keys of given exchange names (optional, if none given, engine does not load any key).

This can be useful when launching public commands that may use private REST API if more precise (depending on the exchange) from a forbidden API for instance.