### PR TITLE
Add a retry mechanism in CI API tests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,9 +12,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: cmake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-11 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1
+
       - name: build
         run: cmake --build build --parallel 2
-      - name: test
-        run: cd build && ctest -j 2 --output-on-failure
+
+      - name: Local Tests
+        run: ctest --test-dir build --output-on-failure --exclude-regex api_test
+        
+      - name: Public API Tests # Tries up to 3 times to avoid random timeout errors not coming from coincenter
+        run: ctest --test-dir build --output-on-failure --tests-regex api_test --repeat until-pass:3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -46,12 +46,14 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       shell: bash
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config ${{matrix.buildmode}} -j 2
 
-    - name: Test
+    - name: Local Tests
       working-directory: ${{github.workspace}}/build
       shell: bash
-      # Execute tests defined by the CMake configuration. Print debug traces on failure
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -j 2 -C ${{matrix.buildmode}} --output-on-failure
+      run: ctest -j 2 -C ${{matrix.buildmode}} --output-on-failure --exclude-regex api_test
+
+    - name: Public API Tests # Tries up to 3 times to avoid random timeout errors not coming from coincenter
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ctest -j 2 -C ${{matrix.buildmode}} --output-on-failure --tests-regex api_test --repeat until-pass:3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: cmake --build . --config ${{matrix.buildmode}} --parallel 2
 
-      - name: Tests
+      - name: Local Tests
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{matrix.buildmode}} -j 2 --output-on-failure
+        run: ctest -C ${{matrix.buildmode}} --output-on-failure --exclude-regex api_test
+
+      - name: Public API Tests # Tries up to 3 times to avoid random timeout errors not coming from coincenter
+        working-directory: ${{github.workspace}}/build
+        run: ctest -C ${{matrix.buildmode}} --output-on-failure --tests-regex api_test --repeat until-pass:3


### PR DESCRIPTION
The aim is to decrease false negatives in the API tests in GitHub CI (especially MacOS ones).
The local tests do not have a retry mechanism (a fail at first run and a success after indicates an issue, possibly coming from memory corruptions).