### PR TITLE
Centralize string definition as cct::string

### DIFF
--- a/src/api/common/include/cryptowatchapi.hpp
+++ b/src/api/common/include/cryptowatchapi.hpp
@@ -30,9 +30,7 @@ class CryptowatchAPI : public ExchangeBase {
   CryptowatchAPI &operator=(CryptowatchAPI &&) = delete;
 
   /// Tells whether given exchange is supported by Cryptowatch.
-  bool queryIsExchangeSupported(const std::string &exchangeName) {
-    return _supportedExchanges.get().contains(exchangeName);
-  }
+  bool queryIsExchangeSupported(const string &exchangeName) { return _supportedExchanges.get().contains(exchangeName); }
 
   /// Query the approximate price of market 'm' for exchange name 'exchangeName'.
   /// Data may not be up to date, but should respond quickly.
@@ -46,11 +44,11 @@ class CryptowatchAPI : public ExchangeBase {
   void updateCacheFile() const override;
 
  private:
-  using Fiats = cct::FlatSet<CurrencyCode>;
-  using SupportedExchanges = cct::FlatSet<std::string>;
+  using Fiats = FlatSet<CurrencyCode>;
+  using SupportedExchanges = FlatSet<string>;
   /// Cryptowatch markets are represented by one unique string pair, it's not trivial to split the two currencies
-  /// acronyms. A second match will be needed to transform it to a final 'cct::Market'
-  using PricesPerMarketMap = std::unordered_map<std::string, double>;
+  /// acronyms. A second match will be needed to transform it to a final 'Market'
+  using PricesPerMarketMap = std::unordered_map<string, double>;
 
   struct SupportedExchangesFunc {
     explicit SupportedExchangesFunc(CurlHandle &curlHandle) : _curlHandle(curlHandle) {}
@@ -75,7 +73,7 @@ class CryptowatchAPI : public ExchangeBase {
   TimePoint _lastUpdatedFiatsTime;
   Clock::duration _fiatsUpdateFrequency;
   CachedResult<SupportedExchangesFunc> _supportedExchanges;
-  CachedResult<AllPricesFunc, std::string> _allPricesCache;
+  CachedResult<AllPricesFunc, string> _allPricesCache;
 };
 }  // namespace api
 }  // namespace cct

--- a/src/api/common/include/exchangepublicapi.hpp
+++ b/src/api/common/include/exchangepublicapi.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <optional>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
 #include "cachedresultvault.hpp"
 #include "cct_flatset.hpp"
+#include "cct_string.hpp"
 #include "cct_vector.hpp"
 #include "coincenterinfo.hpp"
 #include "currencycode.hpp"
@@ -104,7 +104,7 @@ class ExchangePublic : public ExchangeBase {
                  const CoincenterInfo &coincenterInfo)
       : _name(name), _fiatConverter(fiatConverter), _cryptowatchApi(cryptowatchApi), _coincenterInfo(coincenterInfo) {}
 
-  std::string _name;
+  string _name;
   FiatConverter &_fiatConverter;
   CryptowatchAPI &_cryptowatchApi;
   const CoincenterInfo &_coincenterInfo;

--- a/src/api/common/include/ssl_sha.hpp
+++ b/src/api/common/include/ssl_sha.hpp
@@ -3,7 +3,9 @@
 #include <array>
 #include <climits>
 #include <span>
-#include <string>
+#include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 namespace ssl {
@@ -12,18 +14,17 @@ namespace ssl {
 // helper function to compute SHA256:
 using Sha256 = std::array<char, 256 / CHAR_BIT>;
 
-Sha256 ComputeSha256(const std::string& data);
+Sha256 ComputeSha256(std::string_view data);
 
 enum class ShaType { kSha256, kSha512 };
 
-std::string ShaBin(ShaType shaType, const std::string& data, const char* secret);
+string ShaBin(ShaType shaType, std::string_view data, const char* secret);
 
-std::string ShaHex(ShaType shaType, const std::string& data, const char* secret);
+string ShaHex(ShaType shaType, std::string_view data, const char* secret);
 
-std::string ShaDigest(ShaType shaType, std::span<const std::string> data);
+string ShaDigest(ShaType shaType, std::string_view data);
 
-inline std::string ShaDigest(ShaType shaType, const std::string& data) {
-  return ShaDigest(shaType, std::span<const std::string>(std::addressof(data), 1));
-}
+string ShaDigest(ShaType shaType, std::span<const string> data);
+
 }  // namespace ssl
 }  // namespace cct

--- a/src/api/common/include/tradeinfo.hpp
+++ b/src/api/common/include/tradeinfo.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <string>
-
+#include "cct_string.hpp"
 #include "market.hpp"
 #include "monetaryamount.hpp"
 #include "tradeoptions.hpp"
