### PR TITLE
Remove unnecessary request from UpbitPrivate API in queryTradableCurrencies

### DIFF
--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -48,14 +48,16 @@ class UpbitPrivate : public ExchangePrivate {
 
  private:
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic)
-        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+    TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic,
+                           const ExchangeInfo& exchangeInfo)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic), _exchangeInfo(exchangeInfo) {}
 
     CurrencyExchangeFlatSet operator()();
 
     CurlHandle& _curlHandle;
     const APIKey& _apiKey;
     UpbitPublic& _exchangePublic;
+    const ExchangeInfo& _exchangeInfo;
   };
 
   struct DepositWalletFunc {

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -47,6 +47,8 @@ class UpbitPublic : public ExchangePublic {
  private:
   friend class UpbitPrivate;
 
+  static bool CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies);
+
   struct MarketsFunc {
     MarketsFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -32,15 +32,6 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurlPostData
   return dataJson;
 }
 
-bool CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies) {
-  if (excludedCurrencies.contains(standardCode)) {
-    // Forbidden currency, do not consider its market
-    log::trace("Discard {} excluded by config", standardCode.str());
-    return false;
-  }
-  return true;
-}
-
 }  // namespace
 
 UpbitPublic::UpbitPublic(CoincenterInfo& config, FiatConverter& fiatConverter, CryptowatchAPI& cryptowatchAPI)
@@ -87,6 +78,15 @@ CurrencyExchangeFlatSet UpbitPublic::TradableCurrenciesFunc::operator()() {
   log::warn("Public API of Upbit does not provide deposit / withdrawal access");
   log::warn("Use Upbit private API to get full withdrawal and deposit statuses");
   return currencies;
+}
+
+bool UpbitPublic::CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies) {
+  if (excludedCurrencies.contains(standardCode)) {
+    // Forbidden currency, do not consider its market
+    log::trace("Discard {} excluded by config", standardCode.str());
+    return false;
+  }
+  return true;
 }
 
 ExchangePublic::MarketSet UpbitPublic::MarketsFunc::operator()() {


### PR DESCRIPTION
This speeds up `UpbitPrivate::queryTradableCurrencies` and remove incorrect warning logs when using private API to retrieve them.