### PR TITLE
Use ninja in CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,21 +56,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libssl-dev libcurl4-gnutls-dev ${{matrix.compiler}}
+          sudo apt install libssl-dev libcurl4-gnutls-dev ninja-build ${{matrix.compiler}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+        run: cmake -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -GNinja ..
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        shell: bash
-        run: cmake --build . --config ${{matrix.buildmode}} -j 2
+        run: ninja
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,14 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Prerequisites
+        run: brew install ninja
+
       - name: cmake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-11 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-11 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -GNinja
 
       - name: build
-        run: cmake --build build --parallel 2
+        working-directory: ${{github.workspace}}/build
+        run: ninja
 
       - name: Local Tests
-        run: ctest --test-dir build --output-on-failure --exclude-regex api_test
+        working-directory: ${{github.workspace}}/build
+        run: ctest --output-on-failure --exclude-regex api_test
 
       - name: Public API Tests # Tries several times to avoid random timeout errors not coming from coincenter
-        run: ctest --test-dir build --output-on-failure --tests-regex api_test --repeat until-pass:10
+        working-directory: ${{github.workspace}}/build
+        run: ctest --output-on-failure --tests-regex api_test --repeat until-pass:10

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,12 +20,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install libssl-dev libcurl4-gnutls-dev
+          sudo apt install libssl-dev libcurl4-gnutls-dev ninja-build
 
       - name: Install compiler
         run: |
-          sudo apt-get install ${{matrix.compiler}}
+          sudo apt install ${{matrix.compiler}}
         if: matrix.compiler == 'g++-10' || matrix.compiler == 'g++-11'
 
       - name: Install compiler
@@ -41,12 +40,12 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -GNinja
 
       - name: Build
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake --build . --config ${{matrix.buildmode}} -j 2
+        run: ninja
 
       - name: Local Tests
         working-directory: ${{github.workspace}}/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine AS base-env
 
 # Install base dependencies (especially run ones)
-RUN apk update && apk upgrade && apk add g++ libc-dev curl-dev
+RUN apk add g++ libc-dev curl-dev
 
 # Set default directory for application
 WORKDIR /app
@@ -11,7 +11,7 @@ WORKDIR /app
 FROM base-env as build
 
 # Install build tools
-RUN apk update && apk upgrade && apk add cmake ninja git linux-headers
+RUN apk add cmake ninja git linux-headers
 
 # Copy all files, excluding the ones in '.dockerignore' (WARNING: secrets should never be shipped in a Docker image!)
 COPY . .
@@ -21,17 +21,17 @@ WORKDIR /app/bin
 
 # Declare and set default values of following arguments
 ARG BUILD_MODE=Release
-ARG TEST=0
-ARG ASAN=0
+ARG BUILD_TEST=0
+ARG BUILD_ASAN=0
 
 # Create ninja file
-RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_MODE} -DCCT_ENABLE_TESTS=${TEST} -DCCT_ENABLE_ASAN=${ASAN} -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=${BUILD_MODE} -DCCT_ENABLE_TESTS=${BUILD_TEST} -DCCT_ENABLE_ASAN=${BUILD_ASAN} -GNinja ..
 
 # Compile
 RUN ninja
 
 # Launch tests if requested
-RUN if [ "$TEST" = "1" -o "$TEST" = "ON" ]; then ctest -j 2 --output-on-failure; else echo "No tests"; fi
+RUN if [ "$BUILD_TEST" = "1" -o "$BUILD_TEST" = "ON" ]; then ctest -j 2 --output-on-failure; else echo "No tests"; fi
 
 # Multi stage build to separate docker build image from executable (to make the latter smaller)
 FROM base-env

--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ CMake build mode
 `BUILD_MODE` (default: Release)
 
 Compile and launch tests
-`TEST` (default: 0)
+`BUILD_TEST` (default: 0)
 
 Activate Address Sanitizer
-`ASAN` (default: 0)
+`BUILD_ASAN` (default: 0)
 
 #### Build
 


### PR DESCRIPTION
The main benefit of this migration is to get rid of the `-j 2` parameter of the standard build generator. 