@@ -9,17 +8,17 @@
 namespace cct {
 namespace api {
 
-using OrderId = std::string;
+using OrderId = string;
 
 struct TradeInfo {
-  TradeInfo(CurrencyCode fromCur, CurrencyCode toCur, Market market, const TradeOptions &opts, std::string &&uRef)
+  TradeInfo(CurrencyCode fromCur, CurrencyCode toCur, Market market, const TradeOptions &opts, string &&uRef)
       : fromCurrencyCode(fromCur), toCurrencyCode(toCur), m(market), options(opts), userRef(std::move(uRef)) {}
 
   CurrencyCode fromCurrencyCode;
   CurrencyCode toCurrencyCode;
   Market m;
   TradeOptions options;
-  std::string userRef;  // Only used for Kraken, used to group orders queries context
+  string userRef;  // Only used for Kraken, used to group orders queries context
 };
 
 struct TradedAmounts {
@@ -36,7 +35,7 @@ struct TradedAmounts {
 
   bool isZero() const { return tradedFrom.isZero() && tradedTo.isZero(); }
 
-  std::string str() const;
+  string str() const;
 
   MonetaryAmount tradedFrom;  // In currency of 'from' amount
   MonetaryAmount tradedTo;    // In the opposite currency
@@ -54,7 +53,7 @@ struct OrderInfo {
 struct PlaceOrderInfo {
   explicit PlaceOrderInfo(OrderInfo &&oInfo) : orderInfo(std::move(oInfo)) {}
 
-  PlaceOrderInfo(OrderInfo &&oInfo, std::string orderId) : orderInfo(std::move(oInfo)), orderId(std::move(orderId)) {}
+  PlaceOrderInfo(OrderInfo &&oInfo, string orderId) : orderInfo(std::move(oInfo)), orderId(std::move(orderId)) {}
 
   bool isClosed() const { return orderInfo.isClosed; }
   void setClosed() { orderInfo.setClosed(); }

--- a/src/api/common/include/tradeoptions.hpp
+++ b/src/api/common/include/tradeoptions.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <chrono>
-#include <string>
 #include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 namespace api {
@@ -58,9 +59,9 @@ class TradeOptions {
 
   void switchToTakerStrategy() { _strategy = TradeStrategy::kTaker; }
 
-  std::string strategyStr() const;
+  std::string_view strategyStr() const;
 
-  std::string str() const;
+  string str() const;
 
  private:
   Clock::duration _maxTradeTime;

--- a/src/api/common/include/withdrawinfo.hpp
+++ b/src/api/common/include/withdrawinfo.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <chrono>
-#include <string>
 #include <string_view>
 
+#include "cct_string.hpp"
 #include "monetaryamount.hpp"
 #include "wallet.hpp"
 
 namespace cct {
-using WithdrawId = std::string;
+using WithdrawId = string;
 using WithdrawIdView = std::string_view;
 
 namespace api {

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -60,9 +60,9 @@ ExchangePublic::Currencies ExchangePublic::findFastestConversionPath(Market conv
   const bool isToFiatLike = optFiatFromStableCoin || _cryptowatchApi.queryIsCurrencyCodeFiat(toCurrencyCode);
   MarketSet markets = queryTradableMarkets();
 
-  cct::vector<Currencies> searchPaths(1, {fromCurrencyCode});
+  vector<Currencies> searchPaths(1, {fromCurrencyCode});
   auto comp = [](const Currencies &lhs, const Currencies &rhs) { return lhs.size() > rhs.size(); };
-  cct::FlatSet<CurrencyCode> visitedCurrencies;
+  FlatSet<CurrencyCode> visitedCurrencies;
   do {
     std::pop_heap(searchPaths.begin(), searchPaths.end(), comp);
     Currencies path = std::move(searchPaths.back());
@@ -116,7 +116,7 @@ Market ExchangePublic::retrieveMarket(CurrencyCode c1, CurrencyCode c2) {
   if (!markets.contains(m)) {
     m = m.reverse();
     if (!markets.contains(m)) {
-      throw exception("Cannot trade " + std::string(c1.str()) + " into " + std::string(c2.str()) + " on " + _name);
+      throw exception("Cannot trade " + string(c1.str()) + " into " + string(c2.str()) + " on " + _name);
     }
   }
   return m;

--- a/src/api/common/src/tradeinfo.cpp
+++ b/src/api/common/src/tradeinfo.cpp
@@ -6,8 +6,8 @@ TradedAmounts TradedAmounts::operator+(const TradedAmounts &o) const {
   return TradedAmounts(tradedFrom + o.tradedFrom, tradedTo + o.tradedTo);
 }
 
-std::string TradedAmounts::str() const {
-  std::string ret;
+string TradedAmounts::str() const {
+  string ret;
   ret.append(tradedFrom.str());
   ret.append(" -> ");
   ret.append(tradedTo.str());

--- a/src/api/common/src/tradeoptions.cpp
+++ b/src/api/common/src/tradeoptions.cpp
@@ -15,7 +15,7 @@ TradeStrategy StrategyFromStr(std::string_view strategyStr) {
   if (strategyStr == "taker") {
     return TradeStrategy::kTaker;
   }
-  throw exception("Unrecognized trade strategy " + std::string(strategyStr));
+  throw exception("Unrecognized trade strategy " + string(strategyStr));
 }
 }  // namespace
 
@@ -35,7 +35,7 @@ TradeOptions::TradeOptions(std::string_view strategyStr, TradeMode tradeMode, Cl
       _strategy(StrategyFromStr(strategyStr)),
       _tradeMode(tradeMode) {}
 
-std::string TradeOptions::strategyStr() const {
+std::string_view TradeOptions::strategyStr() const {
   switch (_strategy) {
     case TradeStrategy::kMaker:
       return "maker";
@@ -48,8 +48,8 @@ std::string TradeOptions::strategyStr() const {
   }
 }
 
-std::string TradeOptions::str() const {
-  std::string ret(isSimulation() ? "Simulated " : "Real ");
+string TradeOptions::str() const {
+  string ret(isSimulation() ? "Simulated " : "Real ");
   ret.append(strategyStr());
   ret.append(" strategy, timeout of ");
   ret.append(std::to_string(std::chrono::duration_cast<std::chrono::seconds>(_maxTradeTime).count()));

--- a/src/api/common/test/exchangepublicapi_test.cpp
+++ b/src/api/common/test/exchangepublicapi_test.cpp
@@ -45,7 +45,7 @@ TEST_F(ExchangePublicTest, RetrieveMarket) {
 
   EXPECT_EQ(exchangePublic.retrieveMarket("BTC", "KRW"), Market("BTC", "KRW"));
   EXPECT_EQ(exchangePublic.retrieveMarket("KRW", "BTC"), Market("BTC", "KRW"));
-  EXPECT_THROW(exchangePublic.retrieveMarket("EUR", "EOS"), cct::exception);
+  EXPECT_THROW(exchangePublic.retrieveMarket("EUR", "EOS"), exception);
 }
 
 }  // namespace api

--- a/src/api/exchanges/include/huobipublicapi.hpp
+++ b/src/api/exchanges/include/huobipublicapi.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <limits>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
 #include "cachedresult.hpp"
 #include "cct_json.hpp"
+#include "cct_string.hpp"
 #include "curlhandle.hpp"
 #include "currencycode.hpp"
 #include "exchangepublicapi.hpp"

--- a/src/api/exchanges/include/krakenprivateapi.hpp
+++ b/src/api/exchanges/include/krakenprivateapi.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <span>
-#include <string>
 
 #include "cachedresult.hpp"
 #include "cct_json.hpp"
+#include "cct_string.hpp"
 #include "curlhandle.hpp"
 #include "exchangeprivateapi.hpp"
 #include "tradeinfo.hpp"

--- a/src/api/exchanges/include/krakenpublicapi.hpp
+++ b/src/api/exchanges/include/krakenpublicapi.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <string>
-
 #include "cachedresult.hpp"
+#include "cct_string.hpp"
 #include "curlhandle.hpp"
 #include "exchangepublicapi.hpp"
 #include "volumeandpricenbdecimals.hpp"
@@ -72,13 +71,12 @@ class KrakenPublic : public ExchangePublic {
     using WithdrawalMinMap = std::unordered_map<CurrencyCode, MonetaryAmount>;
     using WithdrawalInfoMaps = std::pair<WithdrawalFeeMap, WithdrawalMinMap>;
 
-    WithdrawalFeesFunc(CoincenterInfo& config, const std::string& name) : _config(config), _name(name) {}
+    explicit WithdrawalFeesFunc(CoincenterInfo& config) : _config(config) {}
 
     WithdrawalInfoMaps operator()();
 
     CoincenterInfo& _config;
     CurlHandle _curlHandle;
-    const std::string& _name;
   };
 
   struct MarketsFunc {

--- a/src/api/exchanges/include/kucoinpublicapi.hpp
+++ b/src/api/exchanges/include/kucoinpublicapi.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <limits>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
 #include "cachedresult.hpp"
 #include "cct_flatset.hpp"
 #include "cct_json.hpp"
+#include "cct_string.hpp"
 #include "curlhandle.hpp"
 #include "currencycode.hpp"
 #include "exchangepublicapi.hpp"

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -70,9 +70,11 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct WithdrawalFeesFunc {
-    explicit WithdrawalFeesFunc(const std::string& name) : _name(name) {}
+    explicit WithdrawalFeesFunc(const string& name) : _name(name) {}
+
     WithdrawalFeeMap operator()();
-    const std::string& _name;
+
+    const string& _name;
   };
 
   struct AllOrderBooksFunc {

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -23,13 +23,13 @@ void SetNonceAndSignature(const APIKey& apiKey, CurlPostData& postData) {
   Nonce nonce = Nonce_TimeSinceEpoch();
   postData.set("timestamp", nonce);
   postData.erase("signature");
-  postData.append("signature", ssl::ShaHex(ssl::ShaType::kSha256, postData.toString(), apiKey.privateKey()));
+  postData.append("signature", ssl::ShaHex(ssl::ShaType::kSha256, postData.str(), apiKey.privateKey()));
 }
 
 template <class CurlPostDataT = CurlPostData>
 json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::RequestType requestType,
                   std::string_view baseURL, std::string_view method, CurlPostDataT&& curlPostData = CurlPostData()) {
-  std::string url(baseURL);
+  string url(baseURL);
   url.push_back('/');
   url.append(method);
 
@@ -57,7 +57,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
       statusCode = dataJson["code"];
     }
     const std::string_view errorMessage = dataJson["msg"].get<std::string_view>();
-    throw exception("error " + std::to_string(statusCode) + ", msg: " + std::string(errorMessage));
+    throw exception("error " + std::to_string(statusCode) + ", msg: " + string(errorMessage));
   }
   return dataJson;
 }
@@ -125,7 +125,7 @@ MonetaryAmount BinancePrivate::WithdrawFeesFunc::operator()(CurrencyCode currenc
   if (!result.contains(currencyCode.str())) {
     throw exception("Unable to find asset information in assetDetail query to Binance");
   }
-  const json& withdrawFeeDetails = result[std::string(currencyCode.str())];
+  const json& withdrawFeeDetails = result[string(currencyCode.str())];
   if (!withdrawFeeDetails["withdrawStatus"].get<bool>()) {
     log::error("{} is currently unavailable for withdraw from {}", currencyCode.str(), _exchangePublic.name());
   }
@@ -209,7 +209,7 @@ OrderInfo BinancePrivate::queryOrder(const OrderId& orderId, const TradeInfo& tr
   const Market m = tradeInfo.m;
   const CurlOptions::RequestType requestType =
       isCancel ? CurlOptions::RequestType::kDelete : CurlOptions::RequestType::kGet;
-  const std::string assetsStr = m.assetsPairStr();
+  const string assetsStr = m.assetsPairStr();
   const std::string_view assets(assetsStr);
   BinancePublic& binancePublic = dynamic_cast<BinancePublic&>(_exchangePublic);
   const json result = PrivateQuery(_curlHandle, _apiKey, requestType, binancePublic._commonInfo.getBestBaseURL(),

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -23,14 +23,14 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
   CurlOptions opts(requestType, std::move(postdata));
 
   Nonce nonce = Nonce_TimeSinceEpoch();
-  std::string strToSign = nonce;
+  string strToSign = nonce;
   strToSign.append(opts.requestTypeStr());
   strToSign.append(method);
 
   if (!opts.postdata.empty()) {
     if (endpointWithParameters) {
       strToSign.push_back('?');
-      strToSign.append(opts.postdata.toStringView());
+      strToSign.append(opts.postdata.str());
     } else {
       strToSign.append(opts.postdata.toJson().dump());
       opts.httpHeaders.push_back("Content-Type: application/json");
@@ -38,9 +38,8 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
     }
   }
 
-  std::string signature = B64Encode(ssl::ShaBin(ssl::ShaType::kSha256, strToSign, apiKey.privateKey()));
-  std::string passphrase =
-      B64Encode(ssl::ShaBin(ssl::ShaType::kSha256, std::string(apiKey.passphrase()), apiKey.privateKey()));
+  string signature = B64Encode(ssl::ShaBin(ssl::ShaType::kSha256, strToSign, apiKey.privateKey()));
+  string passphrase = B64Encode(ssl::ShaBin(ssl::ShaType::kSha256, apiKey.passphrase(), apiKey.privateKey()));
 
   opts.userAgent = KucoinPublic::kUserAgent;
 
@@ -50,7 +49,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
   opts.httpHeaders.emplace_back("KC-API-PASSPHRASE: ").append(passphrase);
   opts.httpHeaders.emplace_back("KC-API-KEY-VERSION: 2");
 
-  std::string url = KucoinPublic::kUrlBase;
+  string url = KucoinPublic::kUrlBase;
   url.append(method);
 
   json dataJson = json::parse(curlHandle.query(url, opts));
@@ -210,7 +209,7 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
 }
 
 OrderInfo KucoinPrivate::cancelOrder(const OrderId& orderId, const TradeInfo& tradeInfo) {
-  std::string endpoint = "/api/v1/orders/";
+  string endpoint = "/api/v1/orders/";
   endpoint.append(orderId);
   PrivateQuery(_curlHandle, _apiKey, CurlOptions::RequestType::kDelete, endpoint);
   return queryOrderInfo(orderId, tradeInfo);
@@ -219,7 +218,7 @@ OrderInfo KucoinPrivate::cancelOrder(const OrderId& orderId, const TradeInfo& tr
 OrderInfo KucoinPrivate::queryOrderInfo(const OrderId& orderId, const TradeInfo& tradeInfo) {
   const CurrencyCode fromCurrencyCode(tradeInfo.fromCurrencyCode);
   const Market m = tradeInfo.m;
-  std::string endpoint = "/api/v1/orders/";
+  string endpoint = "/api/v1/orders/";
   endpoint.append(orderId);
 
   json data = PrivateQuery(_curlHandle, _apiKey, CurlOptions::RequestType::kGet, endpoint);

--- a/src/api/exchanges/src/kucoinpublicapi.cpp
+++ b/src/api/exchanges/src/kucoinpublicapi.cpp
@@ -20,12 +20,12 @@ namespace api {
 namespace {
 
 json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, const CurlPostData& curlPostData = CurlPostData()) {
-  std::string url = KucoinPublic::kUrlBase;
+  string url = KucoinPublic::kUrlBase;
   url.push_back('/');
   url.append(endpoint);
   if (!curlPostData.empty()) {
     url.push_back('?');
-    url.append(curlPostData.toStringView());
+    url.append(curlPostData.str());
   }
   CurlOptions opts(CurlOptions::RequestType::kGet);
   opts.userAgent = KucoinPublic::kUserAgent;
@@ -156,7 +156,7 @@ MonetaryAmount KucoinPublic::queryWithdrawalFee(CurrencyCode currencyCode) {
   const auto& currencyInfoSet = _tradableCurrenciesCache.get();
   auto it = currencyInfoSet.find(TradableCurrenciesFunc::CurrencyInfo(currencyCode));
   if (it == currencyInfoSet.end()) {
-    throw exception("Unable to find withdrawal fee for " + std::string(currencyCode.str()));
+    throw exception("Unable to find withdrawal fee for " + string(currencyCode.str()));
   }
   return MonetaryAmount(it->withdrawalMinFee, it->currencyExchange.standardCode());
 }
@@ -201,7 +201,7 @@ ExchangePublic::MarketOrderBookMap KucoinPublic::AllOrderBooksFunc::operator()(i
 
 MarketOrderBook KucoinPublic::OrderBookFunc::operator()(Market m, int depth) {
   // Kucoin has a fixed range of authorized values for depth
-  std::string symbol = m.assetsPairStr('-');
+  string symbol = m.assetsPairStr('-');
   CurlPostData postData{{"symbol", std::string_view(symbol)}};
   static constexpr int kAuthorizedDepths[] = {20, 100};
   auto lb = std::lower_bound(std::begin(kAuthorizedDepths), std::end(kAuthorizedDepths), depth);
@@ -212,13 +212,13 @@ MarketOrderBook KucoinPublic::OrderBookFunc::operator()(Market m, int depth) {
   } else {
     depth = *lb;
   }
-  std::string endpoint("api/v1/market/orderbook/level2_");
+  string endpoint("api/v1/market/orderbook/level2_");
   endpoint.append(std::to_string(depth));
 
   json asksAndBids = PublicQuery(_curlHandle, endpoint, postData);
   const json& asks = asksAndBids["asks"];
   const json& bids = asksAndBids["bids"];
-  using OrderBookVec = cct::vector<OrderBookLine>;
+  using OrderBookVec = vector<OrderBookLine>;
   OrderBookVec orderBookLines;
   orderBookLines.reserve(static_cast<OrderBookVec::size_type>(asks.size() + bids.size()));
   for (auto asksOrBids : {std::addressof(asks), std::addressof(bids)}) {

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -30,7 +30,7 @@ namespace {
 template <class CurlPostDataT = CurlPostData>
 json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::RequestType requestType,
                   std::string_view method, CurlPostDataT&& curlPostData = CurlPostData()) {
-  std::string method_url = UpbitPublic::kUrlBase;
+  string method_url = UpbitPublic::kUrlBase;
   method_url.append("/v1/");
   method_url.append(method);
 
@@ -43,13 +43,13 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
                           .set_payload_claim("nonce", jwt::claim(nonce));
 
   if (!opts.postdata.empty()) {
-    std::string queryHash = ssl::ShaDigest(ssl::ShaType::kSha512, opts.postdata.toString());
+    string queryHash = ssl::ShaDigest(ssl::ShaType::kSha512, opts.postdata.str());
 
     jsonWebToken.set_payload_claim("query_hash", jwt::claim(queryHash))
-        .set_payload_claim("query_hash_alg", jwt::claim(std::string("SHA512")));
+        .set_payload_claim("query_hash_alg", jwt::claim(string("SHA512")));
   }
 
-  std::string token = jsonWebToken.sign(jwt::algorithm::hs256{apiKey.privateKey()});
+  string token = jsonWebToken.sign(jwt::algorithm::hs256{apiKey.privateKey()});
 
   opts.httpHeaders.emplace_back("Authorization: Bearer ").append(token);
 
@@ -135,7 +135,7 @@ Wallet UpbitPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
       log::warn("No deposit address found for {}, generating a new one...", currencyCode.str());
       generateDepositAddressNeeded = true;
     } else {
-      throw exception("error: " + std::string(name) + "msg = " + std::string(msg));
+      throw exception("error: " + string(name) + "msg = " + string(msg));
     }
   }
   if (generateDepositAddressNeeded) {
@@ -147,7 +147,7 @@ Wallet UpbitPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
     result = PrivateQuery(_curlHandle, _apiKey, CurlOptions::RequestType::kGet, "deposits/coin_address", postdata);
   }
   if (result["deposit_address"].is_null()) {
-    throw exception("Deposit address for " + currencyCode.toString() + " is undefined");
+    throw exception("Deposit address for " + string(currencyCode.str()) + " is undefined");
   }
   std::string_view address = result["deposit_address"].get<std::string_view>();
   std::string_view tag;
@@ -344,8 +344,8 @@ SentWithdrawInfo UpbitPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
   MonetaryAmount netEmittedAmount(result["amount"].get<std::string_view>(), currencyCode);
 
   std::string_view state(result["state"].get<std::string_view>());
-  std::string stateUpperStr;
-  std::transform(state.begin(), state.end(), std::back_inserter(stateUpperStr), [](char c) { return cct::toupper(c); });
+  string stateUpperStr;
+  std::transform(state.begin(), state.end(), std::back_inserter(stateUpperStr), [](char c) { return toupper(c); });
   log::debug("{} withdrawal status {}", _exchangePublic.name(), state);
   // state values: {'submitting', 'submitted', 'almost_accepted', 'rejected', 'accepted', 'processing', 'done',
   // 'canceled'}
@@ -367,9 +367,9 @@ bool UpbitPrivate::isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWith
     if (netAmountReceived == sentWithdrawInfo.netEmittedAmount()) {
       std::string_view depositState(trx["state"].get<std::string_view>());
       log::debug("Deposit state {}", depositState);
-      std::string depositStateUpperStr;
+      string depositStateUpperStr;
       std::transform(depositState.begin(), depositState.end(), std::back_inserter(depositStateUpperStr),
-                     [](char c) { return cct::toupper(c); });
+                     [](char c) { return toupper(c); });
       if (depositStateUpperStr == "ACCEPTED") {
         return true;
       }

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -15,7 +15,7 @@ namespace api {
 namespace {
 
 json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurlPostData&& postData = CurlPostData()) {
-  std::string method_url = UpbitPublic::kUrlBase;
+  string method_url = UpbitPublic::kUrlBase;
   method_url.append("/v1/");
   method_url.append(endpoint);
 
@@ -27,7 +27,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurlPostData
   if (dataJson.contains("error")) {
     const long statusCode = dataJson["name"].get<long>();
     std::string_view msg = dataJson["message"].get<std::string_view>();
-    throw exception("error: " + std::to_string(statusCode) + " \"" + std::string(msg) + "\"");
+    throw exception("error: " + std::to_string(statusCode) + " \"" + string(msg) + "\"");
   }
   return dataJson;
 }
@@ -179,8 +179,8 @@ ExchangePublic::MarketOrderBookMap ParseOrderBooks(const json& result, int depth
 
 ExchangePublic::MarketOrderBookMap UpbitPublic::AllOrderBooksFunc::operator()(int depth) {
   const MarketSet& markets = _marketsCache.get();
-  std::string marketsStr;
-  marketsStr.reserve(static_cast<std::string::size_type>(markets.size()) * 8);
+  string marketsStr;
+  marketsStr.reserve(static_cast<string::size_type>(markets.size()) * 8);
   for (Market m : markets) {
     if (!marketsStr.empty()) {
       marketsStr.push_back(',');

--- a/src/api/interface/include/exchangeretrieverbase.hpp
+++ b/src/api/interface/include/exchangeretrieverbase.hpp
@@ -37,14 +37,14 @@ class ExchangeRetrieverBase {
       if (privateExchangeName.name() == exchange.name() &&
           (!privateExchangeName.isKeyNameDefined() || exchange.keyName() == privateExchangeName.keyName())) {
         if (pExchange) {
-          throw exception("Several private exchanges found for " + privateExchangeName.str() +
+          throw exception("Several private exchanges found for " + string(privateExchangeName.str()) +
                           " - remove ambiguity by specifying key name");
         }
         pExchange = std::addressof(exchange);
       }
     }
     if (!pExchange) {
-      throw exception("Cannot find exchange " + privateExchangeName.str());
+      throw exception("Cannot find exchange " + string(privateExchangeName.str()));
     }
     return *pExchange;
   }
@@ -84,7 +84,7 @@ class ExchangeRetrieverBase {
             }
             if (ret.size() == oldSize) {
               throw exception(
-                  std::string("Unable to find public exchange ").append(exchangeName).append(" in the exchange list"));
+                  string("Unable to find public exchange ").append(exchangeName).append(" in the exchange list"));
             }
           }
           break;

--- a/src/api/interface/test/exchangeretrieverbase_test.cpp
+++ b/src/api/interface/test/exchangeretrieverbase_test.cpp
@@ -63,7 +63,7 @@ TEST(ExchangeRetriever, RetrieveSelectedExchangesInitialOrder) {
 }
 
 TEST(ExchangeRetriever, RetrieveSelectedExchangesSelectedOrder) {
-  const std::pair<std::string, std::string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
+  const std::pair<string, string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
   for (const auto &[first, second] : kExchangePairs) {
     ExchangeTest kAllExchanges[] = {ExchangeTest(first, "user1"), ExchangeTest(second, "user1"),
                                     ExchangeTest(first, "user2")};
@@ -79,7 +79,7 @@ TEST(ExchangeRetriever, RetrieveSelectedExchangesSelectedOrder) {
 }
 
 TEST(ExchangeRetriever, RetrieveAtMostOneAccountSelectedExchanges) {
-  const std::pair<std::string, std::string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
+  const std::pair<string, string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
   for (const auto &[first, second] : kExchangePairs) {
     ExchangeTest kAllExchanges[] = {ExchangeTest(first, "user1"), ExchangeTest(second, "user1"),
                                     ExchangeTest(first, "user2")};
@@ -94,7 +94,7 @@ TEST(ExchangeRetriever, RetrieveAtMostOneAccountSelectedExchanges) {
 }
 
 TEST(ExchangeRetriever, RetrieveUniquePublicExchange) {
-  const std::pair<std::string, std::string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
+  const std::pair<string, string> kExchangePairs[] = {{"kraken", "bithumb"}, {"bithumb", "kraken"}};
   for (const auto &[first, second] : kExchangePairs) {
     ExchangeTest kAllExchanges[] = {ExchangeTest(first, "user1"), ExchangeTest(second, "user1")};
     ExchangeRetriever exchangeRetriever(kAllExchanges);

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -2,9 +2,9 @@
 
 #include <chrono>
 #include <optional>
-#include <string>
 #include <utility>
 
+#include "cct_string.hpp"
 #include "commandlineoptionsparser.hpp"
 #include "currencycode.hpp"
 #include "tradeoptions.hpp"
@@ -21,35 +21,35 @@ struct CoincenterCmdLineOptions {
 
   static void PrintVersion(const char* programName);
 
-  std::string logLevel;
+  string logLevel;
   bool help = false;
   bool version = false;
   bool logFile = false;
-  std::optional<std::string> nosecrets;
+  std::optional<string> nosecrets;
 
-  std::string markets;
+  string markets;
 
-  std::string orderbook;
+  string orderbook;
   int orderbook_depth{};
-  std::string orderbook_cur;
+  string orderbook_cur;
 
-  std::string conversion_path;
+  string conversion_path;
 
-  std::optional<std::string> balance;
-  std::string balance_cur{CurrencyCode::kNeutral.str()};
+  std::optional<string> balance;
+  string balance_cur{CurrencyCode::kNeutral.str()};
 
-  std::string trade;
-  std::string trade_strategy{api::TradeOptions().strategyStr()};
+  string trade;
+  string trade_strategy{api::TradeOptions().strategyStr()};
   Duration trade_timeout{api::TradeOptions::kDefaultTradeDuration};
   Duration trade_emergency{api::TradeOptions::kDefaultEmergencyTime};
   Duration trade_updateprice{api::TradeOptions::kDefaultMinTimeBetweenPriceUpdates};
   bool trade_sim{api::TradeOptions().isSimulation()};
 
-  std::string withdraw;
-  std::string withdraw_fee;
+  string withdraw;
+  string withdraw_fee;
 
-  std::string last24hTradedVolume;
-  std::string lastPrice;
+  string last24hTradedVolume;
+  string lastPrice;
 };
 
 template <class OptValueType>
@@ -111,30 +111,30 @@ inline CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptions
                                                                   " at market price before the timeout to make it eventually completely matched. "
                                                                   "Useful for exchanges proposing cheaper maker than taker fees."}, 
                                                                   &OptValueType::trade_strategy},
-       {{{"Trade", 4}, "--trade-timeout", "<time>", std::string("Adjust trade timeout (default: ")
+       {{{"Trade", 4}, "--trade-timeout", "<time>", string("Adjust trade timeout (default: ")
                                                 .append(std::to_string(defaultTradeTimeout))
                                                 .append("s). Remaining orders will be cancelled after the timeout.")}, 
                                                 &OptValueType::trade_timeout},
-       {{{"Trade", 4}, "--trade-emergency", "<time>", std::string("Adjust emergency buffer for the 'adapt' strategy (default: ")
+       {{{"Trade", 4}, "--trade-emergency", "<time>", string("Adjust emergency buffer for the 'adapt' strategy (default: ")
                                                    .append(std::to_string(emergencyBufferTime))
                                                    .append("s). Remaining order will be switched from limit to market price "
                                                    "after 'timeout - emergency' time to force completion of the trade")}, 
                                                    &OptValueType::trade_emergency},
-       {{{"Trade", 4}, "--trade-updateprice", "<time>", std::string("Set the min time allowed between two limit price updates (default: ")
+       {{{"Trade", 4}, "--trade-updateprice", "<time>", string("Set the min time allowed between two limit price updates (default: ")
                                                     .append(std::to_string(minUpdatePriceTime))
                                                     .append("s). Avoids cancelling / placing new orders too often with high volumes "
                                                     "which can be counter productive sometimes.")}, &OptValueType::trade_updateprice},
-       {{{"Trade", 4}, "--trade-sim", "", std::string("Activates simulation mode only (default: ")
+       {{{"Trade", 4}, "--trade-sim", "", string("Activates simulation mode only (default: ")
                                          .append(isSimulationModeByDefault ? "true" : "false")
                                          .append("). For some exchanges, API can even be queried in this "
                                          "mode to ensure deeper and more realistic trading inputs")}, &OptValueType::trade_sim},
 
-       {{{"Withdraw crypto", 5}, "--withdraw", 'w', "<amt cur,from-to>", std::string("Withdraw amount from exchange 'from' to exchange 'to'."
+       {{{"Withdraw crypto", 5}, "--withdraw", 'w', "<amt cur,from-to>", string("Withdraw amount from exchange 'from' to exchange 'to'."
                                                                          " Amount is gross, including fees. Address and tag will be retrieved"
                                                                          " automatically from destination exchange and should match an entry in '")
                                                                         .append(Wallet::kDepositAddressesFilename)
                                                                         .append("' file.")}, &OptValueType::withdraw},
-       {{{"Withdraw crypto", 5}, "--withdraw-fee", "<cur[,exch1,...]>", std::string("Prints withdraw fees of given currency on all supported exchanges,"
+       {{{"Withdraw crypto", 5}, "--withdraw-fee", "<cur[,exch1,...]>", string("Prints withdraw fees of given currency on all supported exchanges,"
                                                                          " or only for the list of specified ones if provided (comma separated).")}, 
                                                                 &OptValueType::withdraw_fee}});
   // clang-format on

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 #include <utility>
 
+#include "cct_string.hpp"
 #include "commandlineoptionsparser.hpp"
 #include "currencycode.hpp"
 #include "exchangename.hpp"
@@ -39,6 +39,6 @@ class StringOptionParser {
  protected:
   std::size_t getNextCommaPos(std::size_t startPos = 0, bool throwIfNone = true) const;
 
-  std::string _opt;
+  string _opt;
 };
 }  // namespace cct

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -26,19 +26,18 @@ PrivateExchangeNames StringOptionParser::getPrivateExchanges() const {
   PrivateExchangeNames ret;
   ret.reserve(fullNames.size());
   std::transform(fullNames.begin(), fullNames.end(), std::back_inserter(ret),
-                 [](const std::string& exchangeName) { return PrivateExchangeName(exchangeName); });
+                 [](std::string_view exchangeName) { return PrivateExchangeName(exchangeName); });
   return ret;
 }
 
 StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() const {
   std::size_t commaPos = getNextCommaPos(0, false);
-  std::string_view marketStr(_opt.begin(), commaPos == std::string::npos ? _opt.end() : _opt.begin() + commaPos);
+  std::string_view marketStr(_opt.begin(), commaPos == string::npos ? _opt.end() : _opt.begin() + commaPos);
   std::size_t dashPos = marketStr.find_first_of('-');
   if (dashPos == std::string_view::npos) {
     throw std::invalid_argument("Expected a dash");
   }
-  std::size_t startExchangesPos =
-      commaPos == std::string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
+  std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
 
   return MarketExchanges{Market(CurrencyCode(std::string_view(marketStr.begin(), marketStr.begin() + dashPos)),
                                 CurrencyCode(std::string_view(marketStr.begin() + dashPos + 1, marketStr.end()))),
@@ -47,24 +46,21 @@ StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() con
 
 StringOptionParser::MonetaryAmountExchanges StringOptionParser::getMonetaryAmountExchanges() const {
   std::size_t commaPos = getNextCommaPos(0, false);
-  std::size_t startExchangesPos =
-      commaPos == std::string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
+  std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
   return MonetaryAmountExchanges{
-      MonetaryAmount(
-          std::string_view(_opt.begin(), commaPos == std::string::npos ? _opt.end() : _opt.begin() + commaPos)),
+      MonetaryAmount(std::string_view(_opt.begin(), commaPos == string::npos ? _opt.end() : _opt.begin() + commaPos)),
       GetExchanges(std::string_view(_opt.begin() + startExchangesPos, _opt.end()))};
 }
 
 StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange
 StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchange() const {
   std::size_t dashPos = _opt.find_first_of('-');
-  if (dashPos == std::string::npos) {
+  if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
   MonetaryAmount startTradeAmount(std::string_view(_opt.begin(), _opt.begin() + dashPos));
   std::size_t commaPos = getNextCommaPos(dashPos + 1);
-  std::size_t startExchangesPos =
-      commaPos == std::string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
+  std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
   CurrencyCode toTradeCurrency(std::string_view(_opt.begin() + dashPos + 1, _opt.begin() + commaPos));
   return MonetaryAmountCurrencyCodePrivateExchange{
       startTradeAmount, toTradeCurrency,
@@ -77,7 +73,7 @@ StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getM
   MonetaryAmount amountToWithdraw(std::string_view(_opt.begin(), _opt.begin() + commaPos));
   std::string_view exchangeNames(_opt.begin() + commaPos + 1, _opt.end());
   std::size_t dashPos = exchangeNames.find_first_of('-');
-  if (dashPos == std::string::npos) {
+  if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
   return MonetaryAmountFromToPrivateExchange{
@@ -87,7 +83,7 @@ StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getM
 
 std::size_t StringOptionParser::getNextCommaPos(std::size_t startPos, bool throwIfNone) const {
   std::size_t commaPos = _opt.find_first_of(',', startPos);
-  if (commaPos == std::string::npos && throwIfNone) {
+  if (commaPos == string::npos && throwIfNone) {
     throw std::invalid_argument("Expected a comma");
   }
   return commaPos;
@@ -96,7 +92,7 @@ std::size_t StringOptionParser::getNextCommaPos(std::size_t startPos, bool throw
 StringOptionParser::CurrencyCodePublicExchanges StringOptionParser::getCurrencyCodePublicExchanges() const {
   std::size_t commaPos = getNextCommaPos(0, false);
   CurrencyCodePublicExchanges ret;
-  if (commaPos == std::string::npos) {
+  if (commaPos == string::npos) {
     ret.first = CurrencyCode(_opt);
   } else {
     ret.first = CurrencyCode(std::string_view(_opt.begin(), _opt.begin() + commaPos));

--- a/src/objects/include/apikey.hpp
+++ b/src/objects/include/apikey.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <string>
 #include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 namespace api {
 class APIKey {
  public:
-  APIKey(std::string_view platform, std::string_view name, std::string &&key, std::string &&privateKey,
-         std::string &&passphrase);
+  APIKey(std::string_view platform, std::string_view name, string &&key, string &&privateKey, string &&passphrase);
 
   APIKey(const APIKey &) = delete;
   APIKey operator=(const APIKey &) = delete;
@@ -17,18 +17,18 @@ class APIKey {
 
   std::string_view platform() const { return _platform; }
   std::string_view name() const { return _name; }
-  const std::string &key() const { return _key; }
+  const string &key() const { return _key; }
   const char *privateKey() const { return _privateKey.c_str(); }
   std::string_view passphrase() const { return _passphrase; }
 
   ~APIKey();
 
  private:
-  std::string _platform;
-  std::string _name;
-  std::string _key;
-  std::string _privateKey;
-  std::string _passphrase;
+  string _platform;
+  string _name;
+  string _key;
+  string _privateKey;
+  string _passphrase;
 };
 }  // namespace api
 }  // namespace cct

--- a/src/objects/include/apikeysprovider.hpp
+++ b/src/objects/include/apikeysprovider.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <map>
-#include <string>
 #include <string_view>
 
 #include "apikey.hpp"
 #include "cct_const.hpp"
 #include "cct_run_modes.hpp"
 #include "cct_smallvector.hpp"
+#include "cct_string.hpp"
 #include "cct_vector.hpp"
 #include "exchangename.hpp"
 
@@ -15,7 +15,7 @@ namespace cct {
 namespace api {
 class APIKeysProvider {
  public:
-  using KeyNames = SmallVector<std::string, kTypicalNbPrivateAccounts>;
+  using KeyNames = SmallVector<string, kTypicalNbPrivateAccounts>;
 
   explicit APIKeysProvider(settings::RunMode runMode = settings::RunMode::kProd)
       : APIKeysProvider(PublicExchangeNames(), false, runMode) {}
@@ -38,7 +38,7 @@ class APIKeysProvider {
 
  private:
   using APIKeys = vector<APIKey>;
-  using APIKeysMap = std::map<std::string, APIKeys, std::less<>>;
+  using APIKeysMap = std::map<string, APIKeys, std::less<>>;
 
   static APIKeysMap ParseAPIKeys(const PublicExchangeNames &exchangesWithoutSecrets, bool allExchangesWithoutSecrets,
                                  settings::RunMode runMode);

--- a/src/objects/include/coincenterinfo.hpp
+++ b/src/objects/include/coincenterinfo.hpp
@@ -5,12 +5,12 @@
 #include <chrono>
 #include <map>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <unordered_map>
 
 #include "apiquerytypeenum.hpp"
 #include "cct_run_modes.hpp"
+#include "cct_string.hpp"
 #include "currencycode.hpp"
 #include "exchangeinfo.hpp"
 
@@ -18,7 +18,7 @@ namespace cct {
 class CoincenterInfo {
  public:
   using CurrencyEquivalentAcronymMap = std::unordered_map<CurrencyCode, CurrencyCode>;
-  using ExchangeInfoMap = std::map<std::string, ExchangeInfo, std::less<>>;
+  using ExchangeInfoMap = std::map<string, ExchangeInfo, std::less<>>;
   using Duration = std::chrono::high_resolution_clock::duration;
   using StableCoinsMap = std::unordered_map<CurrencyCode, CurrencyCode>;
 

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -57,8 +57,6 @@ class CurrencyCode {
     return std::string_view(_data.begin(), std::find(_data.begin(), _data.end(), '\0'));
   }
 
-  std::string toString() const { return std::string(str()); }
-
   /// Returns a 64 bits code
   constexpr uint64_t code() const {
     uint64_t ret = _data[6];

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
+#include "cct_string.hpp"
 #include "currencycode.hpp"
 
 namespace cct {
@@ -24,7 +24,7 @@ class CurrencyExchange {
   std::string_view exchangeStr() const { return _exchangeCode.str(); }
   std::string_view altStr() const { return _altCode.str(); }
 
-  std::string str() const;
+  string str() const;
 
   CurrencyCode standardCode() const { return _standardCode; }
   CurrencyCode exchangeCode() const { return _exchangeCode; }

--- a/src/objects/include/currencyexchangeflatset.hpp
+++ b/src/objects/include/currencyexchangeflatset.hpp
@@ -50,7 +50,7 @@ class CurrencyExchangeFlatSet {
   const CurrencyExchange &getOrThrow(CurrencyCode standardCode) const {
     const_iterator it = find(standardCode);
     if (it == _set.end()) {
-      throw exception("Unknown " + std::string(standardCode.str()));
+      throw exception("Unknown " + string(standardCode.str()));
     }
     return *it;
   }

--- a/src/objects/include/exchangename.hpp
+++ b/src/objects/include/exchangename.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
 #include "cct_const.hpp"
 #include "cct_fixedcapacityvector.hpp"
 #include "cct_smallvector.hpp"
+#include "cct_string.hpp"
 
 namespace cct {
 
-using PublicExchangeName = std::string;
+using PublicExchangeName = string;
 using PublicExchangeNames = FixedCapacityVector<PublicExchangeName, kNbSupportedExchanges>;
 
 class PrivateExchangeName {
@@ -34,15 +34,15 @@ class PrivateExchangeName {
 
   bool isKeyNameDefined() const { return _dashPos < _nameWithKey.size(); }
 
-  const std::string &str() const { return _nameWithKey; }
+  std::string_view str() const { return _nameWithKey; }
 
   bool operator==(const PrivateExchangeName &o) const { return _nameWithKey == o._nameWithKey; }
   bool operator!=(const PrivateExchangeName &o) const { return !(*this == o); }
 
  private:
-  std::string _nameWithKey;
+  string _nameWithKey;
   std::size_t _dashPos = 0;
 };
 
-using PrivateExchangeNames = cct::SmallVector<PrivateExchangeName, kTypicalNbPrivateAccounts>;
+using PrivateExchangeNames = SmallVector<PrivateExchangeName, kTypicalNbPrivateAccounts>;
 }  // namespace cct

--- a/src/objects/include/exchangenamesview.hpp
+++ b/src/objects/include/exchangenamesview.hpp
@@ -1,7 +1,8 @@
 #pragma once
 #include <span>
-#include <string>
+
+#include "cct_string.hpp"
 
 namespace cct {
-using ExchangeNamesView = std::span<const std::string>;
+using ExchangeNamesView = std::span<const string>;
 }

--- a/src/objects/include/fiatconverter.hpp
+++ b/src/objects/include/fiatconverter.hpp
@@ -2,10 +2,10 @@
 
 #include <chrono>
 #include <mutex>
-#include <string>
 #include <unordered_map>
 
 #include "cachedresult.hpp"
+#include "cct_string.hpp"
 #include "curlhandle.hpp"
 #include "currencycode.hpp"
 #include "market.hpp"
@@ -71,6 +71,6 @@ class FiatConverter {
   PricesMap _pricesMap;
   Clock::duration _ratesUpdateFrequency;
   std::mutex _pricesMutex;
-  std::string _apiKey;
+  string _apiKey;
 };
 }  // namespace cct

--- a/src/objects/include/market.hpp
+++ b/src/objects/include/market.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <string>
-
+#include "cct_string.hpp"
 #include "currencycode.hpp"
 #include "monetaryamount.hpp"
 
@@ -43,8 +42,8 @@ class Market {
   bool operator==(const Market& o) const { return std::equal(_assets.begin(), _assets.end(), o._assets.begin()); }
   bool operator!=(const Market& o) const { return !(*this == o); }
 
-  std::string str() const { return assetsPairStr('-'); }
-  std::string assetsPairStr(char sep = 0) const;
+  string str() const { return assetsPairStr('-'); }
+  string assetsPairStr(char sep = 0) const;
 
   friend std::ostream& operator<<(std::ostream& os, const Market& m);
 

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -2,10 +2,10 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
 #include <string_view>
 
 #include "cct_mathhelpers.hpp"
+#include "cct_string.hpp"
 #include "currencycode.hpp"
 
 namespace cct {
@@ -161,9 +161,9 @@ class MonetaryAmount {
   constexpr void truncate(int8_t maxNbDecimals) { sanitizeNbDecimals(maxNbDecimals); }
 
   /// Get a string representation of the amount hold by this MonetaryAmount (without currency).
-  std::string amountStr() const;
+  string amountStr() const;
 
-  std::string str() const;
+  string str() const;
 
   friend std::ostream &operator<<(std::ostream &os, const MonetaryAmount &m);
 

--- a/src/objects/include/wallet.hpp
+++ b/src/objects/include/wallet.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
+#include "cct_string.hpp"
 #include "currencycode.hpp"
 #include "exchangename.hpp"
 
@@ -46,7 +46,7 @@ class Wallet {
 
   bool hasDestinationTag() const { return !_tag.empty(); }
 
-  std::string str() const;
+  string str() const;
 
   bool operator==(const Wallet &w) const {
     return _currency == w._currency && _privateExchangeName == w._privateExchangeName && _address == w._address &&
@@ -59,8 +59,8 @@ class Wallet {
 
  private:
   PrivateExchangeName _privateExchangeName;
-  std::string _address;
-  std::string _tag;
+  string _address;
+  string _tag;
   CurrencyCode _currency;
 };
 

--- a/src/objects/src/apikey.cpp
+++ b/src/objects/src/apikey.cpp
@@ -4,8 +4,7 @@
 
 namespace cct {
 namespace api {
-APIKey::APIKey(std::string_view platform, std::string_view name, std::string &&key, std::string &&privateKey,
-               std::string &&passphrase)
+APIKey::APIKey(std::string_view platform, std::string_view name, string &&key, string &&privateKey, string &&passphrase)
     : _platform(platform),
       _name(name),
       _key(std::move(key)),

--- a/src/objects/src/apikeysprovider.cpp
+++ b/src/objects/src/apikeysprovider.cpp
@@ -1,11 +1,10 @@
 #include "apikeysprovider.hpp"
 
-#include <string>
-
 #include "cct_const.hpp"
 #include "cct_exception.hpp"
 #include "cct_json.hpp"
 #include "cct_log.hpp"
+#include "cct_string.hpp"
 #include "jsonhelpers.hpp"
 
 namespace cct {
@@ -30,7 +29,7 @@ APIKeysProvider::KeyNames APIKeysProvider::getKeyNames(std::string_view platform
   if (foundIt != _apiKeysMap.end()) {
     const APIKeys& apiKeys = foundIt->second;
     std::transform(apiKeys.begin(), apiKeys.end(), std::back_inserter(keyNames),
-                   [](const APIKey& apiKey) { return std::string(apiKey.name()); });
+                   [](const APIKey& apiKey) { return string(apiKey.name()); });
   }
   return keyNames;
 }
@@ -39,12 +38,12 @@ const APIKey& APIKeysProvider::get(const PrivateExchangeName& privateExchangeNam
   std::string_view platformStr = privateExchangeName.name();
   auto foundIt = _apiKeysMap.find(platformStr);
   if (foundIt == _apiKeysMap.end()) {
-    throw exception("Unable to retrieve private key for " + std::string(platformStr));
+    throw exception("Unable to retrieve private key for " + string(platformStr));
   }
   const APIKeys& apiKeys = foundIt->second;
   if (!privateExchangeName.isKeyNameDefined()) {
     if (apiKeys.size() > 1) {
-      throw exception("Specify name for " + std::string(platformStr) + " keys as you have several");
+      throw exception("Specify name for " + string(platformStr) + " keys as you have several");
     }
     return apiKeys.front();
   }
@@ -52,8 +51,8 @@ const APIKey& APIKeysProvider::get(const PrivateExchangeName& privateExchangeNam
     return apiKey.name() == privateExchangeName.keyName();
   });
   if (keyNameIt == apiKeys.end()) {
-    throw exception("Unable to retrieve private key for " + std::string(platformStr) + " named " +
-                    std::string(privateExchangeName.keyName()));
+    throw exception("Unable to retrieve private key for " + string(platformStr) + " named " +
+                    string(privateExchangeName.keyName()));
   }
   return *keyNameIt;
 }
@@ -73,7 +72,7 @@ APIKeysProvider::APIKeysMap APIKeysProvider::ParseAPIKeys(const PublicExchangeNa
       }
       for (const auto& [name, keySecretObj] : keyObj.items()) {
         if (keySecretObj.contains("key") && keySecretObj.contains("private")) {
-          std::string passphrase;
+          string passphrase;
           if (keySecretObj.contains("passphrase")) {
             passphrase = keySecretObj["passphrase"];
           }

--- a/src/objects/src/balanceportfolio.cpp
+++ b/src/objects/src/balanceportfolio.cpp
@@ -42,23 +42,23 @@ void BalancePortfolio::print(std::ostream &os) const {
     CurrencyCode balanceCurrencyCode = _monetaryAmountSet.front().equi.currencyCode();
     if (balanceCurrencyCode != CurrencyCode::kNeutral) {
       MonetaryAmount totalSum = MonetaryAmount("0", balanceCurrencyCode);
-      cct::FixedCapacityVector<std::string, 3> cols;
+      FixedCapacityVector<string, 3> cols;
       cols.emplace_back("Amount");
       cols.emplace_back("Currency");
       cols.emplace_back("Eq. (").append(balanceCurrencyCode.str()).push_back(')');
-      VariadicTable<std::string, std::string, std::string> vt(cols);
+      VariadicTable<string, string, string> vt(cols);
       for (const auto &m : convertToSortedByAmountVector()) {
-        vt.addRow(m.amount.amountStr(), std::string(m.amount.currencyCode().str()),
+        vt.addRow(m.amount.amountStr(), string(m.amount.currencyCode().str()),
                   m.equi.isZero() ? "???" : m.equi.amountStr());
         totalSum += m.equi;
       }
       vt.print(os);
       os << "* Total: " << totalSum << std::endl;
     } else {
-      std::array<std::string, 2> cols = {"Amount", "Currency"};
-      VariadicTable<std::string, std::string> vt(cols);
+      std::array<string, 2> cols = {"Amount", "Currency"};
+      VariadicTable<string, string> vt(cols);
       for (const auto &m : *this) {
-        vt.addRow(m.amount.amountStr(), std::string(m.amount.currencyCode().str()));
+        vt.addRow(m.amount.amountStr(), string(m.amount.currencyCode().str()));
       }
       vt.print(os);
     }

--- a/src/objects/src/currencyexchange.cpp
+++ b/src/objects/src/currencyexchange.cpp
@@ -19,8 +19,8 @@ CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode excha
       _canWithdraw(withdraw == Withdraw::kAvailable),
       _unknownDepositWithdrawalStatus(false) {}
 
-std::string CurrencyExchange::str() const {
-  std::string ret(_standardCode.str());
+string CurrencyExchange::str() const {
+  string ret(_standardCode.str());
   ret.push_back('-');
   ret.push_back('D');
   ret.push_back(_canDeposit ? '1' : '0');

--- a/src/objects/src/exchangeinfo.cpp
+++ b/src/objects/src/exchangeinfo.cpp
@@ -11,7 +11,7 @@ ExchangeInfo::ExchangeInfo(std::string_view exchangeNameStr, const json &exchang
   // Load trade fees
   constexpr char kTradeFeesStr[] = "tradefees";
   if (!exchangeData.contains(kTradeFeesStr)) {
-    throw exception("Unable to load trade fees for exchange " + std::string(exchangeNameStr));
+    throw exception("Unable to load trade fees for exchange " + string(exchangeNameStr));
   }
   const json &tradeFeesData = exchangeData[kTradeFeesStr];
   std::string_view makerStr = tradeFeesData["maker"].get<std::string_view>();
@@ -34,10 +34,10 @@ ExchangeInfo::ExchangeInfo(std::string_view exchangeNameStr, const json &exchang
         // Don't make these json fields required, do nothing if not present
         const json &subData = assetData[kSubAssetConfig[subIdx]];
         CurrencySet &currencySet = *pCurrencySetPerConfig[subIdx];
-        std::string currenciesCSV = subData;
+        string currenciesCSV = subData;
         std::size_t first = 0;
         std::size_t last = currenciesCSV.find_first_of(',');
-        while (last != std::string::npos) {
+        while (last != string::npos) {
           currencySet.emplace(std::string_view(currenciesCSV.begin() + first, currenciesCSV.begin() + last));
           first = last + 1;
           last = currenciesCSV.find_first_of(',', first);
@@ -58,7 +58,7 @@ ExchangeInfo::ExchangeInfo(std::string_view exchangeNameStr, const json &exchang
   // Load query config
   constexpr char kQuery[] = "query";
   if (!exchangeData.contains(kQuery)) {
-    throw exception("Unable to load query configuration for exchange " + std::string(exchangeNameStr));
+    throw exception("Unable to load query configuration for exchange " + string(exchangeNameStr));
   }
   const json &queryData = exchangeData[kQuery];
   _minPublicQueryDelay = std::chrono::milliseconds(queryData["minpublicquerydelayms"].get<int>());

--- a/src/objects/src/exchangename.cpp
+++ b/src/objects/src/exchangename.cpp
@@ -12,7 +12,7 @@ PrivateExchangeName::PrivateExchangeName(std::string_view globalExchangeName)
 
 PrivateExchangeName::PrivateExchangeName(std::string_view exchangeName, std::string_view keyName)
     : _nameWithKey(exchangeName), _dashPos(_nameWithKey.size()) {
-  if (_nameWithKey.find_first_of('_') != std::string::npos) {
+  if (_nameWithKey.find_first_of('_') != string::npos) {
     throw exception("Invalid exchange name " + _nameWithKey);
   }
   if (!keyName.empty()) {

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -11,7 +11,7 @@ constexpr char kRatesFileName[] = ".ratescache.json";
 constexpr char kCurrencyConverterBaseUrl[] = "https://free.currconv.com/api/v7";
 constexpr char kFiatConverterJsonKeyFile[] = "thirdparty_secret.json";
 
-std::string LoadCurrencyConverterAPIKey() {
+string LoadCurrencyConverterAPIKey() {
   constexpr char kDefaultCommunityKey[] = "b25453de7984135a084b";
   // example http://free.currconv.com/api/v7/currencies?apiKey=b25453de7984135a084b
 
@@ -25,7 +25,7 @@ std::string LoadCurrencyConverterAPIKey() {
     log::warn("Using default key provided as a demo to the community");
     return kDefaultCommunityKey;
   }
-  return std::string(data["freecurrencyconverter"].get<std::string_view>());
+  return string(data["freecurrencyconverter"].get<std::string_view>());
 }
 
 }  // namespace
@@ -49,7 +49,7 @@ FiatConverter::FiatConverter(Clock::duration ratesUpdateFrequency, bool loadFrom
 void FiatConverter::updateCacheFile() const {
   json data;
   for (const auto& [market, priceTimeValue] : _pricesMap) {
-    std::string marketPairStr = market.assetsPairStr('-');
+    string marketPairStr = market.assetsPairStr('-');
     data[marketPairStr]["rate"] = priceTimeValue.rate;
     data[marketPairStr]["timeepoch"] =
         std::chrono::duration_cast<std::chrono::seconds>(priceTimeValue.lastUpdatedTime.time_since_epoch()).count();
@@ -58,15 +58,15 @@ void FiatConverter::updateCacheFile() const {
 }
 
 std::optional<double> FiatConverter::queryCurrencyRate(Market m) {
-  std::string url = kCurrencyConverterBaseUrl;
+  string url = kCurrencyConverterBaseUrl;
   url.append("/convert?");
 
   CurlOptions opts(CurlOptions::RequestType::kGet);
-  std::string qStr(m.assetsPairStr('_'));
+  string qStr(m.assetsPairStr('_'));
   opts.postdata.append("q", qStr);
   opts.postdata.append("apiKey", _apiKey);
 
-  url.append(opts.postdata.c_str());
+  url.append(opts.postdata.str());
   opts.postdata.clear();
 
   json data = json::parse(_curlHandle.query(url, opts), nullptr, false /* allow exceptions */);

--- a/src/objects/src/market.cpp
+++ b/src/objects/src/market.cpp
@@ -6,14 +6,14 @@ namespace cct {
 Market::Market(std::string_view marketStrRep, char currencyCodeSep) {
   std::size_t sepPos = marketStrRep.find_first_of(currencyCodeSep);
   if (sepPos == std::string_view::npos) {
-    throw exception("Market string representation " + std::string(marketStrRep) + " should have a separator");
+    throw exception("Market string representation " + string(marketStrRep) + " should have a separator");
   }
   _assets.front() = std::string_view(marketStrRep.begin(), marketStrRep.begin() + sepPos);
   _assets.back() = std::string_view(marketStrRep.begin() + sepPos + 1, marketStrRep.end());
 }
 
-std::string Market::assetsPairStr(char sep) const {
-  std::string ret(_assets.front().str());
+string Market::assetsPairStr(char sep) const {
+  string ret(_assets.front().str());
   if (sep != 0) {
     ret.push_back(sep);
   }

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -375,11 +375,11 @@ std::optional<MonetaryAmount> MarketOrderBook::convertQuoteAmountToBase(Monetary
 }
 
 void MarketOrderBook::print(std::ostream& os) const {
-  cct::FixedCapacityVector<std::string, 3> cols;
+  FixedCapacityVector<string, 3> cols;
   cols.emplace_back("Sellers of ").append(_market.base().str()).append(" (asks)");
   cols.emplace_back(_market.base().str()).append(" price in ").append(_market.quote().str());
   cols.emplace_back("Buyers of ").append(_market.base().str()).append(" (bids)");
-  VariadicTable<std::string, std::string, std::string> vt(std::move(cols));
+  VariadicTable<string, string, string> vt(std::move(cols));
   for (int op = _orders.size(); op > 0; --op) {
     const int pos = op - 1;
     MonetaryAmount amount(std::abs(_orders[pos].amount), CurrencyCode::kNeutral, _volAndPriNbDecimals.volNbDecimals);
@@ -393,7 +393,7 @@ void MarketOrderBook::print(std::ostream& os) const {
 }
 
 void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName, MonetaryAmount conversionPriceRate) const {
-  cct::FixedCapacityVector<std::string, 4> cols;
+  FixedCapacityVector<string, 4> cols;
   cols.emplace_back("Sellers of ").append(_market.base().str()).append(" (asks)");
   cols.emplace_back(exchangeName)
       .append(" ")
@@ -406,7 +406,7 @@ void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName, Mon
       .append(" price in ")
       .append(conversionPriceRate.currencyCode().str());
   cols.emplace_back("Buyers of ").append(_market.base().str()).append(" (bids)");
-  VariadicTable<std::string, std::string, std::string, std::string> vt(std::move(cols));
+  VariadicTable<string, string, string, string> vt(std::move(cols));
   for (int op = _orders.size(); op > 0; --op) {
     const int pos = op - 1;
     MonetaryAmount amount(std::abs(_orders[pos].amount), CurrencyCode::kNeutral, _volAndPriNbDecimals.volNbDecimals);

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -31,14 +31,14 @@ std::pair<MonetaryAmount::AmountType, int8_t> AmountIntegralFromStr(std::string_
       isNeg = true;
       amountStr.remove_prefix(1);
     } else if (firstChar != '.' && (firstChar < '0' || firstChar > '9')) {
-      throw exception("Parsing error, unexpected first char " + std::string(1, firstChar));
+      throw exception("Parsing error, unexpected first char " + string(1, firstChar));
     }
   }
   std::size_t dotPos = amountStr.find_first_of('.');
   int8_t nbDecimals = 0;
   MonetaryAmount::AmountType roundingUpNinesDouble = 0;
   MonetaryAmount::AmountType decPart = 0, integerPart = 0;
-  if (dotPos != std::string::npos) {
+  if (dotPos != string::npos) {
     while (amountStr.back() == '0') {
       amountStr.remove_suffix(1);
     }
@@ -46,7 +46,7 @@ std::pair<MonetaryAmount::AmountType, int8_t> AmountIntegralFromStr(std::string_
       std::size_t bestFindPos = 0;
       for (std::string_view pattern : {"000", "999"}) {
         std::size_t findPos = amountStr.rfind(pattern);
-        if (findPos != std::string::npos && findPos > dotPos) {
+        if (findPos != string::npos && findPos > dotPos) {
           while (amountStr[findPos - 1] == pattern.front()) {
             --findPos;
           }
@@ -71,7 +71,7 @@ std::pair<MonetaryAmount::AmountType, int8_t> AmountIntegralFromStr(std::string_
       int8_t nbDigitsToRemove =
           static_cast<int8_t>(amountStr.size() - std::numeric_limits<MonetaryAmount::AmountType>::digits10 - 1);
       if (nbDigitsToRemove > nbDecimals) {
-        throw exception("Received amount string " + std::string(amountStr) + " whose integral part is too big");
+        throw exception("Received amount string " + string(amountStr) + " whose integral part is too big");
       }
       log::trace("Received amount string '{}' too big for MonetaryAmount, truncating {} digits", amountStr,
                  nbDigitsToRemove);
@@ -84,7 +84,7 @@ std::pair<MonetaryAmount::AmountType, int8_t> AmountIntegralFromStr(std::string_
     std::from_chars(amountStr.data(), amountStr.data() + amountStr.size(), integerPart);
   }
 
-  MonetaryAmount::AmountType integralAmount = integerPart * cct::ipow(10, nbDecimals) + decPart + roundingUpNinesDouble;
+  MonetaryAmount::AmountType integralAmount = integerPart * ipow(10, nbDecimals) + decPart + roundingUpNinesDouble;
   if (isNeg) {
     integralAmount *= -1;
   }
@@ -399,12 +399,12 @@ MonetaryAmount MonetaryAmount::operator/(MonetaryAmount div) const {
   return ret;
 }
 
-std::string MonetaryAmount::amountStr() const {
+string MonetaryAmount::amountStr() const {
   const int isNeg = static_cast<int>(_amount < 0);
   const int nbDigits = ndigits(_amount);
   const int nbZerosToInsertFront = std::max(0, static_cast<int>(_nbDecimals + 1 - nbDigits));
 
-  std::string ret(static_cast<size_t>(isNeg) + nbDigits, '-');
+  string ret(static_cast<size_t>(isNeg) + nbDigits, '-');
   std::to_chars(ret.data(), ret.data() + ret.size(), _amount);
 
   ret.insert(ret.begin() + isNeg, nbZerosToInsertFront, '0');
@@ -416,8 +416,8 @@ std::string MonetaryAmount::amountStr() const {
   return ret;
 }
 
-std::string MonetaryAmount::str() const {
-  std::string ret = amountStr();
+string MonetaryAmount::str() const {
+  string ret = amountStr();
   if (!_currencyCode.isNeutral()) {
     ret.push_back(' ');
     ret.append(_currencyCode.str());

--- a/src/objects/src/wallet.cpp
+++ b/src/objects/src/wallet.cpp
@@ -14,7 +14,7 @@ bool Wallet::IsAddressPresentInDepositFile(const PrivateExchangeName &privateExc
     log::warn("No deposit addresses found in {} for {}", Wallet::kDepositAddressesFilename, privateExchangeName.name());
     return false;
   }
-  const json &exchangeWallets = data[std::string(privateExchangeName.name())];
+  const json &exchangeWallets = data[string(privateExchangeName.name())];
   bool uniqueKeyName = true;
   for (const auto &[privateExchangeKeyName, wallets] : exchangeWallets.items()) {
     if (privateExchangeName.keyName().empty()) {
@@ -31,13 +31,13 @@ bool Wallet::IsAddressPresentInDepositFile(const PrivateExchangeName &privateExc
     for (const auto &[currencyCodeStr, value] : wallets.items()) {
       CurrencyCode currencyCode(currencyCodeStr);
       if (currencyCode == currency) {
-        std::string addressAndTag = value;
+        string addressAndTag = value;
         std::size_t tagPos = addressAndTag.find_first_of(',');
         std::string_view address(addressAndTag.begin(), addressAndTag.begin() + std::min(tagPos, addressAndTag.size()));
         if (expectedAddress != address) {
           return false;
         }
-        std::string_view tag(tagPos == std::string::npos ? addressAndTag.end() : (addressAndTag.begin() + tagPos + 1),
+        std::string_view tag(tagPos == string::npos ? addressAndTag.end() : (addressAndTag.begin() + tagPos + 1),
                              addressAndTag.end());
         if (expectedTag != tag) {
           return false;
@@ -56,7 +56,7 @@ Wallet::Wallet(const PrivateExchangeName &privateExchangeName, CurrencyCode curr
     : _privateExchangeName(privateExchangeName), _address(address), _tag(tag), _currency(currency) {
 #ifndef CCT_DO_NOT_VALIDATE_DEPOSIT_ADDRESS_IN_FILE
   if (!IsAddressPresentInDepositFile(_privateExchangeName, currency, address, tag)) {
-    throw exception("Incorrect wallet compared to the one stored in " + std::string(Wallet::kDepositAddressesFilename));
+    throw exception("Incorrect wallet compared to the one stored in " + string(Wallet::kDepositAddressesFilename));
   }
 #endif
 }
@@ -66,13 +66,13 @@ Wallet::Wallet(PrivateExchangeName &&privateExchangeName, CurrencyCode currency,
     : _privateExchangeName(std::move(privateExchangeName)), _address(address), _tag(tag), _currency(currency) {
 #ifndef CCT_DO_NOT_VALIDATE_DEPOSIT_ADDRESS_IN_FILE
   if (!IsAddressPresentInDepositFile(_privateExchangeName, currency, address, tag)) {
-    throw exception("Incorrect wallet compared to the one stored in " + std::string(Wallet::kDepositAddressesFilename));
+    throw exception("Incorrect wallet compared to the one stored in " + string(Wallet::kDepositAddressesFilename));
   }
 #endif
 }
 
-std::string Wallet::str() const {
-  std::string ret(_privateExchangeName.str());
+string Wallet::str() const {
+  string ret(_privateExchangeName.str());
   ret.append(" wallet of ");
   ret.append(_currency.str());
   ret.append(", address: [");

--- a/src/objects/test/exchangename_test.cpp
+++ b/src/objects/test/exchangename_test.cpp
@@ -26,7 +26,7 @@ TEST(ExchangeName, ComplexKeyName) {
 
 TEST(ExchangeName, ConstructorWith2Params) {
   EXPECT_EQ(PrivateExchangeName("binance", "_user13").str(), "binance__user13");
-  EXPECT_THROW(PrivateExchangeName("kraken_", "_user13"), cct::exception);
+  EXPECT_THROW(PrivateExchangeName("kraken_", "_user13"), exception);
 }
 
 TEST(ExchangeName, IsKeyNameDefined) {

--- a/src/objects/test/fiatconverter_test.cpp
+++ b/src/objects/test/fiatconverter_test.cpp
@@ -25,7 +25,7 @@ constexpr double kGBP = 0.88;
 
 CurlHandle::CurlHandle(Clock::duration d, settings::RunMode) : _handle(nullptr), _minDurationBetweenQueries(d) {}
 
-std::string CurlHandle::query(std::string_view url, const CurlOptions &) {
+string CurlHandle::query(std::string_view url, const CurlOptions &) {
   json j;
   if (url.find("currencies") != std::string_view::npos) {
     // Currencies
@@ -59,7 +59,7 @@ std::string CurlHandle::query(std::string_view url, const CurlOptions &) {
     }
 
     if (rate != 0) {
-      j["results"][std::string(marketStr)]["val"] = rate;
+      j["results"][string(marketStr)]["val"] = rate;
     }
   }
   return j.dump();

--- a/src/objects/test/marketorderbook_test.cpp
+++ b/src/objects/test/marketorderbook_test.cpp
@@ -48,7 +48,7 @@ TEST_F(MarketOrderBookTestCase1, ComputeCumulAmountBoughtImmediately) {
             MonetaryAmount("5.1809", "ETH"));
   EXPECT_EQ(marketOrderBook.computeCumulAmountBoughtImmediatelyAt(MonetaryAmount("1300.75", "EUR")),
             MonetaryAmount("0", "ETH"));
-  EXPECT_THROW(marketOrderBook.computeCumulAmountBoughtImmediatelyAt(MonetaryAmount("1", "ETH")), cct::exception);
+  EXPECT_THROW(marketOrderBook.computeCumulAmountBoughtImmediatelyAt(MonetaryAmount("1", "ETH")), exception);
 }
 
 TEST_F(MarketOrderBookTestCase1, ComputeCumulAmountSoldImmediately) {
@@ -58,7 +58,7 @@ TEST_F(MarketOrderBookTestCase1, ComputeCumulAmountSoldImmediately) {
             MonetaryAmount("0.89", "ETH"));
   EXPECT_EQ(marketOrderBook.computeCumulAmountSoldImmediatelyAt(MonetaryAmount("1303.5", "EUR")),
             MonetaryAmount("0", "ETH"));
-  EXPECT_THROW(marketOrderBook.computeCumulAmountSoldImmediatelyAt(MonetaryAmount("1", "ETH")), cct::exception);
+  EXPECT_THROW(marketOrderBook.computeCumulAmountSoldImmediatelyAt(MonetaryAmount("1", "ETH")), exception);
 }
 
 TEST_F(MarketOrderBookTestCase1, ComputeMinPriceAtWhichAmountWouldBeBoughtImmediately) {
@@ -202,10 +202,10 @@ TEST(MarketOrderBookExtendedTest, ComputeVolAndPriNbDecimalsFromTickerInfo) {
 TEST(MarketOrderBookExtendedTest, InvalidDepth) {
   EXPECT_THROW(MarketOrderBook(MonetaryAmount("1XLM"), MonetaryAmount("1ADA"), MonetaryAmount("1XLM"),
                                MonetaryAmount("5ADA"), {0, 0}, 0),
-               cct::exception);
+               exception);
   EXPECT_THROW(MarketOrderBook(MonetaryAmount("1XLM"), MonetaryAmount("1ADA"), MonetaryAmount("1XLM"),
                                MonetaryAmount("5ADA"), {0, 0}, -1),
-               cct::exception);
+               exception);
 }
 
 }  // namespace cct

--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -161,7 +161,7 @@ TEST(MonetaryAmountTest, Divide) {
   EXPECT_EQ(MonetaryAmount("-870.5647", CurrencyCode("ETH")) / MonetaryAmount("4709.3467736", CurrencyCode("ETH")),
             MonetaryAmount("-0.18485890758358997"));
   EXPECT_EQ(MonetaryAmount("487.76 EUR") / MonetaryAmount("1300.5 EUR"), MonetaryAmount("0.3750557477893118"));
-  EXPECT_THROW(MonetaryAmount("100") / MonetaryAmount("0.00000000000000001"), cct::exception);
+  EXPECT_THROW(MonetaryAmount("100") / MonetaryAmount("0.00000000000000001"), exception);
   EXPECT_EQ(MonetaryAmount("10") / MonetaryAmount("0.0000000000000001"), MonetaryAmount("100000000000000000"));
 }
 
@@ -170,7 +170,7 @@ TEST(MonetaryAmountTest, Multiply) {
             MonetaryAmount("14.8785", CurrencyCode("ETH")));
   EXPECT_EQ(MonetaryAmount("79871.9000917457") * MonetaryAmount("-34.141590974"),
             MonetaryAmount("-2726953.66542788469"));
-  EXPECT_THROW(MonetaryAmount("1", "EUR") * MonetaryAmount("2", "ETH"), cct::exception);
+  EXPECT_THROW(MonetaryAmount("1", "EUR") * MonetaryAmount("2", "ETH"), exception);
 }
 
 TEST(MonetaryAmountTest, Convert) {

--- a/src/tools/include/cct_allocator.hpp
+++ b/src/tools/include/cct_allocator.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <amc/allocator.hpp>
+
+namespace cct {
+using amc::allocator;
+}

--- a/src/tools/include/cct_codec.hpp
+++ b/src/tools/include/cct_codec.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <string>
+#include <span>
 #include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 
-std::string BinToHex(const unsigned char* in, int size);
+string BinToHex(std::span<const unsigned char> bindata);
 
-std::string B64Encode(std::string_view bindata);
+string B64Encode(std::string_view bindata);
 
-std::string B64Decode(std::string_view ascdata);
+string B64Decode(std::string_view ascdata);
 }  // namespace cct

--- a/src/tools/include/cct_exception.hpp
+++ b/src/tools/include/cct_exception.hpp
@@ -6,19 +6,19 @@
 #include <exception>
 #include <iostream>
 #include <memory>
-#include <string>
 #include <string_view>
 
 #include "cct_log.hpp"
+#include "cct_string.hpp"
 
 namespace cct {
 class exception : public std::exception {
  public:
   static constexpr int kMsgMaxLen = 127;
 
-  static_assert(std::is_nothrow_default_constructible<std::string>::value &&
-                    std::is_nothrow_move_constructible<std::string>::value,
-                "cct::exception cannot be nothrow with a std::string");
+  static_assert(std::is_nothrow_default_constructible<string>::value &&
+                    std::is_nothrow_move_constructible<string>::value,
+                "exception cannot be nothrow with a string");
 
   explicit exception(const char* str) noexcept : _info(str) {
     if (str) {
@@ -31,7 +31,7 @@ class exception : public std::exception {
   }
 
   /// We cannot store a reference of a given string in an exception because of dangling reference problem.
-  /// We neither can store a std::string directly as it could throw by allocating memory, which is not acceptable in an
+  /// We neither can store a string directly as it could throw by allocating memory, which is not acceptable in an
   /// exception's constructor.
   ///
   /// Thus we store the msg in a fixed size char storage.
@@ -44,7 +44,7 @@ class exception : public std::exception {
     copyStrToInlineStorage(str);
   }
 
-  explicit exception(std::string&& str) noexcept : _str(std::move(str)) {
+  explicit exception(string&& str) noexcept : _str(std::move(str)) {
     try {
       log::critical(_str);
     } catch (...) {
@@ -97,6 +97,6 @@ class exception : public std::exception {
 
   const char* _info = nullptr;
   std::array<char, kMsgMaxLen + 1> _storage;
-  std::string _str;
+  string _str;
 };
 }  // namespace cct

--- a/src/tools/include/cct_json.hpp
+++ b/src/tools/include/cct_json.hpp
@@ -1,16 +1,18 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <nlohmann/json.hpp>
-#include <string>
 
+#include "cct_allocator.hpp"
 #include "cct_smallvector.hpp"
+#include "cct_string.hpp"
 #include "cct_vector.hpp"
 
 namespace cct {
 
-using json = nlohmann::basic_json<std::map, cct::vector, std::string, bool, std::int64_t, std::uint64_t, double,
-                                  amc::allocator, nlohmann::adl_serializer, cct::SmallVector<std::uint8_t, 8>>;
+using json = nlohmann::basic_json<std::map, vector, string, bool, int64_t, uint64_t, double, allocator,
+                                  nlohmann::adl_serializer, SmallVector<uint8_t, 8>>;
 
 }  // namespace cct

--- a/src/tools/include/cct_nonce.hpp
+++ b/src/tools/include/cct_nonce.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <string>
+#include "cct_string.hpp"
 
 namespace cct {
 
-using Nonce = std::string;
+using Nonce = string;
 
 /// Create a string representation of a nonce.
 Nonce Nonce_TimeSinceEpoch();

--- a/src/tools/include/cct_string.hpp
+++ b/src/tools/include/cct_string.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+namespace cct {
+using std::string;
+}

--- a/src/tools/include/cct_time_helpers.hpp
+++ b/src/tools/include/cct_time_helpers.hpp
@@ -2,7 +2,8 @@
 
 #include <chrono>
 #include <ctime>
-#include <string>
+
+#include "cct_string.hpp"
 
 namespace cct {
 namespace time {

--- a/src/tools/include/cct_toupperlower.hpp
+++ b/src/tools/include/cct_toupperlower.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <algorithm>
-#include <string>
 #include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 /// constexpr version of std::toupper with chars, as unfortunately for now (May 2021) std::toupper is not constexpr
@@ -77,15 +78,15 @@ constexpr char tolower(char c) noexcept {
   }
 }
 
-inline std::string toupper(std::string_view str) {
-  std::string ret(str);
-  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return cct::toupper(c); });
+inline string toupper(std::string_view str) {
+  string ret(str);
+  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return toupper(c); });
   return ret;
 }
 
-inline std::string tolower(std::string_view str) {
-  std::string ret(str);
-  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return cct::tolower(c); });
+inline string tolower(std::string_view str) {
+  string ret(str);
+  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return tolower(c); });
   return ret;
 }
 }  // namespace cct

--- a/src/tools/include/commandlineoption.hpp
+++ b/src/tools/include/commandlineoption.hpp
@@ -2,8 +2,9 @@
 
 #include <chrono>
 #include <stdexcept>
-#include <string>
 #include <string_view>
+
+#include "cct_string.hpp"
 
 namespace cct {
 using InvalidArgumentException = std::invalid_argument;
@@ -27,20 +28,20 @@ class CommandLineOption {
 
   bool matches(std::string_view optName) const;
 
-  const std::string& optionGroupName() const { return _optionGroupName; }
-  const std::string& fullName() const { return _fullName; }
-  const std::string& description() const { return _description; }
-  const std::string& valueDescription() const { return _valueDescription; }
+  std::string_view optionGroupName() const { return _optionGroupName; }
+  std::string_view fullName() const { return _fullName; }
+  std::string_view description() const { return _description; }
+  std::string_view valueDescription() const { return _valueDescription; }
 
-  std::string shortName() const;
+  string shortName() const;
 
   bool operator<(const CommandLineOption& o) const;
 
  private:
-  std::string _optionGroupName;
-  std::string _fullName;
-  std::string _valueDescription;
-  std::string _description;
+  string _optionGroupName;
+  string _fullName;
+  string _valueDescription;
+  string _description;
   int _prio;
   char _shortName;
 };

--- a/src/tools/include/curlhandle.hpp
+++ b/src/tools/include/curlhandle.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <chrono>
-#include <string>
 #include <string_view>
 #include <utility>
 
 #include "cct_run_modes.hpp"
+#include "cct_string.hpp"
 #include "curloptions.hpp"
 
 namespace cct {
@@ -35,9 +35,9 @@ class CurlHandle {
   CurlHandle(CurlHandle &&o) noexcept;
   CurlHandle &operator=(CurlHandle &&o) noexcept;
 
-  std::string urlEncode(std::string_view url);
+  string urlEncode(std::string_view url);
 
-  std::string query(std::string_view url, const CurlOptions &opts);
+  string query(std::string_view url, const CurlOptions &opts);
 
   Clock::duration minDurationBetweenQueries() const { return _minDurationBetweenQueries; }
 

--- a/src/tools/include/curloptions.hpp
+++ b/src/tools/include/curloptions.hpp
@@ -3,12 +3,12 @@
 #include <charconv>
 #include <initializer_list>
 #include <limits>
-#include <string>
 #include <string_view>
 #include <type_traits>
 #include <variant>
 
 #include "cct_json.hpp"
+#include "cct_string.hpp"
 #include "cct_vector.hpp"
 
 namespace cct {
@@ -17,13 +17,13 @@ class CurlPostData {
  public:
   struct KeyValuePair {
     using IntegralType = int64_t;
-    using value_type = std::variant<std::string, std::string_view, IntegralType>;
+    using value_type = std::variant<string, std::string_view, IntegralType>;
 
     KeyValuePair(std::string_view k, std::string_view v) : key(k), val(v) {}
 
     KeyValuePair(std::string_view k, const char *v) : key(k), val(std::string_view(v)) {}
 
-    KeyValuePair(std::string_view k, std::string v) : key(k), val(std::move(v)) {}
+    KeyValuePair(std::string_view k, string v) : key(k), val(std::move(v)) {}
 
     KeyValuePair(std::string_view k, IntegralType v) : key(k), val(v) {}
 
@@ -31,11 +31,11 @@ class CurlPostData {
     value_type val;
   };
 
-  CurlPostData() noexcept(std::is_nothrow_default_constructible_v<std::string>) = default;
+  CurlPostData() noexcept(std::is_nothrow_default_constructible_v<string>) = default;
 
   CurlPostData(std::initializer_list<KeyValuePair> init);
 
-  explicit CurlPostData(std::string &&rawPostData) noexcept(std::is_nothrow_move_constructible_v<std::string>)
+  explicit CurlPostData(string &&rawPostData) noexcept(std::is_nothrow_move_constructible_v<string>)
       : _postdata(std::move(rawPostData)) {}
 
   /// Append a new URL option from given key value pair.
@@ -65,7 +65,7 @@ class CurlPostData {
   /// Erases given key if present.
   void erase(std::string_view key);
 
-  bool contains(std::string_view key) const { return find(key) != std::string::npos; }
+  bool contains(std::string_view key) const { return find(key) != string::npos; }
 
   /// Get the value associated to given key
   std::string_view get(std::string_view key) const;
@@ -76,9 +76,7 @@ class CurlPostData {
 
   void clear() noexcept { _postdata.clear(); }
 
-  std::string_view toStringView() const { return _postdata; }
-
-  const std::string &toString() const { return _postdata; }
+  std::string_view str() const { return _postdata; }
 
   json toJson() const;
 
@@ -86,7 +84,7 @@ class CurlPostData {
   /// Finds the position of the given key
   std::size_t find(std::string_view key) const;
 
-  std::string _postdata;
+  string _postdata;
 };
 
 class CurlOptions {
@@ -108,7 +106,7 @@ class CurlOptions {
     return _requestType == RequestType::kGet ? "GET" : (_requestType == RequestType::kPost ? "POST" : "DELETE");
   }
 
-  cct::vector<std::string> httpHeaders;
+  vector<string> httpHeaders;
 
   const char *userAgent;
 

--- a/src/tools/src/cct_codec.cpp
+++ b/src/tools/src/cct_codec.cpp
@@ -7,26 +7,28 @@
 
 namespace cct {
 
-std::string BinToHex(const unsigned char* in, int size) {
-  constexpr char kHexits[] = "0123456789abcdef";
-  std::string ret(2 * size, 0);
-  for (int i = 0; i < size; ++i) {
-    ret[i * 2] = kHexits[in[i] >> 4];
-    ret[(i * 2) + 1] = kHexits[in[i] & 0x0F];
+string BinToHex(std::span<const unsigned char> bindata) {
+  static constexpr char kHexits[] = "0123456789abcdef";
+  const int s = bindata.size();
+  string ret(2 * s, 0);
+  ret.reserve(2 * s);
+  for (int i = 0; i < s; ++i) {
+    ret[i * 2] = kHexits[bindata[i] >> 4];
+    ret[(i * 2) + 1] = kHexits[bindata[i] & 0x0F];
   }
   return ret;
 }
 
-std::string B64Encode(std::string_view bindata) {
+string B64Encode(std::string_view bindata) {
   const ::std::size_t binlen = bindata.size();
   // Use = signs so the end is properly padded.
-  std::string retval((((binlen + 2) / 3) * 4), '=');
+  string retval((((binlen + 2) / 3) * 4), '=');
   std::size_t outpos = 0;
   int bits_collected = 0;
   unsigned int accumulator = 0;
   const std::string_view::const_iterator binend = bindata.end();
 
-  constexpr char kB64Table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  static constexpr char kB64Table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
   for (std::string_view::const_iterator i = bindata.begin(); i != binend; ++i) {
     accumulator = (accumulator << 8) | (*i & 0xffu);
@@ -46,8 +48,8 @@ std::string B64Encode(std::string_view bindata) {
   return retval;
 }
 
-std::string B64Decode(std::string_view ascdata) {
-  std::string retval;
+string B64Decode(std::string_view ascdata) {
+  string retval;
   const std::string_view::const_iterator last = ascdata.end();
   int bits_collected = 0;
   unsigned int accumulator = 0;
@@ -65,7 +67,7 @@ std::string B64Decode(std::string_view ascdata) {
       // Skip whitespace and padding. Be liberal in what you accept.
       continue;
     }
-    if ((c > 127) || (c < 0) || (kReverseTable[c] > 63)) {
+    if (c > 127 || c < 0 || kReverseTable[c] > 63) {
       throw ::std::invalid_argument("This contains characters not legal in a base64 encoded string.");
     }
     accumulator = (accumulator << 6) | kReverseTable[c];

--- a/src/tools/src/commandlineoption.cpp
+++ b/src/tools/src/commandlineoption.cpp
@@ -54,8 +54,8 @@ bool CommandLineOption::matches(std::string_view optName) const {
   return optName == _fullName;
 }
 
-std::string CommandLineOption::shortName() const {
-  std::string ret;
+string CommandLineOption::shortName() const {
+  string ret;
   if (_shortName != '\0') {
     ret.push_back('-');
     ret.push_back(_shortName);

--- a/src/tools/src/curlhandle.cpp
+++ b/src/tools/src/curlhandle.cpp
@@ -19,7 +19,7 @@ namespace cct {
 namespace {
 
 size_t CurlWriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
-  reinterpret_cast<std::string *>(userp)->append(static_cast<const char *>(contents), size * nmemb);
+  reinterpret_cast<string *>(userp)->append(static_cast<const char *>(contents), size * nmemb);
   return size * nmemb;
 }
 }  // namespace
@@ -80,19 +80,19 @@ void CurlHandle::setUpProxy(const CurlOptions::ProxySettings &proxy) {
   }
 }
 
-std::string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
+string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
   checkHandleOrInit();
   CURL *curl = reinterpret_cast<CURL *>(_handle);
 
   // General option settings.
   const char *optsStr = opts.postdata.c_str();
 
-  std::string modifiedURL(url);
-  std::string jsonBuf;  // Declared here as its scope should be valid until the actual curl call
+  string modifiedURL(url);
+  string jsonBuf;  // Declared here as its scope should be valid until the actual curl call
   if (opts.requestType() != CurlOptions::RequestType::kPost && !opts.postdata.empty()) {
     // Add parameters as query string after the URL
     modifiedURL.push_back('?');
-    modifiedURL.append(opts.postdata.toStringView());
+    modifiedURL.append(opts.postdata.str());
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
   } else {
     if (opts.postdataInJsonFormat && !opts.postdata.empty()) {
@@ -127,7 +127,7 @@ std::string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
 
   curl_easy_setopt(curl, CURLOPT_VERBOSE, opts.verbose ? 1L : 0L);
   curl_slist *curlListPtr = nullptr, *oldCurlListPtr = nullptr;
-  for (const std::string &header : opts.httpHeaders) {
+  for (const string &header : opts.httpHeaders) {
     curlListPtr = curl_slist_append(curlListPtr, header.c_str());
     if (!curlListPtr) {
       if (oldCurlListPtr) {
@@ -142,7 +142,7 @@ std::string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
   CurlListUniquePtr curlListUniquePtr(curlListPtr);
 
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curlListPtr);
-  std::string out;
+  string out;
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &out);
 
   setUpProxy(opts.proxy);
@@ -181,9 +181,9 @@ std::string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
   return out;
 }
 
-std::string CurlHandle::urlEncode(std::string_view url) {
+string CurlHandle::urlEncode(std::string_view url) {
   CURL *curl = reinterpret_cast<CURL *>(_handle);
-  std::string ret(url);
+  string ret(url);
 
   using CurlStringUniquePtr = std::unique_ptr<char, decltype([](char *ptr) { curl_free(ptr); })>;
 

--- a/src/tools/src/curloptions.cpp
+++ b/src/tools/src/curloptions.cpp
@@ -10,7 +10,7 @@ namespace cct {
 CurlPostData::CurlPostData(std::initializer_list<KeyValuePair> init) {
   for (const KeyValuePair& kv : init) {
     if (kv.val.index() == 0) {
-      append(kv.key, std::get<std::string>(kv.val));
+      append(kv.key, std::get<string>(kv.val));
     } else if (kv.val.index() == 1) {
       append(kv.key, std::get<std::string_view>(kv.val));
     } else {
@@ -47,12 +47,12 @@ std::size_t CurlPostData::find(std::string_view key) const {
   const std::size_t ks = key.size();
   const std::size_t ps = _postdata.size();
   std::size_t pos = _postdata.find(key);
-  while (pos != std::string::npos && pos + ks < ps && _postdata[pos + ks] != '=') {
+  while (pos != string::npos && pos + ks < ps && _postdata[pos + ks] != '=') {
     pos = _postdata.find(key, pos + ks + 1);
   }
-  if (pos != std::string::npos && (pos + ks == ps || _postdata[pos + ks] == '&')) {
+  if (pos != string::npos && (pos + ks == ps || _postdata[pos + ks] == '&')) {
     // we found a value, not a key
-    pos = std::string::npos;
+    pos = string::npos;
   }
   return pos;
 }
@@ -62,7 +62,7 @@ void CurlPostData::set(std::string_view key, std::string_view value) {
          value.find('&') == std::string_view::npos && key.find('=') == std::string_view::npos &&
          value.find('=') == std::string_view::npos);
   std::size_t pos = find(key);
-  if (pos == std::string::npos) {
+  if (pos == string::npos) {
     append(key, value);
   } else {
     pos += key.size() + 1;
@@ -77,7 +77,7 @@ void CurlPostData::set(std::string_view key, std::string_view value) {
 
 void CurlPostData::erase(std::string_view key) {
   std::size_t first = find(key);
-  if (first != std::string::npos) {
+  if (first != string::npos) {
     if (first != 0) {
       --first;
     }
@@ -92,15 +92,15 @@ void CurlPostData::erase(std::string_view key) {
 
 std::string_view CurlPostData::get(std::string_view key) const {
   std::size_t pos = find(key);
-  std::string::const_iterator first;
-  std::string::const_iterator last;
-  if (pos == std::string::npos) {
+  string::const_iterator first;
+  string::const_iterator last;
+  if (pos == string::npos) {
     first = _postdata.end();
     last = _postdata.end();
   } else {
     first = _postdata.begin() + pos + key.size() + 1;
     std::size_t endPos = _postdata.find_first_of('&', pos + key.size() + 1);
-    if (endPos == std::string::npos) {
+    if (endPos == string::npos) {
       last = _postdata.end();
     } else {
       last = _postdata.begin() + endPos;
@@ -113,15 +113,15 @@ json CurlPostData::toJson() const {
   json ret;
   for (std::size_t sep = _postdata.find('&'), oldSep = 0;; sep = _postdata.find('&', oldSep)) {
     std::string_view keyValuePair(_postdata.begin() + oldSep,
-                                  sep == std::string::npos ? _postdata.end() : _postdata.begin() + sep);
+                                  sep == string::npos ? _postdata.end() : _postdata.begin() + sep);
     if (keyValuePair.empty()) {
       break;
     }
     std::size_t equalPos = keyValuePair.find('=');
-    std::string key(keyValuePair.begin(), keyValuePair.begin() + equalPos);
-    std::string val(keyValuePair.begin() + equalPos + 1, keyValuePair.end());
+    string key(keyValuePair.begin(), keyValuePair.begin() + equalPos);
+    string val(keyValuePair.begin() + equalPos + 1, keyValuePair.end());
     ret[key] = std::move(val);
-    if (sep == std::string::npos) {
+    if (sep == string::npos) {
       break;
     }
     oldSep = sep + 1;

--- a/src/tools/src/jsonhelpers.cpp
+++ b/src/tools/src/jsonhelpers.cpp
@@ -3,15 +3,15 @@
 #include <filesystem>
 #include <fstream>
 #include <streambuf>
-#include <string>
 
 #include "cct_const.hpp"
 #include "cct_exception.hpp"
+#include "cct_string.hpp"
 
 namespace cct {
 namespace {
-std::string FullFileName(std::string_view fileName, FileType fileType) {
-  std::string fullFilePath(fileType == FileType::kData ? kDataPath : kConfigPath);
+string FullFileName(std::string_view fileName, FileType fileType) {
+  string fullFilePath(fileType == FileType::kData ? kDataPath : kConfigPath);
   fullFilePath.push_back('/');
   fullFilePath.append(fileName);
   return fullFilePath;
@@ -24,20 +24,20 @@ std::string FullFileName(std::string_view fileName, FileType fileType) {
 ///                         kNoThrow: file may not be present, in this case an empty json will be returned
 json OpenJsonFile(std::string_view fileName, FileNotFoundMode fileNotFoundMode, FileType fileType) {
   json ret;
-  std::string filePath = FullFileName(fileName, fileType);
+  string filePath = FullFileName(fileName, fileType);
   if (fileNotFoundMode == FileNotFoundMode::kThrow || std::filesystem::exists(filePath)) {
     std::ifstream file(filePath);
     if (!file) {
       throw exception("Unable to open " + filePath + " for reading");
     }
-    ret = json::parse(std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>()));
+    ret = json::parse(string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>()));
   }
   return ret;
 }
 
 /// Writes json into file
 void WriteJsonFile(std::string_view fileName, const json &data, FileType fileType) {
-  std::string filePath = FullFileName(fileName, fileType);
+  string filePath = FullFileName(fileName, fileType);
   std::ofstream file(filePath);
   if (!file) {
     throw exception("Unable to open " + filePath + " for writing");

--- a/src/tools/test/cct_exception_test.cpp
+++ b/src/tools/test/cct_exception_test.cpp
@@ -24,7 +24,7 @@ TEST(CctExceptionTest, InfoTakenFromConstCharStar) {
 }
 
 TEST(CctExceptionTest, InlineStorage) {
-  std::string shortStrStdString(kShortStr);
+  string shortStrStdString(kShortStr);
   exception ex(shortStrStdString);
   EXPECT_EQ(ex.what(), shortStrStdString);
 
@@ -33,25 +33,25 @@ TEST(CctExceptionTest, InlineStorage) {
   ex = exception(shortStrStdString);
   EXPECT_EQ(ex.what(), shortStrStdString);
 
-  std::string longStrStdString(kVeryLongStr);
+  string longStrStdString(kVeryLongStr);
   ex = exception(longStrStdString);
   EXPECT_LT(strlen(ex.what()), longStrStdString.length());
-  EXPECT_EQ(ex.what(), std::string(longStrStdString.begin(), longStrStdString.begin() + exception::kMsgMaxLen));
+  EXPECT_EQ(ex.what(), string(longStrStdString.begin(), longStrStdString.begin() + exception::kMsgMaxLen));
 
-  std::string longStrStdStringCopy = longStrStdString;
+  string longStrStdStringCopy = longStrStdString;
   ex = exception(std::move(longStrStdString));
   EXPECT_EQ(ex.what(), longStrStdStringCopy);
 }
 
 TEST(CctExceptionTest, MoveStringConstructor) {
-  std::string str;
+  string str;
   exception ex(std::move(str));
   EXPECT_STREQ(ex.what(), "");
 }
 
 TEST(CctExceptionTest, RuleOfFive) {
-  std::string longStr(kVeryLongStr);
-  std::string shortStr(kShortStr);
+  string longStr(kVeryLongStr);
+  string shortStr(kShortStr);
   exception exWithLongStr(std::move(longStr));
   exception exWithShortStr(std::move(shortStr));
 
@@ -59,7 +59,7 @@ TEST(CctExceptionTest, RuleOfFive) {
   EXPECT_STREQ(exWithShortStr.what(), kShortStr);
   exWithShortStr = exWithLongStr;
   EXPECT_STRNE(exWithShortStr.what(), kVeryLongStr);
-  EXPECT_EQ(std::string(exWithShortStr.what()), std::string(kVeryLongStr).substr(0, exception::kMsgMaxLen));
+  EXPECT_EQ(string(exWithShortStr.what()), string(kVeryLongStr).substr(0, exception::kMsgMaxLen));
   exWithShortStr = std::move(exWithLongStr);
   EXPECT_STREQ(exWithShortStr.what(), kVeryLongStr);
 }

--- a/src/tools/test/commandlineoptionsparser_test.cpp
+++ b/src/tools/test/commandlineoptionsparser_test.cpp
@@ -13,11 +13,11 @@ class CommandLineOptionsParserTest : public ::testing::Test {
   using Duration = Clock::duration;
 
   struct Opts {
-    std::string stringOpt{};
+    string stringOpt{};
     int intOpt{};
     int int2Opt{};
     bool boolOpt{};
-    std::optional<std::string> optStr{};
+    std::optional<string> optStr{};
     Duration timeOpt;
   };
 
@@ -32,7 +32,7 @@ class CommandLineOptionsParserTest : public ::testing::Test {
                  {{{"General", 1}, "--help", 'h', "", "Help descr"}, &Opts::boolOpt}}) {}
 
   Opts createOptions(std::initializer_list<const char *> init) {
-    cct::vector<const char *> opts = init;
+    vector<const char *> opts = init;
     return _parser.parse(opts);
   }
 
@@ -66,11 +66,11 @@ TEST_F(CommandLineOptionsParserTest, OptStringNotEmpty) {
 }
 
 TEST_F(CommandLineOptionsParserTest, OptStringEmpty1) {
-  EXPECT_EQ(*createOptions({"coincenter", "--opt4", "--opt1", "Opt1 value"}).optStr, std::string());
+  EXPECT_EQ(*createOptions({"coincenter", "--opt4", "--opt1", "Opt1 value"}).optStr, string());
 }
 
 TEST_F(CommandLineOptionsParserTest, OptStringEmpty2) {
-  EXPECT_EQ(*createOptions({"coincenter", "--opt4"}).optStr, std::string());
+  EXPECT_EQ(*createOptions({"coincenter", "--opt4"}).optStr, string());
 }
 
 TEST_F(CommandLineOptionsParserTest, OptStringEmpty3) {

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -25,7 +25,7 @@ class CurlSetup : public ::testing::Test {
 };
 
 TEST_F(CurlSetup, BasicCurlTest) {
-  std::string out = handle.query(kTestUrl, CurlOptions(CurlOptions::RequestType::kGet));
+  string out = handle.query(kTestUrl, CurlOptions(CurlOptions::RequestType::kGet));
   EXPECT_EQ(out, "POOL_UP");
 }
 
@@ -36,8 +36,8 @@ TEST_F(CurlSetup, QueryKrakenTime) {
 #endif
   opts.httpHeaders.push_back("MyHeaderIsVeryLongToAvoidSSO");
 
-  std::string s = handle.query("https://api.kraken.com/0/public/Time", opts);
-  EXPECT_TRUE(s.find("unixtime") != std::string::npos);
+  string s = handle.query("https://api.kraken.com/0/public/Time", opts);
+  EXPECT_TRUE(s.find("unixtime") != string::npos);
 }
 
 TEST_F(CurlSetup, QueryKrakenSystemStatus) {
@@ -46,9 +46,9 @@ TEST_F(CurlSetup, QueryKrakenSystemStatus) {
   opts.verbose = true;
 #endif
   log::set_level(log::level::trace);
-  std::string s = handle.query("https://api.kraken.com/0/public/SystemStatus", opts);
-  EXPECT_TRUE(s.find("online") != std::string::npos || s.find("maintenance") != std::string::npos ||
-              s.find("cancel_only") != std::string::npos || s.find("post_only") != std::string::npos);
+  string s = handle.query("https://api.kraken.com/0/public/SystemStatus", opts);
+  EXPECT_TRUE(s.find("online") != string::npos || s.find("maintenance") != string::npos ||
+              s.find("cancel_only") != string::npos || s.find("post_only") != string::npos);
 }
 
 TEST_F(CurlSetup, ProxyMockTest) {
@@ -58,7 +58,7 @@ TEST_F(CurlSetup, ProxyMockTest) {
 #ifdef DEBUG
     opts.verbose = true;
 #endif
-    std::string out = handle.query(kTestUrl, opts);
+    string out = handle.query(kTestUrl, opts);
     EXPECT_EQ(out, "POOL_LEFT");
   }
 }

--- a/src/tools/test/curloptions_test.cpp
+++ b/src/tools/test/curloptions_test.cpp
@@ -39,16 +39,16 @@ TEST(CurlOptionsTest, SetAndAppend) {
   EXPECT_STREQ(curlPostData.c_str(), "abc=777&de=aX&def=titi&777=yoplalepiege&d=encoreplustricky");
   curlPostData.set("d", "cestboncestfini");
   EXPECT_STREQ(curlPostData.c_str(), "abc=777&de=aX&def=titi&777=yoplalepiege&d=cestboncestfini");
-  EXPECT_THROW(curlPostData.append("777", "cestinterditca"), cct::exception);
+  EXPECT_THROW(curlPostData.append("777", "cestinterditca"), exception);
 }
 
 TEST(CurlOptionsTest, Erase) {
   CurlPostData curlPostData{{"abc", "354"}, {"tata", "abc"}, {"rm", "xX"}, {"huhu", "haha"}};
   curlPostData.erase("rm");
   const std::string_view expected = "abc=354&tata=abc&huhu=haha";
-  EXPECT_EQ(curlPostData.toStringView(), expected);
+  EXPECT_EQ(curlPostData.str(), expected);
   curlPostData.erase("haha");
-  EXPECT_EQ(curlPostData.toStringView(), expected);
+  EXPECT_EQ(curlPostData.str(), expected);
 }
 
 TEST(CurlOptionsTest, EmptyConvertToJson) {
@@ -95,7 +95,7 @@ TEST_F(CurlOptionsCase1, SetIntegralValues) {
   EXPECT_EQ(curlPostData.get("price1"), "42");
   curlPostData.set("777", -666);
   EXPECT_EQ(curlPostData.get("777"), "-666");
-  EXPECT_EQ(curlPostData.toStringView(), "units=0.11176&price=357.78&777=-666&hola=quetal&price1=42");
+  EXPECT_EQ(curlPostData.str(), "units=0.11176&price=357.78&777=-666&hola=quetal&price1=42");
   int8_t s = -116;
   curlPostData.set("testu", s);
   EXPECT_EQ(curlPostData.get("testu"), "-116");


### PR DESCRIPTION
The idea is to ease potential change of `std::string` implementation in one line of code.
Remove as well the unnecessary `cct::` of the library.

Spread usage of `std::string_view` to avoid unnecessary copies of `string`