### PR TITLE
Use folly::fbstring as cct::string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.15)
 
-project(coincenter VERSION 3.3.0
+project(coincenter VERSION 3.4.0
                    DESCRIPTION "A C++ library centralizing several crypto currencies exchanges REST API into a single all in one tool with a unified interface"
                    LANGUAGES CXX)
 
@@ -88,7 +88,7 @@ if (CCT_BUILD_PROMETHEUS_FROM_SRC)
   FetchContent_Declare(
     prometheus-cpp
     GIT_REPOSITORY https://github.com/jupp0r/prometheus-cpp.git
-    GIT_TAG        v0.13.0
+    GIT_TAG        v1.0.0
   )
 
   FetchContent_MakeAvailable(prometheus-cpp)

--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -28,8 +28,12 @@ string Query(CurlHandle& curlHandle, std::string_view method, CurlPostData&& pos
 }
 
 const json& CollectResults(const json& dataJson) {
-  if (dataJson.contains("error") && !dataJson["error"].empty()) {
-    throw exception("Cryptowatch::query error: " + string(dataJson["error"].front()));
+  auto errIt = dataJson.find("error");
+  if (errIt != dataJson.end() && !errIt->empty()) {
+    std::string_view errMsg = errIt->front().get<std::string_view>();
+    string ex("Cryptowatch::query error: ");
+    ex.append(errMsg);
+    throw exception(std::move(ex));
   }
   return dataJson["result"];
 }

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -173,7 +173,17 @@ Market ExchangePublic::retrieveMarket(CurrencyCode c1, CurrencyCode c2) {
   if (!markets.contains(m)) {
     m = m.reverse();
     if (!markets.contains(m)) {
-      throw exception("Cannot trade " + string(c1.str()) + " into " + string(c2.str()) + " on " + _name);
+      string ex("Cannot find ");
+      ex.append(c1.str())
+          .append("-")
+          .append(c2.str())
+          .append(" nor ")
+          .append(c2.str())
+          .append("-")
+          .append(c1.str())
+          .append(" markets on ")
+          .append(_name);
+      throw exception(std::move(ex));
     }
   }
   return m;

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -57,8 +57,11 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
       }
       statusCode = dataJson["code"];
     }
-    const std::string_view errorMessage = dataJson["msg"].get<std::string_view>();
-    throw exception("error " + std::to_string(statusCode) + ", msg: " + string(errorMessage));
+    string ex("Error: ");
+    ex.append(MonetaryAmount(statusCode).amountStr());
+    ex.append(", msg: ");
+    ex.append(dataJson["msg"].get<std::string_view>());
+    throw exception(std::move(ex));
   }
   return dataJson;
 }

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -104,7 +104,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, std::string_view
               std::size_t idxFirst = nbDecimalsMaxPos + strlen(kMagicKoreanString1);
               auto first = msg.begin() + idxFirst;
               std::string_view maxNbDecimalsStr(first, msg.begin() + msg.find(kMagicKoreanString2, idxFirst));
-              CurrencyCode currencyCode(std::string_view(msg.begin(), msg.begin() + msg.find_first_of(' ')));
+              CurrencyCode currencyCode(std::string_view(msg.begin(), msg.begin() + msg.find(' ')));
               // I did not find the way via the API to get the maximum precision of Bithumb assets,
               // so I get them this way, by parsing the Korean error message of the response
               log::warn("Bithumb told us that maximum precision of {} is {} decimals", currencyCode.str(),
@@ -139,7 +139,9 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, std::string_view
           }
         }
       }
-      throw exception(string("Bithumb::query error: ").append(statusCode).append(" \"").append(msg).append("\""));
+      string ex("Bithumb::query error: ");
+      ex.append(statusCode).append(" \"").append(msg).append("\"");
+      throw exception(std::move(ex));
     }
   }
   return methodName.starts_with("trade") ? dataJson : dataJson["data"];
@@ -196,13 +198,12 @@ Wallet BithumbPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) 
   // {"currency": "QTUM","wallet_address": "QMFxxxXXXXxxxxXXXXXxxxx"}
   // {"currency":"EOS","wallet_address":"bithumbrecv1&memo=123456789"}
   std::string_view addressAndTag = result["wallet_address"].get<std::string_view>();
-  std::size_t tagPos = addressAndTag.find_first_of('&');
+  std::size_t tagPos = addressAndTag.find('&');
   std::string_view address(addressAndTag.begin(), addressAndTag.begin() + std::min(tagPos, addressAndTag.size()));
   std::string_view tag(
       tagPos != std::string_view::npos
           ? (addressAndTag.begin() +
-             std::min(addressAndTag.find_first_of('=', std::min(tagPos + 1, addressAndTag.size())) + 1U,
-                      addressAndTag.size()))
+             std::min(addressAndTag.find('=', std::min(tagPos + 1, addressAndTag.size())) + 1U, addressAndTag.size()))
           : addressAndTag.end(),
       addressAndTag.end());
 

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -55,7 +55,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, CurlOptions::Req
   json dataJson = json::parse(curlHandle.query(url, opts));
   auto errCodeIt = dataJson.find("code");
   if (errCodeIt != dataJson.end() && errCodeIt->get<std::string_view>() != "200000") {
-    std::string errStr("Kucoin error ");
+    string errStr("Kucoin error ");
     errStr.append(errCodeIt->get<std::string_view>());
     auto msgIt = dataJson.find("msg");
     if (msgIt != dataJson.end()) {
@@ -219,7 +219,7 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
   }
   json result =
       PrivateQuery(_curlHandle, _apiKey, CurlOptions::RequestType::kPost, "/api/v1/orders", std::move(placePostData));
-  placeOrderInfo.orderId = result["orderId"].get<std::string_view>();
+  placeOrderInfo.orderId = string(result["orderId"].get<std::string_view>());
   return placeOrderInfo;
 }
 

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -27,7 +27,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurlPostData
   if (dataJson.contains("error")) {
     const long statusCode = dataJson["name"].get<long>();
     std::string_view msg = dataJson["message"].get<std::string_view>();
-    throw exception("error: " + std::to_string(statusCode) + " \"" + string(msg) + "\"");
+    throw exception("error: " + MonetaryAmount(statusCode).amountStr() + " \"" + string(msg) + "\"");
   }
   return dataJson;
 }
@@ -141,7 +141,7 @@ ExchangePublic::MarketOrderBookMap ParseOrderBooks(const json& result, int depth
   ExchangePublic::MarketOrderBookMap ret;
   for (const json& marketDetails : result) {
     std::string_view marketStr = marketDetails["market"].get<std::string_view>();
-    std::size_t dashPos = marketStr.find_first_of('-');
+    std::size_t dashPos = marketStr.find('-');
     if (dashPos == std::string_view::npos) {
       log::error("Unable to parse order book json for market {}", marketStr);
       continue;

--- a/src/api/interface/include/exchangeretrieverbase.hpp
+++ b/src/api/interface/include/exchangeretrieverbase.hpp
@@ -37,14 +37,17 @@ class ExchangeRetrieverBase {
       if (privateExchangeName.name() == exchange.name() &&
           (!privateExchangeName.isKeyNameDefined() || exchange.keyName() == privateExchangeName.keyName())) {
         if (pExchange) {
-          throw exception("Several private exchanges found for " + string(privateExchangeName.str()) +
-                          " - remove ambiguity by specifying key name");
+          string ex("Several private exchanges found for ");
+          ex.append(privateExchangeName.str()).append(" - remove ambiguity by specifying key name");
+          throw exception(std::move(ex));
         }
         pExchange = std::addressof(exchange);
       }
     }
     if (!pExchange) {
-      throw exception("Cannot find exchange " + string(privateExchangeName.str()));
+      string ex("Cannot find exchange ");
+      ex.append(privateExchangeName.str());
+      throw exception(std::move(ex));
     }
     return *pExchange;
   }

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 #include "commandlineoptionsparser.hpp"
 #include "currencycode.hpp"
 #include "exchangename.hpp"
@@ -35,6 +36,8 @@ class StringOptionParser {
   MonetaryAmountFromToPrivateExchange getMonetaryAmountFromToPrivateExchange() const;
 
   CurrencyCodePublicExchanges getCurrencyCodePublicExchanges() const;
+
+  using trivially_relocatable = is_trivially_relocatable<string>::type;
 
  protected:
   std::size_t getNextCommaPos(std::size_t startPos = 0, bool throwIfNone = true) const;

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -64,7 +64,9 @@ Coincenter::Coincenter(const PublicExchangeNames &exchangesWithoutSecrets, bool 
     } else if (exchangeName == "upbit") {
       exchangePublic = std::addressof(_upbitPublic);
     } else {
-      throw exception("Should not happen, unsupported platform " + string(exchangeName));
+      string ex("Should not happen, unsupported platform ");
+      ex.append(exchangeName);
+      throw exception(std::move(ex));
     }
 
     const bool canUsePrivateExchange = _apiKeyProvider.contains(exchangeName);
@@ -85,9 +87,9 @@ Coincenter::Coincenter(const PublicExchangeNames &exchangesWithoutSecrets, bool 
         } else if (exchangeName == "upbit") {
           exchangePrivate = std::addressof(_upbitPrivates.emplace_front(_coincenterInfo, _upbitPublic, apiKey));
         } else {
-          std::string err("Should not happen, unsupported platform ");
-          err.append(exchangeName);
-          throw exception(std::move(err));
+          string ex("Should not happen, unsupported platform ");
+          ex.append(exchangeName);
+          throw exception(std::move(ex));
         }
 
         _exchanges.emplace_back(_coincenterInfo.exchangeInfo(exchangePublic->name()), *exchangePublic,

--- a/src/engine/src/coincenteroptions.cpp
+++ b/src/engine/src/coincenteroptions.cpp
@@ -25,7 +25,7 @@ void CoincenterCmdLineOptions::setLogLevel() const {
       break;
     }
     default:
-      log::set_level(log::level::from_str(logLevel));
+      log::set_level(log::level::from_str(std::string(logLevel)));
       break;
   }
 }

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -8,8 +8,7 @@ PublicExchangeNames GetExchanges(std::string_view str) {
   PublicExchangeNames exchanges;
   if (!str.empty()) {
     std::size_t first, last;
-    for (first = 0, last = str.find_first_of(','); last != std::string_view::npos;
-         last = str.find_first_of(',', last + 1)) {
+    for (first = 0, last = str.find(','); last != std::string_view::npos; last = str.find(',', last + 1)) {
       exchanges.emplace_back(str.begin() + first, str.begin() + last);
       first = last + 1;
     }
@@ -33,7 +32,7 @@ PrivateExchangeNames StringOptionParser::getPrivateExchanges() const {
 StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() const {
   std::size_t commaPos = getNextCommaPos(0, false);
   std::string_view marketStr(_opt.begin(), commaPos == string::npos ? _opt.end() : _opt.begin() + commaPos);
-  std::size_t dashPos = marketStr.find_first_of('-');
+  std::size_t dashPos = marketStr.find('-');
   if (dashPos == std::string_view::npos) {
     throw std::invalid_argument("Expected a dash");
   }
@@ -54,7 +53,7 @@ StringOptionParser::MonetaryAmountExchanges StringOptionParser::getMonetaryAmoun
 
 StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange
 StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchange() const {
-  std::size_t dashPos = _opt.find_first_of('-');
+  std::size_t dashPos = _opt.find('-');
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
@@ -72,7 +71,7 @@ StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getM
   std::size_t commaPos = getNextCommaPos();
   MonetaryAmount amountToWithdraw(std::string_view(_opt.begin(), _opt.begin() + commaPos));
   std::string_view exchangeNames(_opt.begin() + commaPos + 1, _opt.end());
-  std::size_t dashPos = exchangeNames.find_first_of('-');
+  std::size_t dashPos = exchangeNames.find('-');
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
@@ -82,7 +81,7 @@ StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getM
 }
 
 std::size_t StringOptionParser::getNextCommaPos(std::size_t startPos, bool throwIfNone) const {
-  std::size_t commaPos = _opt.find_first_of(',', startPos);
+  std::size_t commaPos = _opt.find(',', startPos);
   if (commaPos == string::npos && throwIfNone) {
     throw std::invalid_argument("Expected a comma");
   }

--- a/src/monitoring/include/abstractmetricgateway.hpp
+++ b/src/monitoring/include/abstractmetricgateway.hpp
@@ -25,6 +25,6 @@ class AbstractMetricGateway {
  protected:
   explicit AbstractMetricGateway(const MonitoringInfo& monitoringInfo) : _monitoringInfo(monitoringInfo) {}
 
-  MonitoringInfo _monitoringInfo;
+  const MonitoringInfo& _monitoringInfo;
 };
 }  // namespace cct

--- a/src/monitoring/include/metric.hpp
+++ b/src/monitoring/include/metric.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <cstdint>
 
+#include "cct_type_traits.hpp"
 #include "cct_vector.hpp"
 #include "flatkeyvaluestring.hpp"
 
@@ -29,7 +30,10 @@ struct MetricSummaryInfo {
     double quantile;
     double error;
   };
+
   using Quantiles = vector<Quantile>;
+
+  using trivially_relocatable = is_trivially_relocatable<Quantiles>::type;
 
   Quantiles quantiles;
   std::chrono::milliseconds max_age = std::chrono::seconds{60};

--- a/src/monitoring/include/monitoringinfo.hpp
+++ b/src/monitoring/include/monitoringinfo.hpp
@@ -3,6 +3,7 @@
 #include <string_view>
 
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 
 namespace cct {
 
@@ -23,6 +24,8 @@ class MonitoringInfo {
   uint16_t port() const { return _port; }
 
   bool useMonitoring() const { return _port != 0; }
+
+  using trivially_relocatable = is_trivially_relocatable<string>::type;
 
  private:
   string _jobName;

--- a/src/monitoring/src/prometheusmetricgateway.cpp
+++ b/src/monitoring/src/prometheusmetricgateway.cpp
@@ -6,6 +6,7 @@
 #include <prometheus/summary.h>
 
 #include <cassert>
+#include <string>
 
 #include "cct_exception.hpp"
 #include "cct_log.hpp"
@@ -26,7 +27,7 @@ constexpr int kHTTPSuccessReturnCode = 200;
 constexpr Clock::duration kPrometheusAutoFlushPeriod = std::chrono::minutes(3);
 constexpr int kCheckFlushCounter = 20;
 
-string GetHostName() {
+std::string GetHostName() {
   char hostname[1024];
   if (::gethostname(hostname, sizeof(hostname))) {
     return {};
@@ -57,9 +58,9 @@ PrometheusMetricGateway::~PrometheusMetricGateway() {
 }
 
 namespace {
-using ExtractedDataFromMetricKey = std::tuple<std::map<std::string, std::string>, string, string>;
+using ExtractedDataFromMetricKey = std::tuple<std::map<std::string, std::string>, std::string, std::string>;
 
-inline std::tuple<std::map<std::string, std::string>, string, string> ExtractData(const MetricKey& key) {
+inline ExtractedDataFromMetricKey ExtractData(const MetricKey& key) {
   ExtractedDataFromMetricKey ret;
   std::string_view metricNameSV, metricHelpSV;
   for (const auto& [k, v] : key) {
@@ -68,11 +69,11 @@ inline std::tuple<std::map<std::string, std::string>, string, string> ExtractDat
     } else if (k == "metric_help") {
       metricHelpSV = v;
     } else {
-      std::get<0>(ret).insert_or_assign(string(k), string(v));
+      std::get<0>(ret).insert_or_assign(std::string(k), std::string(v));
     }
   }
-  std::get<1>(ret) = string(metricNameSV);
-  std::get<2>(ret) = string(metricHelpSV);
+  std::get<1>(ret) = std::string(metricNameSV);
+  std::get<2>(ret) = std::string(metricHelpSV);
   return ret;
 }
 

--- a/src/objects/include/balanceportfolio.hpp
+++ b/src/objects/include/balanceportfolio.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cct_type_traits.hpp"
 #include "cct_vector.hpp"
 #include "currencycode.hpp"
 #include "monetaryamount.hpp"
@@ -39,6 +40,8 @@ class BalancePortfolio {
   void sortByDecreasingEquivalentAmount();
 
   BalancePortfolio &operator+=(const BalancePortfolio &o);
+
+  using trivially_relocatable = is_trivially_relocatable<MonetaryAmountVec>::type;
 
  private:
   MonetaryAmountVec _sortedAmounts;

--- a/src/objects/include/currencyexchangeflatset.hpp
+++ b/src/objects/include/currencyexchangeflatset.hpp
@@ -2,6 +2,7 @@
 
 #include "cct_exception.hpp"
 #include "cct_flatset.hpp"
+#include "cct_type_traits.hpp"
 #include "currencyexchange.hpp"
 
 namespace cct {
@@ -53,7 +54,9 @@ class CurrencyExchangeFlatSet {
   const CurrencyExchange &getOrThrow(CurrencyCode standardCode) const {
     const_iterator it = find(standardCode);
     if (it == _set.end()) {
-      throw exception("Unknown " + string(standardCode.str()));
+      string ex("Unknown ");
+      ex.append(standardCode.str());
+      throw exception(std::move(ex));
     }
     return *it;
   }
@@ -68,6 +71,8 @@ class CurrencyExchangeFlatSet {
   std::pair<iterator, bool> emplace(Args &&...args) {
     return _set.emplace(std::forward<Args &&>(args)...);
   }
+
+  using trivially_relocatable = is_trivially_relocatable<SetType>::type;
 
  private:
   SetType _set;

--- a/src/objects/include/exchangename.hpp
+++ b/src/objects/include/exchangename.hpp
@@ -6,6 +6,7 @@
 #include "cct_fixedcapacityvector.hpp"
 #include "cct_smallvector.hpp"
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 
 namespace cct {
 
@@ -38,6 +39,8 @@ class PrivateExchangeName {
 
   bool operator==(const PrivateExchangeName &o) const { return _nameWithKey == o._nameWithKey; }
   bool operator!=(const PrivateExchangeName &o) const { return !(*this == o); }
+
+  using trivially_relocatable = is_trivially_relocatable<string>::type;
 
  private:
   string _nameWithKey;

--- a/src/objects/include/marketorderbook.hpp
+++ b/src/objects/include/marketorderbook.hpp
@@ -135,6 +135,8 @@ class MarketOrderBook {
   ///                            currency
   void print(std::ostream& os, std::string_view exchangeName, MonetaryAmount conversionPriceRate) const;
 
+  using trivially_relocatable = std::true_type;
+
  private:
   /// Represents a total amount of waiting orders at a given price.
   /// Note that currency is not stored in situ for memory footprint reasons, but it's not an issue as we can get it from
@@ -170,8 +172,8 @@ class MarketOrderBook {
 
     bool operator==(AmountPrice o) const { return amount == o.amount && price == o.price; }
 
-    AmountType amount{};
-    AmountType price{};
+    AmountType amount = 0;
+    AmountType price = 0;
   };
 
   using AmountPriceVector = SmallVector<AmountPrice, 20>;
@@ -207,4 +209,5 @@ class MarketOrderBook {
   int _lowestAskPricePos;
   bool _isArtificiallyExtended;
 };
+
 }  // namespace cct

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -6,6 +6,7 @@
 
 #include "cct_mathhelpers.hpp"
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 #include "currencycode.hpp"
 
 namespace cct {

--- a/src/objects/include/wallet.hpp
+++ b/src/objects/include/wallet.hpp
@@ -3,6 +3,7 @@
 #include <string_view>
 
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 #include "currencycode.hpp"
 #include "exchangename.hpp"
 
@@ -40,6 +41,9 @@ class Wallet {
   static bool IsAddressPresentInDepositFile(std::string_view dataDir, const PrivateExchangeName &privateExchangeName,
                                             CurrencyCode currency, std::string_view expectedAddress,
                                             std::string_view expectedTag);
+
+  using trivially_relocatable = std::integral_constant<bool, is_trivially_relocatable_v<PrivateExchangeName> &&
+                                                                 is_trivially_relocatable_v<string> >::type;
 
  private:
   PrivateExchangeName _privateExchangeName;

--- a/src/objects/src/apikeysprovider.cpp
+++ b/src/objects/src/apikeysprovider.cpp
@@ -38,12 +38,16 @@ const APIKey& APIKeysProvider::get(const PrivateExchangeName& privateExchangeNam
   std::string_view platformStr = privateExchangeName.name();
   auto foundIt = _apiKeysMap.find(platformStr);
   if (foundIt == _apiKeysMap.end()) {
-    throw exception("Unable to retrieve private key for " + string(platformStr));
+    string ex("Unable to retrieve private key for ");
+    ex.append(platformStr);
+    throw exception(std::move(ex));
   }
   const APIKeys& apiKeys = foundIt->second;
   if (!privateExchangeName.isKeyNameDefined()) {
     if (apiKeys.size() > 1) {
-      throw exception("Specify name for " + string(platformStr) + " keys as you have several");
+      string ex("Specify name for ");
+      ex.append(platformStr).append(" keys as you have several");
+      throw exception(std::move(ex));
     }
     return apiKeys.front();
   }
@@ -51,8 +55,9 @@ const APIKey& APIKeysProvider::get(const PrivateExchangeName& privateExchangeNam
     return apiKey.name() == privateExchangeName.keyName();
   });
   if (keyNameIt == apiKeys.end()) {
-    throw exception("Unable to retrieve private key for " + string(platformStr) + " named " +
-                    string(privateExchangeName.keyName()));
+    string ex("Unable to retrieve private key for ");
+    ex.append(platformStr).append(" named ").append(privateExchangeName.keyName());
+    throw exception(std::move(ex));
   }
   return *keyNameIt;
 }

--- a/src/objects/src/exchangeinfo.cpp
+++ b/src/objects/src/exchangeinfo.cpp
@@ -12,8 +12,8 @@ ExchangeInfo::ExchangeInfo(std::string_view exchangeNameStr, std::string_view ma
       _excludedCurrenciesWithdrawal(excludedCurrenciesWithdraw.begin(), excludedCurrenciesWithdraw.end()),
       _minPublicQueryDelay(std::chrono::milliseconds(minPublicQueryDelayMs)),
       _minPrivateQueryDelay(std::chrono::milliseconds(minPrivateQueryDelayMs)),
-      _generalMakerRatio((MonetaryAmount("100") - MonetaryAmount(makerStr)) / 100),
-      _generalTakerRatio((MonetaryAmount("100") - MonetaryAmount(takerStr)) / 100),
+      _generalMakerRatio((MonetaryAmount(100) - MonetaryAmount(makerStr)) / 100),
+      _generalTakerRatio((MonetaryAmount(100) - MonetaryAmount(takerStr)) / 100),
       _validateDepositAddressesInFile(validateDepositAddressesInFile) {
   if (log::get_level() <= log::level::debug) {
     string excludedAssets(1, '[');

--- a/src/objects/src/exchangename.cpp
+++ b/src/objects/src/exchangename.cpp
@@ -4,7 +4,7 @@
 
 namespace cct {
 PrivateExchangeName::PrivateExchangeName(std::string_view globalExchangeName)
-    : _nameWithKey(globalExchangeName), _dashPos(globalExchangeName.find_first_of('_')) {
+    : _nameWithKey(globalExchangeName), _dashPos(globalExchangeName.find('_')) {
   if (_dashPos == std::string_view::npos) {
     _dashPos = _nameWithKey.size();
   }
@@ -12,7 +12,7 @@ PrivateExchangeName::PrivateExchangeName(std::string_view globalExchangeName)
 
 PrivateExchangeName::PrivateExchangeName(std::string_view exchangeName, std::string_view keyName)
     : _nameWithKey(exchangeName), _dashPos(_nameWithKey.size()) {
-  if (_nameWithKey.find_first_of('_') != string::npos) {
+  if (_nameWithKey.find('_') != string::npos) {
     throw exception("Invalid exchange name " + _nameWithKey);
   }
   if (!keyName.empty()) {

--- a/src/objects/src/market.cpp
+++ b/src/objects/src/market.cpp
@@ -4,9 +4,11 @@
 
 namespace cct {
 Market::Market(std::string_view marketStrRep, char currencyCodeSep) {
-  std::size_t sepPos = marketStrRep.find_first_of(currencyCodeSep);
+  std::size_t sepPos = marketStrRep.find(currencyCodeSep);
   if (sepPos == std::string_view::npos) {
-    throw exception("Market string representation " + string(marketStrRep) + " should have a separator");
+    string ex("Market string representation ");
+    ex.append(marketStrRep).append(" should have a separator");
+    throw exception(std::move(ex));
   }
   _assets.front() = std::string_view(marketStrRep.begin(), marketStrRep.begin() + sepPos);
   _assets.back() = std::string_view(marketStrRep.begin() + sepPos + 1, marketStrRep.end());

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -42,8 +42,12 @@ MarketOrderBook::MarketOrderBook(Market market, OrderBookLineSpan orderLines, Vo
     auto adjacentFindIt = std::adjacent_find(_orders.begin(), _orders.end(),
                                              [](AmountPrice lhs, AmountPrice rhs) { return lhs.price == rhs.price; });
     if (adjacentFindIt != _orders.end()) {
-      throw exception("Forbidden duplicate price " + std::to_string(adjacentFindIt->price) +
-                      " in the order book for market " + market.str());
+      string ex("Forbidden duplicate price ");
+      ex.append(MonetaryAmount(adjacentFindIt->price).amountStr());
+      ex.append(" in the order book for market ");
+      ex.append(market.str());
+
+      throw exception(std::move(ex));
     }
 
     auto highestBidPriceIt =

--- a/src/objects/src/wallet.cpp
+++ b/src/objects/src/wallet.cpp
@@ -41,7 +41,7 @@ bool Wallet::IsAddressPresentInDepositFile(std::string_view dataDir, const Priva
       CurrencyCode currencyCode(currencyCodeStr);
       if (currencyCode == currency) {
         string addressAndTag = value;
-        std::size_t tagPos = addressAndTag.find_first_of(',');
+        std::size_t tagPos = addressAndTag.find(',');
         std::string_view address(addressAndTag.begin(), addressAndTag.begin() + std::min(tagPos, addressAndTag.size()));
         if (expectedAddress != address) {
           return false;
@@ -66,7 +66,7 @@ void ValidateDepositAddressIfNeeded(const PrivateExchangeName &privateExchangeNa
                                     const CoincenterInfo &coincenterInfo) {
   if (coincenterInfo.exchangeInfo(privateExchangeName.name()).validateDepositAddressesInFile() &&
       !Wallet::IsAddressPresentInDepositFile(coincenterInfo.dataDir(), privateExchangeName, currency, address, tag)) {
-    std::string errMsg("Incorrect wallet compared to the one stored in ");
+    string errMsg("Incorrect wallet compared to the one stored in ");
     errMsg.append(kDepositAddressesFileName);
     throw exception(std::move(errMsg));
   }

--- a/src/tech/include/cct_config.hpp
+++ b/src/tech/include/cct_config.hpp
@@ -32,12 +32,16 @@
 #define CCT_GCC_DISABLE_WARNING(warningName) CCT_DISABLE_WARNING(warningName)
 #endif
 
-#define CCT_COLD __attribute__((__cold__))
-#define CCT_HOT __attribute__((hot))
-#define CCT_NOINLINE __attribute__((__noinline__))
+#ifdef _MSC_VER
+#define CCT_ALWAYS_INLINE __forceinline
+#define CCT_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
 #define CCT_ALWAYS_INLINE inline __attribute__((__always_inline__))
-#define CCT_NORETURN __attribute__((__noreturn__))
-#define CCT_PACKED __attribute__((__packed__))
+#define CCT_NOINLINE __attribute__((__noinline__))
+#else
+#define CCT_ALWAYS_INLINE inline
+#define CCT_NOINLINE
+#endif
 
 #define CCT_STRINGIFY(x) #x
 #define CCT_VER_STRING(major, minor, patch) CCT_STRINGIFY(major) "." CCT_STRINGIFY(minor) "." CCT_STRINGIFY(patch)
@@ -54,8 +58,4 @@
 #define CCT_COMPILER_VERSION CCT_COMPILER_NAME " " CCT_STRINGIFY(_MSC_FULL_VER)
 #else
 #error "Unknown compiler"
-#endif
-
-#ifndef NDEBUG
-#define CCT_DEBUG_MODE 1
 #endif

--- a/src/tech/include/cct_string.hpp
+++ b/src/tech/include/cct_string.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
+#include "fbstring.hpp"
 
 namespace cct {
-using std::string;
+using string = ::folly::fbstring;
 }

--- a/src/tech/include/commandlineoption.hpp
+++ b/src/tech/include/commandlineoption.hpp
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 
 namespace cct {
 using InvalidArgumentException = std::invalid_argument;
@@ -40,6 +41,8 @@ class CommandLineOption {
   bool hasShortName() const { return _shortName != '\0'; }
 
   bool operator<(const CommandLineOption& o) const;
+
+  using trivially_relocatable = is_trivially_relocatable<string>::type;
 
  private:
   string _optionGroupName;

--- a/src/tech/include/commandlineoptionsparser.hpp
+++ b/src/tech/include/commandlineoptionsparser.hpp
@@ -23,7 +23,8 @@
 namespace cct {
 
 inline void ThrowExpectingValueException(const CommandLineOption& commandLineOption) {
-  throw InvalidArgumentException("Expecting a value for option: " + string(commandLineOption.fullName()));
+  static const string ex = "Expecting a value for option: " + string(commandLineOption.fullName());
+  throw InvalidArgumentException(ex.c_str());
 }
 
 #ifndef _WIN32
@@ -119,7 +120,8 @@ class CommandLineOptionsParser : private Opts {
       const bool knownOption = std::any_of(_commandLineOptionsWithValues.begin(), _commandLineOptionsWithValues.end(),
                                            [argStr](const auto& opt) { return opt.first.matches(argStr); });
       if (!knownOption) {
-        throw InvalidArgumentException("Unrecognized command-line option: " + string(argStr));
+        static const string ex = "Unrecognized command-line option: " + string(argStr);
+        throw InvalidArgumentException(ex.c_str());
       }
 
       for (auto& cbk : _callbacks) {
@@ -247,16 +249,16 @@ class CommandLineOptionsParser : private Opts {
   }
 
   static void ThrowDuplicatedOptionsException(char shortName) {
-    string errMsg("Options with same short name '");
+    static string errMsg("Options with same short name '");
     errMsg.push_back(shortName);
     errMsg.append("' have been found");
-    throw InvalidArgumentException(std::move(errMsg));
+    throw InvalidArgumentException(errMsg.c_str());
   }
 
   static void ThrowDuplicatedOptionsException(std::string_view lhsName, std::string_view rhsName) {
-    string errMsg("Duplicated options '");
+    static string errMsg("Duplicated options '");
     errMsg.append(lhsName).append("' and '").append(rhsName).append("' have been found");
-    throw InvalidArgumentException(std::move(errMsg));
+    throw InvalidArgumentException(errMsg.c_str());
   }
 
   static bool IsOptionValue(const char* argv) {

--- a/src/tech/include/fbstring.hpp
+++ b/src/tech/include/fbstring.hpp
@@ -1,0 +1,2980 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @author: Andrei Alexandrescu (aalexandre)
+// String type.
+
+// clang-format off
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+#include "cct_config.hpp"
+#include "cct_type_traits.hpp"
+
+#define FOLLY_HAS_STRING_VIEW 1
+#define FOLLY_ALWAYS_INLINE CCT_ALWAYS_INLINE
+#define FOLLY_NOINLINE CCT_NOINLINE
+#define FOLLY_LIKELY CCT_LIKELY
+#define FOLLY_UNLIKELY CCT_UNLIKELY
+#define FOLLY_FALLTHROUGH [[fallthrough]]
+
+#if defined(__GNUC__) || defined(__clang__)
+// Clang & GCC
+#define FOLLY_PUSH_WARNING _Pragma("GCC diagnostic push")
+#define FOLLY_POP_WARNING _Pragma("GCC diagnostic pop")
+#define FOLLY_GNU_DISABLE_WARNING_INTERNAL2(warningName) #warningName
+#define FOLLY_GNU_DISABLE_WARNING(warningName) \
+  _Pragma(                                     \
+      FOLLY_GNU_DISABLE_WARNING_INTERNAL2(GCC diagnostic ignored warningName))
+#ifdef __clang__
+#define FOLLY_CLANG_DISABLE_WARNING(warningName) \
+  FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
+#else
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName) \
+  FOLLY_GNU_DISABLE_WARNING(warningName)
+#endif
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#elif defined(_MSC_VER)
+#define FOLLY_PUSH_WARNING __pragma(warning(push))
+#define FOLLY_POP_WARNING __pragma(warning(pop))
+// Disable the GCC warnings.
+#define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber) \
+  __pragma(warning(disable : warningNumber))
+#else
+#define FOLLY_PUSH_WARNING
+#define FOLLY_POP_WARNING
+#define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#endif
+
+namespace folly {
+#ifdef _MSC_VER
+// It's MSVC, so we just have to guess ... and allow an override
+#ifdef FOLLY_ENDIAN_BE
+constexpr auto kIsLittleEndian = false;
+#else
+constexpr auto kIsLittleEndian = true;
+#endif
+#else
+constexpr auto kIsLittleEndian = __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
+#endif
+
+inline size_t goodMallocSize(size_t minSize) noexcept { return minSize; }
+} // namespace folly
+
+
+#ifdef FOLLY_HAS_STRING_VIEW
+#include <string_view>
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <utility>
+
+FOLLY_PUSH_WARNING
+// Ignore shadowing warnings within this file, so includers can use -Wshadow.
+FOLLY_GNU_DISABLE_WARNING("-Wshadow")
+
+namespace folly {
+
+[[noreturn]] FOLLY_ALWAYS_INLINE void assume_unreachable() {
+#if defined(__GNUC__)
+  __builtin_unreachable();
+#elif defined(_MSC_VER)
+  __assume(0);
+#else
+  exit (EXIT_FAILURE);
+#endif
+}
+
+/**
+ * Trivial wrappers around malloc, calloc, realloc that check for allocation
+ * failure and throw std::bad_alloc in that case.
+ */
+inline void* checkedMalloc(size_t size) {
+  void* p = malloc(size);
+  if (!p) throw std::bad_alloc();
+  return p;
+}
+
+inline void* checkedRealloc(void* ptr, size_t size) {
+  void* p = realloc(ptr, size);
+  if (!p) throw std::bad_alloc();
+  return p;
+}
+
+#if defined(__GNUC__)
+// This is for checked malloc-like functions (returns non-null pointer
+// which cannot alias any outstanding pointer).
+#define FOLLY_MALLOC_CHECKED_MALLOC \
+  __attribute__((__returns_nonnull__, __malloc__))
+#else
+#define FOLLY_MALLOC_CHECKED_MALLOC
+#endif
+
+/**
+ * This function tries to reallocate a buffer of which only the first
+ * currentSize bytes are used. The problem with using realloc is that
+ * if currentSize is relatively small _and_ if realloc decides it
+ * needs to move the memory chunk to a new buffer, then realloc ends
+ * up copying data that is not used. It's generally not a win to try
+ * to hook in to realloc() behavior to avoid copies - at least in
+ * jemalloc, realloc() almost always ends up doing a copy, because
+ * there is little fragmentation / slack space to take advantage of.
+ */
+FOLLY_MALLOC_CHECKED_MALLOC FOLLY_NOINLINE inline void* smartRealloc(
+    void* p,
+    const size_t currentSize,
+    const size_t currentCapacity,
+    const size_t newCapacity) {
+  assert(p);
+  assert(currentSize <= currentCapacity &&
+         currentCapacity < newCapacity);
+
+  auto const slack = currentCapacity - currentSize;
+  if (slack * 2 > currentSize) {
+    // Too much slack, malloc-copy-free cycle:
+    auto const result = checkedMalloc(newCapacity);
+    std::memcpy(result, p, currentSize);
+    free(p);
+    return result;
+  }
+  // If there's not too much slack, we realloc in hope of coalescing
+  return checkedRealloc(p, newCapacity);
+}
+
+#if defined(__has_feature)
+#define FOLLY_HAS_FEATURE(...) __has_feature(__VA_ARGS__)
+#else
+#define FOLLY_HAS_FEATURE(...) 0
+#endif
+
+/* FOLLY_SANITIZE_ADDRESS is defined to 1 if the current compilation unit
+ * is being compiled with ASAN enabled.
+ *
+ * Beware when using this macro in a header file: this macro may change values
+ * across compilation units if some libraries are built with ASAN enabled
+ * and some built with ASAN disabled.  For instance, this may occur, if folly
+ * itself was compiled without ASAN but a downstream project that uses folly is
+ * compiling with ASAN enabled.
+ *
+ * Use FOLLY_LIBRARY_SANITIZE_ADDRESS (defined in folly-config.h) to check if
+ * folly itself was compiled with ASAN enabled.
+ */
+#if FOLLY_HAS_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+#define FOLLY_SANITIZE_ADDRESS 1
+#endif
+
+// When compiling with ASan, always heap-allocate the string even if
+// it would fit in-situ, so that ASan can detect access to the string
+// buffer after it has been invalidated (destroyed, resized, etc.).
+// Note that this flag doesn't remove support for in-situ strings, as
+// that would break ABI-compatibility and wouldn't allow linking code
+// compiled with this flag with code compiled without.
+#ifdef FOLLY_SANITIZE_ADDRESS
+#define FBSTRING_DISABLE_SSO true
+#else
+#define FBSTRING_DISABLE_SSO false
+#endif
+
+namespace fbstring_detail {
+
+template <class InIt, class OutIt>
+inline std::pair<InIt, OutIt> copy_n(
+    InIt b, typename std::iterator_traits<InIt>::difference_type n, OutIt d) {
+  for (; n != 0; --n, ++b, ++d) {
+    *d = *b;
+  }
+  return std::make_pair(b, d);
+}
+
+template <class Pod, class T>
+inline void podFill(Pod* b, Pod* e, T c) {
+  assert(b && e && b <= e);
+  constexpr auto kUseMemset = sizeof(T) == 1;
+  if constexpr (kUseMemset) {
+    memset(b, c, size_t(e - b));
+  } else {
+    auto const ee = b + ((e - b) & ~7u);
+    for (; b != ee; b += 8) {
+      b[0] = c;
+      b[1] = c;
+      b[2] = c;
+      b[3] = c;
+      b[4] = c;
+      b[5] = c;
+      b[6] = c;
+      b[7] = c;
+    }
+    // Leftovers
+    for (; b != e; ++b) {
+      *b = c;
+    }
+  }
+}
+
+/*
+ * Lightly structured memcpy, simplifies copying PODs and introduces
+ * some asserts. Unfortunately using this function may cause
+ * measurable overhead (presumably because it adjusts from a begin/end
+ * convention to a pointer/size convention, so it does some extra
+ * arithmetic even though the caller might have done the inverse
+ * adaptation outside).
+ */
+template <class Pod>
+inline void podCopy(const Pod* b, const Pod* e, Pod* d) {
+  assert(b != nullptr);
+  assert(e != nullptr);
+  assert(d != nullptr);
+  assert(e >= b);
+  assert(d >= e || d + (e - b) <= b);
+  memcpy(d, b, (e - b) * sizeof(Pod));
+}
+
+/*
+ * Lightly structured memmove, simplifies copying PODs and introduces
+ * some asserts
+ */
+template <class Pod>
+inline void podMove(const Pod* b, const Pod* e, Pod* d) {
+  assert(e >= b);
+  memmove(d, b, (e - b) * sizeof(*b));
+}
+} // namespace fbstring_detail
+
+/**
+ * Defines a special acquisition method for constructing fbstring
+ * objects. AcquireMallocatedString means that the user passes a
+ * pointer to a malloc-allocated string that the fbstring object will
+ * take into custody.
+ */
+enum class AcquireMallocatedString {};
+
+/*
+ * fbstring_core_model is a mock-up type that defines all required
+ * signatures of a fbstring core. The fbstring class itself uses such
+ * a core object to implement all of the numerous member functions
+ * required by the standard.
+ *
+ * If you want to define a new core, copy the definition below and
+ * implement the primitives. Then plug the core into basic_fbstring as
+ * a template argument.
+
+template <class Char>
+class fbstring_core_model {
+ public:
+  fbstring_core_model();
+  fbstring_core_model(const fbstring_core_model &);
+  fbstring_core_model& operator=(const fbstring_core_model &) = delete;
+  ~fbstring_core_model();
+  // Returns a pointer to string's buffer (currently only contiguous
+  // strings are supported). The pointer is guaranteed to be valid
+  // until the next call to a non-const member function.
+  const Char * data() const;
+  // Much like data(), except the string is prepared to support
+  // character-level changes. This call is a signal for
+  // e.g. reference-counted implementation to fork the data. The
+  // pointer is guaranteed to be valid until the next call to a
+  // non-const member function.
+  Char* mutableData();
+  // Returns a pointer to string's buffer and guarantees that a
+  // readable '\0' lies right after the buffer. The pointer is
+  // guaranteed to be valid until the next call to a non-const member
+  // function.
+  const Char * c_str() const;
+  // Shrinks the string by delta characters. Asserts that delta <=
+  // size().
+  void shrink(size_t delta);
+  // Expands the string by delta characters (i.e. after this call
+  // size() will report the old size() plus delta) but without
+  // initializing the expanded region. The expanded region is
+  // zero-terminated. Returns a pointer to the memory to be
+  // initialized (the beginning of the expanded portion). The caller
+  // is expected to fill the expanded area appropriately.
+  // If expGrowth is true, exponential growth is guaranteed.
+  // It is not guaranteed not to reallocate even if size() + delta <
+  // capacity(), so all references to the buffer are invalidated.
+  Char* expandNoinit(size_t delta, bool expGrowth);
+  // Expands the string by one character and sets the last character
+  // to c.
+  void push_back(Char c);
+  // Returns the string's size.
+  size_t size() const;
+  // Returns the string's capacity, i.e. maximum size that the string
+  // can grow to without reallocation. Note that for reference counted
+  // strings that's technically a lie - even assigning characters
+  // within the existing size would cause a reallocation.
+  size_t capacity() const;
+  // Returns true if the data underlying the string is actually shared
+  // across multiple strings (in a refcounted fashion).
+  bool isShared() const;
+  // Makes sure that at least minCapacity characters are available for
+  // the string without reallocation. For reference-counted strings,
+  // it should fork the data even if minCapacity < size().
+  void reserve(size_t minCapacity);
+};
+*/
+
+/**
+ * This is the core of the string. The code should work on 32- and
+ * 64-bit and both big- and little-endianan architectures with any
+ * Char size.
+ *
+ * The storage is selected as follows (assuming we store one-byte
+ * characters on a 64-bit machine): (a) "small" strings between 0 and
+ * 23 chars are stored in-situ without allocation (the rightmost byte
+ * stores the size); (b) "medium" strings from 24 through 254 chars
+ * are stored in malloc-allocated memory that is copied eagerly; (c)
+ * "large" strings of 255 chars and above are stored in a similar
+ * structure as medium arrays, except that the string is
+ * reference-counted and copied lazily. the reference count is
+ * allocated right before the character array.
+ *
+ * The discriminator between these three strategies sits in two
+ * bits of the rightmost char of the storage:
+ * - If neither is set, then the string is small. Its length is represented by
+ *   the lower-order bits on little-endian or the high-order bits on big-endian
+ *   of that rightmost character. The value of these six bits is
+ *   `maxSmallSize - size`, so this quantity must be subtracted from
+ *   `maxSmallSize` to compute the `size` of the string (see `smallSize()`).
+ *   This scheme ensures that when `size == `maxSmallSize`, the last byte in the
+ *   storage is \0. This way, storage will be a null-terminated sequence of
+ *   bytes, even if all 23 bytes of data are used on a 64-bit architecture.
+ *   This enables `c_str()` and `data()` to simply return a pointer to the
+ *   storage.
+ *
+ * - If the MSb is set, the string is medium width.
+ *
+ * - If the second MSb is set, then the string is large. On little-endian,
+ *   these 2 bits are the 2 MSbs of MediumLarge::capacity_, while on
+ *   big-endian, these 2 bits are the 2 LSbs. This keeps both little-endian
+ *   and big-endian fbstring_core equivalent with merely different ops used
+ *   to extract capacity/category.
+ */
+template <class Char>
+class fbstring_core {
+ public:
+  fbstring_core() noexcept { reset(); }
+
+  fbstring_core(const fbstring_core& rhs) {
+    assert(&rhs != this);
+    switch (rhs.category()) {
+      case Category::isSmall:
+        copySmall(rhs);
+        break;
+      case Category::isMedium:
+        copyMedium(rhs);
+        break;
+      case Category::isLarge:
+        copyLarge(rhs);
+        break;
+      default:
+        folly::assume_unreachable();
+    }
+    assert(size() == rhs.size());
+    assert(memcmp(data(), rhs.data(), size() * sizeof(Char)) == 0);
+  }
+
+  fbstring_core& operator=(const fbstring_core& rhs) = delete;
+
+  fbstring_core(fbstring_core&& goner) noexcept {
+    // Take goner's guts
+    ml_ = goner.ml_;
+    // Clean goner's carcass
+    goner.reset();
+  }
+
+  fbstring_core(
+      const Char* const data,
+      const size_t size,
+      bool disableSSO = FBSTRING_DISABLE_SSO) {
+    if (!disableSSO && size <= maxSmallSize) {
+      initSmall(data, size);
+    } else if (size <= maxMediumSize) {
+      initMedium(data, size);
+    } else {
+      initLarge(data, size);
+    }
+    assert(this->size() == size);
+    assert(size == 0 || memcmp(this->data(), data, size * sizeof(Char)) == 0);
+  }
+
+  ~fbstring_core() noexcept {
+    if (category() == Category::isSmall) {
+      return;
+    }
+    destroyMediumLarge();
+  }
+
+  // Snatches a previously mallocated string. The parameter "size"
+  // is the size of the string, and the parameter "allocatedSize"
+  // is the size of the mallocated block.  The string must be
+  // \0-terminated, so allocatedSize >= size + 1 and data[size] == '\0'.
+  //
+  // So if you want a 2-character string, pass malloc(3) as "data",
+  // pass 2 as "size", and pass 3 as "allocatedSize".
+  fbstring_core(
+      Char* const data,
+      const size_t size,
+      const size_t allocatedSize,
+      AcquireMallocatedString) {
+    if (size > 0) {
+      assert(allocatedSize >= size + 1);
+      assert(data[size] == '\0');
+      // Use the medium string storage
+      ml_.data_ = data;
+      ml_.size_ = size;
+      // Don't forget about null terminator
+      ml_.setCapacity(allocatedSize - 1, Category::isMedium);
+    } else {
+      // No need for the memory
+      free(data);
+      reset();
+    }
+  }
+
+  // swap below doesn't test whether &rhs == this (and instead
+  // potentially does extra work) on the premise that the rarity of
+  // that situation actually makes the check more expensive than is
+  // worth.
+  void swap(fbstring_core& rhs) {
+    auto const t = ml_;
+    ml_ = rhs.ml_;
+    rhs.ml_ = t;
+  }
+
+  // In C++11 data() and c_str() are 100% equivalent.
+  const Char* data() const { return c_str(); }
+
+  Char* data() { return c_str(); }
+
+  Char* mutableData() {
+    switch (category()) {
+      case Category::isSmall:
+        return small_;
+      case Category::isMedium:
+        return ml_.data_;
+      case Category::isLarge:
+        return mutableDataLarge();
+    }
+    folly::assume_unreachable();
+  }
+
+  const Char* c_str() const {
+    const Char* ptr = ml_.data_;
+    // With this syntax, GCC and Clang generate a CMOV instead of a branch.
+    ptr = (category() == Category::isSmall) ? small_ : ptr;
+    return ptr;
+  }
+
+  void shrink(const size_t delta) {
+    if (category() == Category::isSmall) {
+      shrinkSmall(delta);
+    } else if (
+        category() == Category::isMedium || RefCounted::refs(ml_.data_) == 1) {
+      shrinkMedium(delta);
+    } else {
+      shrinkLarge(delta);
+    }
+  }
+
+  FOLLY_NOINLINE
+  void reserve(size_t minCapacity, bool disableSSO = FBSTRING_DISABLE_SSO) {
+    FOLLY_PUSH_WARNING
+    FOLLY_CLANG_DISABLE_WARNING("-Wcovered-switch-default")
+    switch (category()) {
+      case Category::isSmall:
+        reserveSmall(minCapacity, disableSSO);
+        break;
+      case Category::isMedium:
+        reserveMedium(minCapacity);
+        break;
+      case Category::isLarge:
+        reserveLarge(minCapacity);
+        break;
+      default:
+        folly::assume_unreachable();
+    }
+    FOLLY_POP_WARNING
+    assert(capacity() >= minCapacity);
+  }
+
+  Char* expandNoinit(
+      const size_t delta,
+      bool expGrowth = false,
+      bool disableSSO = FBSTRING_DISABLE_SSO);
+
+  void push_back(Char c) { *expandNoinit(1, /* expGrowth = */ true) = c; }
+
+  size_t size() const {
+    size_t ret = ml_.size_;
+    if constexpr (kIsLittleEndian) {
+      // We can save a couple instructions, because the category is
+      // small if the last char, as unsigned, is <= maxSmallSize.
+      typedef typename std::make_unsigned<Char>::type UChar;
+      auto maybeSmallSize = size_t(maxSmallSize) -
+          size_t(static_cast<UChar>(small_[maxSmallSize]));
+      // With this syntax, GCC and Clang generate a CMOV instead of a branch.
+      ret = (static_cast<intmax_t>(maybeSmallSize) >= 0) ? maybeSmallSize : ret;
+    } else {
+      ret = (category() == Category::isSmall) ? smallSize() : ret;
+    }
+    return ret;
+  }
+
+  size_t capacity() const {
+    FOLLY_PUSH_WARNING
+    FOLLY_CLANG_DISABLE_WARNING("-Wcovered-switch-default")
+    switch (category()) {
+      case Category::isSmall:
+        return maxSmallSize;
+      case Category::isLarge:
+        // For large-sized strings, a multi-referenced chunk has no
+        // available capacity. This is because any attempt to append
+        // data would trigger a new allocation.
+        if (RefCounted::refs(ml_.data_) > 1) {
+          return ml_.size_;
+        }
+        break;
+      case Category::isMedium:
+      default:
+        break;
+    }
+    FOLLY_POP_WARNING
+    return ml_.capacity();
+  }
+
+  bool isShared() const {
+    return category() == Category::isLarge && RefCounted::refs(ml_.data_) > 1;
+  }
+
+ private:
+  Char* c_str() {
+    Char* ptr = ml_.data_;
+    // With this syntax, GCC and Clang generate a CMOV instead of a branch.
+    ptr = (category() == Category::isSmall) ? small_ : ptr;
+    return ptr;
+  }
+
+  void reset() { setSmallSize(0); }
+
+  FOLLY_NOINLINE void destroyMediumLarge() noexcept {
+    auto const c = category();
+    assert(c != Category::isSmall);
+    if (c == Category::isMedium) {
+      free(ml_.data_);
+    } else {
+      RefCounted::decrementRefs(ml_.data_);
+    }
+  }
+
+  struct RefCounted {
+    std::atomic<size_t> refCount_;
+    Char data_[1];
+
+    constexpr static size_t getDataOffset() {
+      return offsetof(RefCounted, data_);
+    }
+
+    static RefCounted* fromData(Char* p) {
+      return static_cast<RefCounted*>(static_cast<void*>(
+          static_cast<unsigned char*>(static_cast<void*>(p)) -
+          getDataOffset()));
+    }
+
+    static size_t refs(Char* p) {
+      return fromData(p)->refCount_.load(std::memory_order_acquire);
+    }
+
+    static void incrementRefs(Char* p) {
+      fromData(p)->refCount_.fetch_add(1, std::memory_order_acq_rel);
+    }
+
+    static void decrementRefs(Char* p) {
+      auto const dis = fromData(p);
+      size_t oldcnt = dis->refCount_.fetch_sub(1, std::memory_order_acq_rel);
+      assert(oldcnt > 0);
+      if (oldcnt == 1) {
+        free(dis);
+      }
+    }
+
+    static RefCounted* create(size_t* size) {
+      const size_t allocSize =
+          goodMallocSize(getDataOffset() + (*size + 1) * sizeof(Char));
+      auto result = static_cast<RefCounted*>(checkedMalloc(allocSize));
+      result->refCount_.store(1, std::memory_order_release);
+      *size = (allocSize - getDataOffset()) / sizeof(Char) - 1;
+      return result;
+    }
+
+    static RefCounted* create(const Char* data, size_t* size) {
+      const size_t effectiveSize = *size;
+      auto result = create(size);
+      if (FOLLY_LIKELY(effectiveSize > 0)) {
+        fbstring_detail::podCopy(data, data + effectiveSize, result->data_);
+      }
+      return result;
+    }
+
+    static RefCounted* reallocate(
+        Char* const data,
+        const size_t currentSize,
+        const size_t currentCapacity,
+        size_t* newCapacity) {
+      assert(*newCapacity > 0 && *newCapacity > currentSize);
+      const size_t allocNewCapacity =
+          goodMallocSize(getDataOffset() + (*newCapacity + 1) * sizeof(Char));
+      auto const dis = fromData(data);
+      assert(dis->refCount_.load(std::memory_order_acquire) == 1);
+      auto result = static_cast<RefCounted*>(smartRealloc(
+          dis,
+          getDataOffset() + (currentSize + 1) * sizeof(Char),
+          getDataOffset() + (currentCapacity + 1) * sizeof(Char),
+          allocNewCapacity));
+      assert(result->refCount_.load(std::memory_order_acquire) == 1);
+      *newCapacity = (allocNewCapacity - getDataOffset()) / sizeof(Char) - 1;
+      return result;
+    }
+  };
+
+  typedef uint8_t category_type;
+
+  enum class Category : category_type {
+    isSmall = 0,
+    isMedium = kIsLittleEndian ? 0x80 : 0x2,
+    isLarge = kIsLittleEndian ? 0x40 : 0x1,
+  };
+
+  Category category() const {
+    // works for both big-endian and little-endian
+    return static_cast<Category>(bytes_[lastChar] & categoryExtractMask);
+  }
+
+  struct MediumLarge {
+    Char* data_;
+    size_t size_;
+    size_t capacity_;
+
+    size_t capacity() const {
+      return kIsLittleEndian ? capacity_ & capacityExtractMask : capacity_ >> 2;
+    }
+
+    void setCapacity(size_t cap, Category cat) {
+      capacity_ = kIsLittleEndian
+          ? cap | (static_cast<size_t>(cat) << kCategoryShift)
+          : (cap << 2) | static_cast<size_t>(cat);
+    }
+  };
+
+  union {
+    uint8_t bytes_[sizeof(MediumLarge)]; // For accessing the last byte.
+    Char small_[sizeof(MediumLarge) / sizeof(Char)];
+    MediumLarge ml_;
+  };
+
+  constexpr static size_t lastChar = sizeof(MediumLarge) - 1;
+  constexpr static size_t maxSmallSize = lastChar / sizeof(Char);
+  constexpr static size_t maxMediumSize = 254 / sizeof(Char);
+  constexpr static uint8_t categoryExtractMask = kIsLittleEndian ? 0xC0 : 0x3;
+  constexpr static size_t kCategoryShift = (sizeof(size_t) - 1) * 8;
+  constexpr static size_t capacityExtractMask = kIsLittleEndian
+      ? ~(size_t(categoryExtractMask) << kCategoryShift)
+      : 0x0 /* unused */;
+
+  static_assert(
+      !(sizeof(MediumLarge) % sizeof(Char)),
+      "Corrupt memory layout for fbstring.");
+
+  size_t smallSize() const {
+    assert(category() == Category::isSmall);
+    constexpr auto shift = kIsLittleEndian ? 0 : 2;
+    auto smallShifted = static_cast<size_t>(small_[maxSmallSize]) >> shift;
+    assert(static_cast<size_t>(maxSmallSize) >= smallShifted);
+    return static_cast<size_t>(maxSmallSize) - smallShifted;
+  }
+
+  void setSmallSize(size_t s) {
+    // Warning: this should work with uninitialized strings too,
+    // so don't assume anything about the previous value of
+    // small_[maxSmallSize].
+    assert(s <= maxSmallSize);
+    constexpr auto shift = kIsLittleEndian ? 0 : 2;
+    small_[maxSmallSize] = char((maxSmallSize - s) << shift);
+    small_[s] = '\0';
+    assert(category() == Category::isSmall && size() == s);
+  }
+
+  void copySmall(const fbstring_core&);
+  void copyMedium(const fbstring_core&);
+  void copyLarge(const fbstring_core&);
+
+  void initSmall(const Char* data, size_t size);
+  void initMedium(const Char* data, size_t size);
+  void initLarge(const Char* data, size_t size);
+
+  void reserveSmall(size_t minCapacity, bool disableSSO);
+  void reserveMedium(size_t minCapacity);
+  void reserveLarge(size_t minCapacity);
+
+  void shrinkSmall(size_t delta);
+  void shrinkMedium(size_t delta);
+  void shrinkLarge(size_t delta);
+
+  void unshare(size_t minCapacity = 0);
+  Char* mutableDataLarge();
+};
+
+template <class Char>
+inline void fbstring_core<Char>::copySmall(const fbstring_core& rhs) {
+  static_assert(offsetof(MediumLarge, data_) == 0, "fbstring layout failure");
+  static_assert(
+      offsetof(MediumLarge, size_) == sizeof(ml_.data_),
+      "fbstring layout failure");
+  static_assert(
+      offsetof(MediumLarge, capacity_) == 2 * sizeof(ml_.data_),
+      "fbstring layout failure");
+  // Just write the whole thing, don't look at details. In
+  // particular we need to copy capacity anyway because we want
+  // to set the size (don't forget that the last character,
+  // which stores a short string's length, is shared with the
+  // ml_.capacity field).
+  ml_ = rhs.ml_;
+  assert(category() == Category::isSmall && this->size() == rhs.size());
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::copyMedium(const fbstring_core& rhs) {
+  // Medium strings are copied eagerly. Don't forget to allocate
+  // one extra Char for the null terminator.
+  auto const allocSize = goodMallocSize((1 + rhs.ml_.size_) * sizeof(Char));
+  ml_.data_ = static_cast<Char*>(checkedMalloc(allocSize));
+  // Also copies terminator.
+  fbstring_detail::podCopy(
+      rhs.ml_.data_, rhs.ml_.data_ + rhs.ml_.size_ + 1, ml_.data_);
+  ml_.size_ = rhs.ml_.size_;
+  ml_.setCapacity(allocSize / sizeof(Char) - 1, Category::isMedium);
+  assert(category() == Category::isMedium);
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::copyLarge(const fbstring_core& rhs) {
+  // Large strings are just refcounted
+  ml_ = rhs.ml_;
+  RefCounted::incrementRefs(ml_.data_);
+  assert(category() == Category::isLarge && size() == rhs.size());
+}
+
+// Small strings are bitblitted
+template <class Char>
+inline void fbstring_core<Char>::initSmall(
+    const Char* const data, const size_t size) {
+  // Layout is: Char* data_, size_t size_, size_t capacity_
+  static_assert(
+      sizeof(*this) == sizeof(Char*) + 2 * sizeof(size_t),
+      "fbstring has unexpected size");
+  static_assert(
+      sizeof(Char*) == sizeof(size_t), "fbstring size assumption violation");
+  // sizeof(size_t) must be a power of 2
+  static_assert(
+      (sizeof(size_t) & (sizeof(size_t) - 1)) == 0,
+      "fbstring size assumption violation");
+
+// If data is aligned, use fast word-wise copying. Otherwise,
+// use conservative memcpy.
+// The word-wise path reads bytes which are outside the range of
+// the string, and makes ASan unhappy, so we disable it when
+// compiling with ASan.
+#ifndef FOLLY_SANITIZE_ADDRESS
+  if ((reinterpret_cast<size_t>(data) & (sizeof(size_t) - 1)) == 0) {
+    const size_t byteSize = size * sizeof(Char);
+    constexpr size_t wordWidth = sizeof(size_t);
+    switch ((byteSize + wordWidth - 1) / wordWidth) { // Number of words.
+      case 3:
+        ml_.capacity_ = reinterpret_cast<const size_t*>(data)[2];
+        FOLLY_FALLTHROUGH;
+      case 2:
+        ml_.size_ = reinterpret_cast<const size_t*>(data)[1];
+        FOLLY_FALLTHROUGH;
+      case 1:
+        ml_.data_ = *reinterpret_cast<Char**>(const_cast<Char*>(data));
+        FOLLY_FALLTHROUGH;
+      case 0:
+        break;
+    }
+  } else
+#endif
+  {
+    if (size != 0) {
+      fbstring_detail::podCopy(data, data + size, small_);
+    }
+  }
+  setSmallSize(size);
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::initMedium(
+    const Char* const data, const size_t size) {
+  // Medium strings are allocated normally. Don't forget to
+  // allocate one extra Char for the terminating null.
+  auto const allocSize = goodMallocSize((1 + size) * sizeof(Char));
+  ml_.data_ = static_cast<Char*>(checkedMalloc(allocSize));
+  if (FOLLY_LIKELY(size > 0)) {
+    fbstring_detail::podCopy(data, data + size, ml_.data_);
+  }
+  ml_.size_ = size;
+  ml_.setCapacity(allocSize / sizeof(Char) - 1, Category::isMedium);
+  ml_.data_[size] = '\0';
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::initLarge(
+    const Char* const data, const size_t size) {
+  // Large strings are allocated differently
+  size_t effectiveCapacity = size;
+  auto const newRC = RefCounted::create(data, &effectiveCapacity);
+  ml_.data_ = newRC->data_;
+  ml_.size_ = size;
+  ml_.setCapacity(effectiveCapacity, Category::isLarge);
+  ml_.data_[size] = '\0';
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::unshare(size_t minCapacity) {
+  assert(category() == Category::isLarge);
+  size_t effectiveCapacity = std::max(minCapacity, ml_.capacity());
+  auto const newRC = RefCounted::create(&effectiveCapacity);
+  // If this fails, someone placed the wrong capacity in an
+  // fbstring.
+  assert(effectiveCapacity >= ml_.capacity());
+  // Also copies terminator.
+  fbstring_detail::podCopy(ml_.data_, ml_.data_ + ml_.size_ + 1, newRC->data_);
+  RefCounted::decrementRefs(ml_.data_);
+  ml_.data_ = newRC->data_;
+  ml_.setCapacity(effectiveCapacity, Category::isLarge);
+  // size_ remains unchanged.
+}
+
+template <class Char>
+inline Char* fbstring_core<Char>::mutableDataLarge() {
+  assert(category() == Category::isLarge);
+  if (RefCounted::refs(ml_.data_) > 1) { // Ensure unique.
+    unshare();
+  }
+  return ml_.data_;
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::reserveLarge(size_t minCapacity) {
+  assert(category() == Category::isLarge);
+  if (RefCounted::refs(ml_.data_) > 1) { // Ensure unique
+    // We must make it unique regardless; in-place reallocation is
+    // useless if the string is shared. In order to not surprise
+    // people, reserve the new block at current capacity or
+    // more. That way, a string's capacity never shrinks after a
+    // call to reserve.
+    unshare(minCapacity);
+  } else {
+    // String is not shared, so let's try to realloc (if needed)
+    if (minCapacity > ml_.capacity()) {
+      // Asking for more memory
+      auto const newRC = RefCounted::reallocate(
+          ml_.data_, ml_.size_, ml_.capacity(), &minCapacity);
+      ml_.data_ = newRC->data_;
+      ml_.setCapacity(minCapacity, Category::isLarge);
+    }
+    assert(capacity() >= minCapacity);
+  }
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::reserveMedium(
+    const size_t minCapacity) {
+  assert(category() == Category::isMedium);
+  // String is not shared
+  if (minCapacity <= ml_.capacity()) {
+    return; // nothing to do, there's enough room
+  }
+  if (minCapacity <= maxMediumSize) {
+    // Keep the string at medium size. Don't forget to allocate
+    // one extra Char for the terminating null.
+    size_t capacityBytes = goodMallocSize((1 + minCapacity) * sizeof(Char));
+    // Also copies terminator.
+    ml_.data_ = static_cast<Char*>(smartRealloc(
+        ml_.data_,
+        (ml_.size_ + 1) * sizeof(Char),
+        (ml_.capacity() + 1) * sizeof(Char),
+        capacityBytes));
+    ml_.setCapacity(capacityBytes / sizeof(Char) - 1, Category::isMedium);
+  } else {
+    // Conversion from medium to large string
+    fbstring_core nascent;
+    // Will recurse to another branch of this function
+    nascent.reserve(minCapacity);
+    nascent.ml_.size_ = ml_.size_;
+    // Also copies terminator.
+    fbstring_detail::podCopy(
+        ml_.data_, ml_.data_ + ml_.size_ + 1, nascent.ml_.data_);
+    nascent.swap(*this);
+    assert(capacity() >= minCapacity);
+  }
+}
+
+template <class Char>
+FOLLY_NOINLINE void fbstring_core<Char>::reserveSmall(
+    size_t minCapacity, const bool disableSSO) {
+  assert(category() == Category::isSmall);
+  if (!disableSSO && minCapacity <= maxSmallSize) {
+    // small
+    // Nothing to do, everything stays put
+  } else if (minCapacity <= maxMediumSize) {
+    // medium
+    // Don't forget to allocate one extra Char for the terminating null
+    auto const allocSizeBytes =
+        goodMallocSize((1 + minCapacity) * sizeof(Char));
+    auto const pData = static_cast<Char*>(checkedMalloc(allocSizeBytes));
+    auto const size = smallSize();
+    // Also copies terminator.
+    fbstring_detail::podCopy(small_, small_ + size + 1, pData);
+    ml_.data_ = pData;
+    ml_.size_ = size;
+    ml_.setCapacity(allocSizeBytes / sizeof(Char) - 1, Category::isMedium);
+  } else {
+    // large
+    auto const newRC = RefCounted::create(&minCapacity);
+    auto const size = smallSize();
+    // Also copies terminator.
+    fbstring_detail::podCopy(small_, small_ + size + 1, newRC->data_);
+    ml_.data_ = newRC->data_;
+    ml_.size_ = size;
+    ml_.setCapacity(minCapacity, Category::isLarge);
+    assert(capacity() >= minCapacity);
+  }
+}
+
+template <class Char>
+inline Char* fbstring_core<Char>::expandNoinit(
+    const size_t delta,
+    bool expGrowth, /* = false */
+    bool disableSSO /* = FBSTRING_DISABLE_SSO */) {
+  // Strategy is simple: make room, then change size
+  assert(capacity() >= size());
+  size_t sz, newSz;
+  if (category() == Category::isSmall) {
+    sz = smallSize();
+    newSz = sz + delta;
+    if (!disableSSO && FOLLY_LIKELY(newSz <= maxSmallSize)) {
+      setSmallSize(newSz);
+      return small_ + sz;
+    }
+    reserveSmall(
+        expGrowth ? std::max(newSz, 2 * maxSmallSize) : newSz, disableSSO);
+  } else {
+    sz = ml_.size_;
+    newSz = sz + delta;
+    if (FOLLY_UNLIKELY(newSz > capacity())) {
+      // ensures not shared
+      reserve(expGrowth ? std::max(newSz, 1 + capacity() * 3 / 2) : newSz);
+    }
+  }
+  assert(capacity() >= newSz);
+  // Category can't be small - we took care of that above
+  assert(category() == Category::isMedium || category() == Category::isLarge);
+  ml_.size_ = newSz;
+  ml_.data_[newSz] = '\0';
+  assert(size() == newSz);
+  return ml_.data_ + sz;
+}
+
+template <class Char>
+inline void fbstring_core<Char>::shrinkSmall(const size_t delta) {
+  // Check for underflow
+  assert(delta <= smallSize());
+  setSmallSize(smallSize() - delta);
+}
+
+template <class Char>
+inline void fbstring_core<Char>::shrinkMedium(const size_t delta) {
+  // Medium strings and unique large strings need no special
+  // handling.
+  assert(ml_.size_ >= delta);
+  ml_.size_ -= delta;
+  ml_.data_[ml_.size_] = '\0';
+}
+
+template <class Char>
+inline void fbstring_core<Char>::shrinkLarge(const size_t delta) {
+  assert(ml_.size_ >= delta);
+  // Shared large string, must make unique. This is because of the
+  // durn terminator must be written, which may trample the shared
+  // data.
+  if (delta) {
+    fbstring_core(ml_.data_, ml_.size_ - delta).swap(*this);
+  }
+  // No need to write the terminator.
+}
+
+/**
+ * Dummy fbstring core that uses an actual std::string. This doesn't
+ * make any sense - it's just for testing purposes.
+ */
+template <class Char>
+class dummy_fbstring_core {
+ public:
+  dummy_fbstring_core() {}
+  dummy_fbstring_core(const dummy_fbstring_core& another)
+      : backend_(another.backend_) {}
+  dummy_fbstring_core(const Char* s, size_t n) : backend_(s, n) {}
+  void swap(dummy_fbstring_core& rhs) { backend_.swap(rhs.backend_); }
+  const Char* data() const { return backend_.data(); }
+  Char* mutableData() { return const_cast<Char*>(backend_.data()); }
+  void shrink(size_t delta) {
+    assert(delta <= size());
+    backend_.resize(size() - delta);
+  }
+  Char* expandNoinit(size_t delta) {
+    auto const sz = size();
+    backend_.resize(size() + delta);
+    return backend_.data() + sz;
+  }
+  void push_back(Char c) { backend_.push_back(c); }
+  size_t size() const { return backend_.size(); }
+  size_t capacity() const { return backend_.capacity(); }
+  bool isShared() const { return false; }
+  void reserve(size_t minCapacity) { backend_.reserve(minCapacity); }
+
+ private:
+  std::basic_string<Char> backend_;
+};
+
+/**
+ * This is the basic_string replacement. For conformity,
+ * basic_fbstring takes the same template parameters, plus the last
+ * one which is the core.
+ */
+template <
+    typename E,
+    class T = std::char_traits<E>,
+    class A = std::allocator<E>,
+    class Storage = fbstring_core<E>>
+class basic_fbstring {
+  static_assert(
+      std::is_same<A, std::allocator<E>>::value,
+      "fbstring ignores custom allocators");
+
+  template <typename Ex, typename... Args>
+  FOLLY_ALWAYS_INLINE static void enforce(bool condition, Args&&... args) {
+    if (!condition) {
+      throw Ex(static_cast<Args&&>(args)...);
+    }
+  }
+
+  bool isSane() const {
+    return begin() <= end() && empty() == (size() == 0) &&
+        empty() == (begin() == end()) && size() <= max_size() &&
+        capacity() <= max_size() && size() <= capacity() &&
+        begin()[size()] == '\0';
+  }
+
+  struct Invariant {
+    Invariant& operator=(const Invariant&) = delete;
+    explicit Invariant(const basic_fbstring& s) noexcept : s_(s) {
+      assert(s_.isSane());
+    }
+    ~Invariant() noexcept { assert(s_.isSane()); }
+
+   private:
+    const basic_fbstring& s_;
+  };
+
+ public:
+  // types
+  typedef T traits_type;
+  typedef typename traits_type::char_type value_type;
+  typedef A allocator_type;
+  typedef typename std::allocator_traits<A>::size_type size_type;
+  typedef typename std::allocator_traits<A>::difference_type difference_type;
+
+  typedef typename std::allocator_traits<A>::value_type& reference;
+  typedef typename std::allocator_traits<A>::value_type const& const_reference;
+  typedef typename std::allocator_traits<A>::pointer pointer;
+  typedef typename std::allocator_traits<A>::const_pointer const_pointer;
+
+  typedef E* iterator;
+  typedef const E* const_iterator;
+  typedef std::reverse_iterator<iterator> reverse_iterator;
+  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+
+  static constexpr size_type npos = size_type(-1);
+  typedef std::true_type IsRelocatable;
+
+ private:
+  static void procrustes(size_type& n, size_type nmax) {
+    if (n > nmax) {
+      n = nmax;
+    }
+  }
+
+  static size_type traitsLength(const value_type* s);
+
+ public:
+  // C++11 21.4.2 construct/copy/destroy
+
+  // Note: while the following two constructors can be (and previously were)
+  // collapsed into one constructor written this way:
+  //
+  //   explicit basic_fbstring(const A& a = A()) noexcept { }
+  //
+  // This can cause Clang (at least version 3.7) to fail with the error:
+  //   "chosen constructor is explicit in copy-initialization ...
+  //   in implicit initialization of field '(x)' with omitted initializer"
+  //
+  // if used in a struct which is default-initialized.  Hence the split into
+  // these two separate constructors.
+
+  basic_fbstring() noexcept : basic_fbstring(A()) {}
+
+  explicit basic_fbstring(const A&) noexcept {}
+
+  basic_fbstring(const basic_fbstring& str) : store_(str.store_) {}
+
+  // Move constructor
+  basic_fbstring(basic_fbstring&& goner) noexcept
+      : store_(std::move(goner.store_)) {}
+
+  // This is defined for compatibility with std::string
+  template <typename A2>
+  /* implicit */ basic_fbstring(const std::basic_string<E, T, A2>& str)
+      : store_(str.data(), str.size()) {}
+
+  basic_fbstring(
+      const basic_fbstring& str,
+      size_type pos,
+      size_type n = npos,
+      const A& /* a */ = A()) {
+    assign(str, pos, n);
+  }
+
+  FOLLY_NOINLINE
+  /* implicit */ basic_fbstring(const value_type* s, const A& /*a*/ = A())
+      : store_(s, traitsLength(s)) {}
+
+  FOLLY_NOINLINE
+  basic_fbstring(const value_type* s, size_type n, const A& /*a*/ = A())
+      : store_(s, n) {}
+
+  FOLLY_NOINLINE
+  basic_fbstring(size_type n, value_type c, const A& /*a*/ = A()) {
+    auto const pData = store_.expandNoinit(n);
+    fbstring_detail::podFill(pData, pData + n, c);
+  }
+
+  template <class InIt>
+  FOLLY_NOINLINE basic_fbstring(
+      InIt begin,
+      InIt end,
+      typename std::enable_if<
+          !std::is_same<InIt, value_type*>::value,
+          const A>::type& /*a*/
+      = A()) {
+    assign(begin, end);
+  }
+
+  // Specialization for const char*, const char*
+  FOLLY_NOINLINE
+  basic_fbstring(const value_type* b, const value_type* e, const A& /*a*/ = A())
+      : store_(b, size_type(e - b)) {}
+
+  // Nonstandard constructor
+  basic_fbstring(
+      value_type* s, size_type n, size_type c, AcquireMallocatedString a)
+      : store_(s, n, c, a) {}
+
+  // Construction from initialization list
+  FOLLY_NOINLINE
+  basic_fbstring(std::initializer_list<value_type> il) {
+    assign(il.begin(), il.end());
+  }
+
+  /// \sjanel - Added constructors from ssp::basic_string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  explicit basic_fbstring(const SV& sv, const A& = A()) : basic_fbstring(sv.data(), sv.size()) {}
+
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  explicit basic_fbstring(const SV& sv, size_type pos, size_type n, const A& = A())
+    : basic_fbstring(sv.substr(pos, n)) {}
+
+  ~basic_fbstring() noexcept {}
+
+  basic_fbstring& operator=(const basic_fbstring& lhs);
+
+  // Move assignment
+  basic_fbstring& operator=(basic_fbstring&& goner) noexcept;
+
+  // Compatibility with std::string
+  template <typename A2>
+  basic_fbstring& operator=(const std::basic_string<E, T, A2>& rhs) {
+    return assign(rhs.data(), rhs.size());
+  }
+
+  // Compatibility with std::string
+  std::basic_string<E, T, A> toStdString() const {
+    return std::basic_string<E, T, A>(data(), size());
+  }
+
+  basic_fbstring& operator=(const value_type* s) { return assign(s); }
+
+  basic_fbstring& operator=(value_type c);
+
+  // This actually goes directly against the C++ spec, but the
+  // value_type overload is dangerous, so we're explicitly deleting
+  // any overloads of operator= that could implicitly convert to
+  // value_type.
+  // Note that we do need to explicitly specify the template types because
+  // otherwise MSVC 2017 will aggressively pre-resolve value_type to
+  // traits_type::char_type, which won't compare as equal when determining
+  // which overload the implementation is referring to.
+  template <typename TP>
+  typename std::enable_if<
+      std::is_convertible<
+          TP,
+          typename basic_fbstring<E, T, A, Storage>::value_type>::value &&
+          !std::is_same<
+              typename std::decay<TP>::type,
+              typename basic_fbstring<E, T, A, Storage>::value_type>::value,
+      basic_fbstring<E, T, A, Storage>&>::type
+  operator=(TP c) = delete;
+
+  basic_fbstring& operator=(std::initializer_list<value_type> il) {
+    return assign(il.begin(), il.end());
+  }
+
+#if FOLLY_HAS_STRING_VIEW
+  operator std::basic_string_view<value_type, traits_type>() const noexcept {
+    return {data(), size()};
+  }
+#endif
+
+  // C++11 21.4.3 iterators:
+  iterator begin() { return store_.mutableData(); }
+
+  const_iterator begin() const { return store_.data(); }
+
+  const_iterator cbegin() const { return begin(); }
+
+  iterator end() { return store_.mutableData() + store_.size(); }
+
+  const_iterator end() const { return store_.data() + store_.size(); }
+
+  const_iterator cend() const { return end(); }
+
+  reverse_iterator rbegin() { return reverse_iterator(end()); }
+
+  const_reverse_iterator rbegin() const {
+    return const_reverse_iterator(end());
+  }
+
+  const_reverse_iterator crbegin() const { return rbegin(); }
+
+  reverse_iterator rend() { return reverse_iterator(begin()); }
+
+  const_reverse_iterator rend() const {
+    return const_reverse_iterator(begin());
+  }
+
+  const_reverse_iterator crend() const { return rend(); }
+
+  // Added by C++11
+  // C++11 21.4.5, element access:
+  const value_type& front() const { return *begin(); }
+  const value_type& back() const {
+    assert(!empty());
+    // Should be begin()[size() - 1], but that branches twice
+    return *(end() - 1);
+  }
+  value_type& front() { return *begin(); }
+  value_type& back() {
+    assert(!empty());
+    // Should be begin()[size() - 1], but that branches twice
+    return *(end() - 1);
+  }
+  void pop_back() {
+    assert(!empty());
+    store_.shrink(1);
+  }
+
+  // C++11 21.4.4 capacity:
+  size_type size() const { return store_.size(); }
+
+  size_type length() const { return size(); }
+
+  size_type max_size() const { return std::numeric_limits<size_type>::max(); }
+
+  void resize(size_type n, value_type c = value_type());
+
+  size_type capacity() const { return store_.capacity(); }
+
+  void reserve(size_type res_arg = 0) {
+    enforce<std::length_error>(res_arg <= max_size(), "");
+    store_.reserve(res_arg);
+  }
+
+  void shrink_to_fit() {
+    // Shrink only if slack memory is sufficiently large
+    if (capacity() < size() * 3 / 2) {
+      return;
+    }
+    basic_fbstring(cbegin(), cend()).swap(*this);
+  }
+
+  void clear() { resize(0); }
+
+  bool empty() const { return size() == 0; }
+
+  // C++11 21.4.5 element access:
+  const_reference operator[](size_type pos) const { return *(begin() + pos); }
+
+  reference operator[](size_type pos) { return *(begin() + pos); }
+
+  const_reference at(size_type n) const {
+    enforce<std::out_of_range>(n < size(), "");
+    return (*this)[n];
+  }
+
+  reference at(size_type n) {
+    enforce<std::out_of_range>(n < size(), "");
+    return (*this)[n];
+  }
+
+  // C++11 21.4.6 modifiers:
+  basic_fbstring& operator+=(const basic_fbstring& str) { return append(str); }
+
+  basic_fbstring& operator+=(const value_type* s) { return append(s); }
+
+  basic_fbstring& operator+=(const value_type c) {
+    push_back(c);
+    return *this;
+  }
+
+  basic_fbstring& operator+=(std::initializer_list<value_type> il) {
+    append(il);
+    return *this;
+  }
+
+  basic_fbstring& append(const basic_fbstring& str);
+
+  basic_fbstring& append(
+      const basic_fbstring& str, const size_type pos, size_type n);
+
+  basic_fbstring& append(const value_type* s, size_type n);
+
+  basic_fbstring& append(const value_type* s) {
+    return append(s, traitsLength(s));
+  }
+
+  basic_fbstring& append(size_type n, value_type c);
+
+  template <class InputIterator>
+  basic_fbstring& append(InputIterator first, InputIterator last) {
+    insert(end(), first, last);
+    return *this;
+  }
+
+  basic_fbstring& append(std::initializer_list<value_type> il) {
+    return append(il.begin(), il.end());
+  }
+
+  /// \sjanel - Add append string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  basic_fbstring& append(const SV& sv) {
+    return append(sv.begin(), sv.end());
+  }
+
+  void push_back(const value_type c) { // primitive
+    store_.push_back(c);
+  }
+
+  basic_fbstring& assign(const basic_fbstring& str) {
+    if (&str == this) {
+      return *this;
+    }
+    return assign(str.data(), str.size());
+  }
+
+  basic_fbstring& assign(basic_fbstring&& str) {
+    return *this = std::move(str);
+  }
+
+  basic_fbstring& assign(
+      const basic_fbstring& str, const size_type pos, size_type n);
+
+  basic_fbstring& assign(const value_type* s, const size_type n);
+
+  basic_fbstring& assign(const value_type* s) {
+    return assign(s, traitsLength(s));
+  }
+
+  basic_fbstring& assign(std::initializer_list<value_type> il) {
+    return assign(il.begin(), il.end());
+  }
+
+  template <class ItOrLength, class ItOrChar>
+  basic_fbstring& assign(ItOrLength first_or_n, ItOrChar last_or_c) {
+    return replace(begin(), end(), first_or_n, last_or_c);
+  }
+
+  basic_fbstring& insert(size_type pos1, const basic_fbstring& str) {
+    return insert(pos1, str.data(), str.size());
+  }
+
+  basic_fbstring& insert(
+      size_type pos1, const basic_fbstring& str, size_type pos2, size_type n) {
+    enforce<std::out_of_range>(pos2 <= str.length(), "");
+    procrustes(n, str.length() - pos2);
+    return insert(pos1, str.data() + pos2, n);
+  }
+
+  basic_fbstring& insert(size_type pos, const value_type* s, size_type n) {
+    enforce<std::out_of_range>(pos <= length(), "");
+    insert(begin() + pos, s, s + n);
+    return *this;
+  }
+
+  basic_fbstring& insert(size_type pos, const value_type* s) {
+    return insert(pos, s, traitsLength(s));
+  }
+
+  basic_fbstring& insert(size_type pos, size_type n, value_type c) {
+    enforce<std::out_of_range>(pos <= length(), "");
+    insert(begin() + pos, n, c);
+    return *this;
+  }
+
+  iterator insert(const_iterator p, const value_type c) {
+    const size_type pos = p - cbegin();
+    insert(p, 1, c);
+    return begin() + pos;
+  }
+
+ private:
+  typedef std::basic_istream<value_type, traits_type> istream_type;
+  istream_type& getlineImpl(istream_type& is, value_type delim);
+
+ public:
+  friend inline istream_type& getline(
+      istream_type& is, basic_fbstring& str, value_type delim) {
+    return str.getlineImpl(is, delim);
+  }
+
+  friend inline istream_type& getline(istream_type& is, basic_fbstring& str) {
+    return getline(is, str, '\n');
+  }
+
+ private:
+  iterator insertImplDiscr(
+      const_iterator i, size_type n, value_type c, std::true_type);
+
+  template <class InputIter>
+  iterator insertImplDiscr(
+      const_iterator i, InputIter b, InputIter e, std::false_type);
+
+  template <class FwdIterator>
+  iterator insertImpl(
+      const_iterator i,
+      FwdIterator s1,
+      FwdIterator s2,
+      std::forward_iterator_tag);
+
+  template <class InputIterator>
+  iterator insertImpl(
+      const_iterator i,
+      InputIterator b,
+      InputIterator e,
+      std::input_iterator_tag);
+
+ public:
+  template <class ItOrLength, class ItOrChar>
+  iterator insert(const_iterator p, ItOrLength first_or_n, ItOrChar last_or_c) {
+    using Sel = std::bool_constant<std::numeric_limits<ItOrLength>::is_specialized>;
+    return insertImplDiscr(p, first_or_n, last_or_c, Sel());
+  }
+
+  iterator insert(const_iterator p, std::initializer_list<value_type> il) {
+    return insert(p, il.begin(), il.end());
+  }
+
+  basic_fbstring& erase(size_type pos = 0, size_type n = npos) {
+    Invariant checker(*this);
+
+    enforce<std::out_of_range>(pos <= length(), "");
+    procrustes(n, length() - pos);
+    std::copy(begin() + pos + n, end(), begin() + pos);
+    resize(length() - n);
+    return *this;
+  }
+
+  iterator erase(iterator position) {
+    const size_type pos(position - begin());
+    enforce<std::out_of_range>(pos <= size(), "");
+    erase(pos, 1);
+    return begin() + pos;
+  }
+
+  iterator erase(iterator first, iterator last) {
+    const size_type pos(first - begin());
+    erase(pos, last - first);
+    return begin() + pos;
+  }
+
+  // Replaces at most n1 chars of *this, starting with pos1 with the
+  // content of str
+  basic_fbstring& replace(
+      size_type pos1, size_type n1, const basic_fbstring& str) {
+    return replace(pos1, n1, str.data(), str.size());
+  }
+
+  /// \sjanel - Add replace from string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  basic_fbstring& replace(size_type pos1, size_type n1, const SV& sv) {
+    return replace(pos1, n1, sv.data(), sv.size());
+  }
+
+  // Replaces at most n1 chars of *this, starting with pos1,
+  // with at most n2 chars of str starting with pos2
+  basic_fbstring& replace(
+      size_type pos1,
+      size_type n1,
+      const basic_fbstring& str,
+      size_type pos2,
+      size_type n2) {
+    enforce<std::out_of_range>(pos2 <= str.length(), "");
+    return replace(
+        pos1, n1, str.data() + pos2, std::min(n2, str.size() - pos2));
+  }
+
+  // Replaces at most n1 chars of *this, starting with pos, with chars from s
+  basic_fbstring& replace(size_type pos, size_type n1, const value_type* s) {
+    return replace(pos, n1, s, traitsLength(s));
+  }
+
+  // Replaces at most n1 chars of *this, starting with pos, with n2
+  // occurrences of c
+  //
+  // consolidated with
+  //
+  // Replaces at most n1 chars of *this, starting with pos, with at
+  // most n2 chars of str.  str must have at least n2 chars.
+  template <class StrOrLength, class NumOrChar>
+  basic_fbstring& replace(
+      size_type pos, size_type n1, StrOrLength s_or_n2, NumOrChar n_or_c) {
+    Invariant checker(*this);
+
+    enforce<std::out_of_range>(pos <= size(), "");
+    procrustes(n1, length() - pos);
+    const iterator b = begin() + pos;
+    return replace(b, b + n1, s_or_n2, n_or_c);
+  }
+
+  basic_fbstring& replace(iterator i1, iterator i2, const basic_fbstring& str) {
+    return replace(i1, i2, str.data(), str.length());
+  }
+
+  basic_fbstring& replace(iterator i1, iterator i2, const value_type* s) {
+    return replace(i1, i2, s, traitsLength(s));
+  }
+
+  /// \sjanel - Add replace from string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  basic_fbstring& replace(iterator i1, iterator i2, const SV& sv) {
+    return replace(i1, i2, sv.data(), sv.length());
+  }
+
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  basic_fbstring& replace(size_type pos1, size_type n1, const SV& sv,
+                          size_type pos2, size_type n2 = npos) {
+    enforce<std::out_of_range>(pos2 <= sv.length(), "");
+    return replace(
+        pos1, n1, sv.data() + pos2, std::min(n2, sv.size() - pos2));
+  }
+
+ private:
+  basic_fbstring& replaceImplDiscr(
+      iterator i1,
+      iterator i2,
+      const value_type* s,
+      size_type n,
+      std::integral_constant<int, 2>);
+
+  basic_fbstring& replaceImplDiscr(
+      iterator i1,
+      iterator i2,
+      size_type n2,
+      value_type c,
+      std::integral_constant<int, 1>);
+
+  template <class InputIter>
+  basic_fbstring& replaceImplDiscr(
+      iterator i1,
+      iterator i2,
+      InputIter b,
+      InputIter e,
+      std::integral_constant<int, 0>);
+
+ private:
+  template <class FwdIterator>
+  bool replaceAliased(
+      iterator /* i1 */,
+      iterator /* i2 */,
+      FwdIterator /* s1 */,
+      FwdIterator /* s2 */,
+      std::false_type) {
+    return false;
+  }
+
+  template <class FwdIterator>
+  bool replaceAliased(
+      iterator i1, iterator i2, FwdIterator s1, FwdIterator s2, std::true_type);
+
+  template <class FwdIterator>
+  void replaceImpl(
+      iterator i1,
+      iterator i2,
+      FwdIterator s1,
+      FwdIterator s2,
+      std::forward_iterator_tag);
+
+  template <class InputIterator>
+  void replaceImpl(
+      iterator i1,
+      iterator i2,
+      InputIterator b,
+      InputIterator e,
+      std::input_iterator_tag);
+
+ public:
+  template <class T1, class T2>
+  basic_fbstring& replace(
+      iterator i1, iterator i2, T1 first_or_n_or_s, T2 last_or_c_or_n) {
+    constexpr bool num1 = std::numeric_limits<T1>::is_specialized,
+                   num2 = std::numeric_limits<T2>::is_specialized;
+    using Sel =
+        std::integral_constant<int, num1 ? (num2 ? 1 : -1) : (num2 ? 2 : 0)>;
+    return replaceImplDiscr(i1, i2, first_or_n_or_s, last_or_c_or_n, Sel());
+  }
+
+  size_type copy(value_type* s, size_type n, size_type pos = 0) const {
+    enforce<std::out_of_range>(pos <= size(), "");
+    procrustes(n, size() - pos);
+
+    if (n != 0) {
+      fbstring_detail::podCopy(data() + pos, data() + pos + n, s);
+    }
+    return n;
+  }
+
+  void swap(basic_fbstring& rhs) { store_.swap(rhs.store_); }
+
+  const value_type* c_str() const { return store_.c_str(); }
+
+  const value_type* data() const { return c_str(); }
+
+  value_type* data() { return store_.data(); }
+
+  allocator_type get_allocator() const { return allocator_type(); }
+
+  size_type find(const basic_fbstring& str, size_type pos = 0) const {
+    return find(str.data(), pos, str.length());
+  }
+
+  size_type find(
+      const value_type* needle, size_type pos, size_type nsize) const;
+
+  size_type find(const value_type* s, size_type pos = 0) const {
+    return find(s, pos, traitsLength(s));
+  }
+
+  size_type find(value_type c, size_type pos = 0) const {
+    return find(&c, pos, 1);
+  }
+
+  /// \sjanel - Add find string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type find(const SV& sv, size_type pos = 0) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return find(sv.data(), pos, sv.length());
+  }
+
+  size_type rfind(const basic_fbstring& str, size_type pos = npos) const {
+    return rfind(str.data(), pos, str.length());
+  }
+
+  size_type rfind(const value_type* s, size_type pos, size_type n) const;
+
+  size_type rfind(const value_type* s, size_type pos = npos) const {
+    return rfind(s, pos, traitsLength(s));
+  }
+
+  size_type rfind(value_type c, size_type pos = npos) const {
+    return rfind(&c, pos, 1);
+  }
+
+  /// \sjanel - Add rfind string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type rfind(const SV& sv, size_type pos = npos) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return rfind(sv.data(), pos, sv.length());
+  }
+
+  size_type find_first_of(const basic_fbstring& str, size_type pos = 0) const {
+    return find_first_of(str.data(), pos, str.length());
+  }
+
+  size_type find_first_of(
+      const value_type* s, size_type pos, size_type n) const;
+
+  size_type find_first_of(const value_type* s, size_type pos = 0) const {
+    return find_first_of(s, pos, traitsLength(s));
+  }
+
+  size_type find_first_of(value_type c, size_type pos = 0) const {
+    return find_first_of(&c, pos, 1);
+  }
+
+  /// \sjanel - Add find_first_of string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type find_first_of(const SV& sv, size_type pos = 0) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return find_first_of(sv.data(), pos, sv.length());
+  }
+
+  size_type find_last_of(
+      const basic_fbstring& str, size_type pos = npos) const {
+    return find_last_of(str.data(), pos, str.length());
+  }
+
+  size_type find_last_of(const value_type* s, size_type pos, size_type n) const;
+
+  size_type find_last_of(const value_type* s, size_type pos = npos) const {
+    return find_last_of(s, pos, traitsLength(s));
+  }
+
+  size_type find_last_of(value_type c, size_type pos = npos) const {
+    return find_last_of(&c, pos, 1);
+  }
+
+  /// \sjanel - Add find_last_of string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type find_last_of(const SV& sv, size_type pos = npos) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return find_last_of(sv.data(), pos, sv.length());
+  }
+
+  size_type find_first_not_of(
+      const basic_fbstring& str, size_type pos = 0) const {
+    return find_first_not_of(str.data(), pos, str.size());
+  }
+
+  size_type find_first_not_of(
+      const value_type* s, size_type pos, size_type n) const;
+
+  size_type find_first_not_of(const value_type* s, size_type pos = 0) const {
+    return find_first_not_of(s, pos, traitsLength(s));
+  }
+
+  size_type find_first_not_of(value_type c, size_type pos = 0) const {
+    return find_first_not_of(&c, pos, 1);
+  }
+
+  /// \sjanel - Add find_first_not_of string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type find_first_not_of(const SV& sv, size_type pos = 0) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return find_first_not_of(sv.data(), pos, sv.length());
+  }
+
+  size_type find_last_not_of(
+      const basic_fbstring& str, size_type pos = npos) const {
+    return find_last_not_of(str.data(), pos, str.length());
+  }
+
+  size_type find_last_not_of(
+      const value_type* s, size_type pos, size_type n) const;
+
+  size_type find_last_not_of(const value_type* s, size_type pos = npos) const {
+    return find_last_not_of(s, pos, traitsLength(s));
+  }
+
+  size_type find_last_not_of(value_type c, size_type pos = npos) const {
+    return find_last_not_of(&c, pos, 1);
+  }
+
+  /// \sjanel - Add find_last_not_of string_view
+  template <class SV, typename std::enable_if<std::is_convertible<const SV&, std::basic_string_view<E, T> >::value &&
+                                             !std::is_convertible<const SV&, const E*>::value, bool>::type = true>
+  size_type find_last_not_of(const SV& sv, size_type pos = npos) const noexcept(std::is_nothrow_convertible_v<const SV&, std::basic_string_view<E, T>>) {
+    return find_last_not_of(sv.data(), pos, sv.length());
+  }
+
+  basic_fbstring substr(size_type pos = 0, size_type n = npos) const& {
+    enforce<std::out_of_range>(pos <= size(), "");
+    return basic_fbstring(data() + pos, std::min(n, size() - pos));
+  }
+
+  basic_fbstring substr(size_type pos = 0, size_type n = npos) && {
+    enforce<std::out_of_range>(pos <= size(), "");
+    erase(0, pos);
+    if (n < size()) {
+      resize(n);
+    }
+    return std::move(*this);
+  }
+
+  int compare(const basic_fbstring& str) const {
+    // FIX due to Goncalo N M de Carvalho July 18, 2005
+    return compare(0, size(), str);
+  }
+
+  int compare(size_type pos1, size_type n1, const basic_fbstring& str) const {
+    return compare(pos1, n1, str.data(), str.size());
+  }
+
+  int compare(size_type pos1, size_type n1, const value_type* s) const {
+    return compare(pos1, n1, s, traitsLength(s));
+  }
+
+  int compare(
+      size_type pos1, size_type n1, const value_type* s, size_type n2) const {
+    enforce<std::out_of_range>(pos1 <= size(), "");
+    procrustes(n1, size() - pos1);
+    // The line below fixed by Jean-Francois Bastien, 04-23-2007. Thanks!
+    const int r = traits_type::compare(pos1 + data(), s, std::min(n1, n2));
+    return r != 0 ? r : n1 > n2 ? 1 : n1 < n2 ? -1 : 0;
+  }
+
+  int compare(
+      size_type pos1,
+      size_type n1,
+      const basic_fbstring& str,
+      size_type pos2,
+      size_type n2) const {
+    enforce<std::out_of_range>(pos2 <= str.size(), "");
+    return compare(
+        pos1, n1, str.data() + pos2, std::min(n2, str.size() - pos2));
+  }
+
+  // Code from Jean-Francois Bastien (03/26/2007)
+  int compare(const value_type* s) const {
+    // Could forward to compare(0, size(), s, traitsLength(s))
+    // but that does two extra checks
+    const size_type n1(size()), n2(traitsLength(s));
+    const int r = traits_type::compare(data(), s, std::min(n1, n2));
+    return r != 0 ? r : n1 > n2 ? 1 : n1 < n2 ? -1 : 0;
+  }
+
+  /// \sjanel - Add starts_with (C++20)
+  bool starts_with(std::basic_string_view<E, T> sv) const noexcept {
+    return sv.size() <= size() && traits_type::compare(data(), sv.data(), sv.size()) == 0;
+  }
+
+  bool starts_with(const E* s) const {
+    return starts_with(std::basic_string_view<E, T>(s, traitsLength(s)));
+  }
+
+  bool starts_with(E c) const noexcept {
+    return !empty() && front() == c;
+  }
+
+  bool ends_with(std::basic_string_view<E, T> sv) const noexcept {
+    const auto ourSize = size();
+    return sv.size() <= ourSize && traits_type::compare(data() + ourSize - sv.size(), sv.data(), sv.size()) == 0;
+  }
+
+  bool ends_with(const E* s) const {
+    return ends_with(std::basic_string_view<E, T>(s, traitsLength(s)));
+  }
+
+  bool ends_with(E c) const noexcept {
+    return !empty() && back() == c;
+  }
+
+  using trivially_relocatable = std::true_type;
+
+ private:
+  // Data
+  Storage store_;
+};
+
+template <typename E, class T, class A, class S>
+FOLLY_NOINLINE typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::traitsLength(const value_type* s) {
+  return s ? traits_type::length(s)
+           : (throw std::logic_error(
+                  "basic_fbstring: null pointer initializer not valid"),
+              0);
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::operator=(
+    const basic_fbstring& lhs) {
+  Invariant checker(*this);
+
+  if (FOLLY_UNLIKELY(&lhs == this)) {
+    return *this;
+  }
+
+  return assign(lhs.data(), lhs.size());
+}
+
+// Move assignment
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::operator=(
+    basic_fbstring&& goner) noexcept {
+  if (FOLLY_UNLIKELY(&goner == this)) {
+    // Compatibility with std::basic_string<>,
+    // C++11 21.4.2 [string.cons] / 23 requires self-move-assignment support.
+    return *this;
+  }
+  // No need of this anymore
+  this->~basic_fbstring();
+  // Move the goner into this
+  new (&store_) S(std::move(goner.store_));
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::operator=(
+    value_type c) {
+  Invariant checker(*this);
+
+  if (empty()) {
+    store_.expandNoinit(1);
+  } else if (store_.isShared()) {
+    basic_fbstring(1, c).swap(*this);
+    return *this;
+  } else {
+    store_.shrink(size() - 1);
+  }
+  front() = c;
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline void basic_fbstring<E, T, A, S>::resize(
+    const size_type n, const value_type c /*= value_type()*/) {
+  Invariant checker(*this);
+
+  auto size = this->size();
+  if (n <= size) {
+    store_.shrink(size - n);
+  } else {
+    auto const delta = n - size;
+    auto pData = store_.expandNoinit(delta);
+    fbstring_detail::podFill(pData, pData + delta, c);
+  }
+  assert(this->size() == n);
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::append(
+    const basic_fbstring& str) {
+#ifndef NDEBUG
+  auto desiredSize = size() + str.size();
+#endif
+  append(str.data(), str.size());
+  assert(size() == desiredSize);
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::append(
+    const basic_fbstring& str, const size_type pos, size_type n) {
+  const size_type sz = str.size();
+  enforce<std::out_of_range>(pos <= sz, "");
+  procrustes(n, sz - pos);
+  return append(str.data() + pos, n);
+}
+
+template <typename E, class T, class A, class S>
+FOLLY_NOINLINE basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::append(
+    const value_type* s, size_type n) {
+  Invariant checker(*this);
+
+  if (FOLLY_UNLIKELY(!n)) {
+    // Unlikely but must be done
+    return *this;
+  }
+  auto const oldSize = size();
+  auto const oldData = data();
+  auto pData = store_.expandNoinit(n, /* expGrowth = */ true);
+
+  // Check for aliasing (rare). We could use "<=" here but in theory
+  // those do not work for pointers unless the pointers point to
+  // elements in the same array. For that reason we use
+  // std::less_equal, which is guaranteed to offer a total order
+  // over pointers. See discussion at http://goo.gl/Cy2ya for more
+  // info.
+  std::less_equal<const value_type*> le;
+  if (FOLLY_UNLIKELY(le(oldData, s) && !le(oldData + oldSize, s))) {
+    assert(le(s + n, oldData + oldSize));
+    // expandNoinit() could have moved the storage, restore the source.
+    s = data() + (s - oldData);
+    fbstring_detail::podMove(s, s + n, pData);
+  } else {
+    fbstring_detail::podCopy(s, s + n, pData);
+  }
+
+  assert(size() == oldSize + n);
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::append(
+    size_type n, value_type c) {
+  Invariant checker(*this);
+  auto pData = store_.expandNoinit(n, /* expGrowth = */ true);
+  fbstring_detail::podFill(pData, pData + n, c);
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::assign(
+    const basic_fbstring& str, const size_type pos, size_type n) {
+  const size_type sz = str.size();
+  enforce<std::out_of_range>(pos <= sz, "");
+  procrustes(n, sz - pos);
+  return assign(str.data() + pos, n);
+}
+
+template <typename E, class T, class A, class S>
+FOLLY_NOINLINE basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::assign(
+    const value_type* s, const size_type n) {
+  Invariant checker(*this);
+
+  if (n == 0) {
+    resize(0);
+  } else if (size() >= n) {
+    // s can alias this, we need to use podMove.
+    fbstring_detail::podMove(s, s + n, store_.mutableData());
+    store_.shrink(size() - n);
+    assert(size() == n);
+  } else {
+    // If n is larger than size(), s cannot alias this string's
+    // storage.
+    resize(0);
+    // Do not use exponential growth here: assign() should be tight,
+    // to mirror the behavior of the equivalent constructor.
+    fbstring_detail::podCopy(s, s + n, store_.expandNoinit(n));
+  }
+
+  assert(size() == n);
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::istream_type&
+basic_fbstring<E, T, A, S>::getlineImpl(istream_type& is, value_type delim) {
+  Invariant checker(*this);
+
+  clear();
+  size_t size = 0;
+  while (true) {
+    size_t avail = capacity() - size;
+    // fbstring has 1 byte extra capacity for the null terminator,
+    // and getline null-terminates the read string.
+    is.getline(store_.expandNoinit(avail), avail + 1, delim);
+    size += is.gcount();
+
+    if (is.bad() || is.eof() || !is.fail()) {
+      // Done by either failure, end of file, or normal read.
+      if (!is.bad() && !is.eof()) {
+        --size; // gcount() also accounts for the delimiter.
+      }
+      resize(size);
+      break;
+    }
+
+    assert(size == this->size());
+    assert(size == capacity());
+    // Start at minimum allocation 63 + terminator = 64.
+    reserve(std::max<size_t>(63, 3 * size / 2));
+    // Clear the error so we can continue reading.
+    is.clear();
+  }
+  return is;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::find(
+    const value_type* needle,
+    const size_type pos,
+    const size_type nsize) const {
+  auto const size = this->size();
+  // nsize + pos can overflow (eg pos == npos), guard against that by checking
+  // that nsize + pos does not wrap around.
+  if (nsize + pos > size || nsize + pos < pos) {
+    return npos;
+  }
+
+  if (nsize == 0) {
+    return pos;
+  }
+  // Don't use std::search, use a Boyer-Moore-like trick by comparing
+  // the last characters first
+  auto const haystack = data();
+  auto const nsize_1 = nsize - 1;
+  auto const lastNeedle = needle[nsize_1];
+
+  // Boyer-Moore skip value for the last char in the needle. Zero is
+  // not a valid value; skip will be computed the first time it's
+  // needed.
+  size_type skip = 0;
+
+  const E* i = haystack + pos;
+  auto iEnd = haystack + size - nsize_1;
+
+  while (i < iEnd) {
+    // Boyer-Moore: match the last element in the needle
+    while (i[nsize_1] != lastNeedle) {
+      if (++i == iEnd) {
+        // not found
+        return npos;
+      }
+    }
+    // Here we know that the last char matches
+    // Continue in pedestrian mode
+    for (size_t j = 0;;) {
+      assert(j < nsize);
+      if (i[j] != needle[j]) {
+        // Not found, we can skip
+        // Compute the skip value lazily
+        if (skip == 0) {
+          skip = 1;
+          while (skip <= nsize_1 && needle[nsize_1 - skip] != lastNeedle) {
+            ++skip;
+          }
+        }
+        i += skip;
+        break;
+      }
+      // Check if done searching
+      if (++j == nsize) {
+        // Yay
+        return i - haystack;
+      }
+    }
+  }
+  return npos;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::iterator
+basic_fbstring<E, T, A, S>::insertImplDiscr(
+    const_iterator i, size_type n, value_type c, std::true_type) {
+  Invariant checker(*this);
+
+  assert(i >= cbegin() && i <= cend());
+  const size_type pos = i - cbegin();
+
+  auto oldSize = size();
+  store_.expandNoinit(n, /* expGrowth = */ true);
+  auto b = begin();
+  fbstring_detail::podMove(b + pos, b + oldSize, b + pos + n);
+  fbstring_detail::podFill(b + pos, b + pos + n, c);
+
+  return b + pos;
+}
+
+template <typename E, class T, class A, class S>
+template <class InputIter>
+inline typename basic_fbstring<E, T, A, S>::iterator
+basic_fbstring<E, T, A, S>::insertImplDiscr(
+    const_iterator i, InputIter b, InputIter e, std::false_type) {
+  return insertImpl(
+      i, b, e, typename std::iterator_traits<InputIter>::iterator_category());
+}
+
+template <typename E, class T, class A, class S>
+template <class FwdIterator>
+inline typename basic_fbstring<E, T, A, S>::iterator
+basic_fbstring<E, T, A, S>::insertImpl(
+    const_iterator i,
+    FwdIterator s1,
+    FwdIterator s2,
+    std::forward_iterator_tag) {
+  Invariant checker(*this);
+
+  assert(i >= cbegin() && i <= cend());
+  const size_type pos = i - cbegin();
+  auto n = std::distance(s1, s2);
+  assert(n >= 0);
+
+  auto oldSize = size();
+  store_.expandNoinit(n, /* expGrowth = */ true);
+  auto b = begin();
+  fbstring_detail::podMove(b + pos, b + oldSize, b + pos + n);
+  std::copy(s1, s2, b + pos);
+
+  return b + pos;
+}
+
+template <typename E, class T, class A, class S>
+template <class InputIterator>
+inline typename basic_fbstring<E, T, A, S>::iterator
+basic_fbstring<E, T, A, S>::insertImpl(
+    const_iterator i,
+    InputIterator b,
+    InputIterator e,
+    std::input_iterator_tag) {
+  const auto pos = i - cbegin();
+  basic_fbstring temp(cbegin(), i);
+  for (; b != e; ++b) {
+    temp.push_back(*b);
+  }
+  temp.append(i, cend());
+  swap(temp);
+  return begin() + pos;
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::replaceImplDiscr(
+    iterator i1,
+    iterator i2,
+    const value_type* s,
+    size_type n,
+    std::integral_constant<int, 2>) {
+  assert(i1 <= i2);
+  assert(begin() <= i1 && i1 <= end());
+  assert(begin() <= i2 && i2 <= end());
+  return replace(i1, i2, s, s + n);
+}
+
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::replaceImplDiscr(
+    iterator i1,
+    iterator i2,
+    size_type n2,
+    value_type c,
+    std::integral_constant<int, 1>) {
+  const size_type n1 = i2 - i1;
+  if (n1 > n2) {
+    std::fill(i1, i1 + n2, c);
+    erase(i1 + n2, i2);
+  } else {
+    std::fill(i1, i2, c);
+    insert(i2, n2 - n1, c);
+  }
+  assert(isSane());
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+template <class InputIter>
+inline basic_fbstring<E, T, A, S>& basic_fbstring<E, T, A, S>::replaceImplDiscr(
+    iterator i1,
+    iterator i2,
+    InputIter b,
+    InputIter e,
+    std::integral_constant<int, 0>) {
+  using Cat = typename std::iterator_traits<InputIter>::iterator_category;
+  replaceImpl(i1, i2, b, e, Cat());
+  return *this;
+}
+
+template <typename E, class T, class A, class S>
+template <class FwdIterator>
+inline bool basic_fbstring<E, T, A, S>::replaceAliased(
+    iterator i1, iterator i2, FwdIterator s1, FwdIterator s2, std::true_type) {
+  std::less_equal<const value_type*> le{};
+  const bool aliased = le(&*begin(), &*s1) && le(&*s1, &*end());
+  if (!aliased) {
+    return false;
+  }
+  // Aliased replace, copy to new string
+  basic_fbstring temp;
+  temp.reserve(size() - (i2 - i1) + std::distance(s1, s2));
+  temp.append(begin(), i1).append(s1, s2).append(i2, end());
+  swap(temp);
+  return true;
+}
+
+template <typename E, class T, class A, class S>
+template <class FwdIterator>
+inline void basic_fbstring<E, T, A, S>::replaceImpl(
+    iterator i1,
+    iterator i2,
+    FwdIterator s1,
+    FwdIterator s2,
+    std::forward_iterator_tag) {
+  Invariant checker(*this);
+
+  // Handle aliased replace
+  using Sel = std::bool_constant<
+      std::is_same<FwdIterator, iterator>::value ||
+      std::is_same<FwdIterator, const_iterator>::value>;
+  if (replaceAliased(i1, i2, s1, s2, Sel())) {
+    return;
+  }
+
+  auto const n1 = i2 - i1;
+  assert(n1 >= 0);
+  auto const n2 = std::distance(s1, s2);
+  assert(n2 >= 0);
+
+  if (n1 > n2) {
+    // shrinks
+    std::copy(s1, s2, i1);
+    erase(i1 + n2, i2);
+  } else {
+    // grows
+    s1 = fbstring_detail::copy_n(s1, n1, i1).first;
+    insert(i2, s1, s2);
+  }
+  assert(isSane());
+}
+
+template <typename E, class T, class A, class S>
+template <class InputIterator>
+inline void basic_fbstring<E, T, A, S>::replaceImpl(
+    iterator i1,
+    iterator i2,
+    InputIterator b,
+    InputIterator e,
+    std::input_iterator_tag) {
+  basic_fbstring temp(begin(), i1);
+  temp.append(b, e).append(i2, end());
+  swap(temp);
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::rfind(
+    const value_type* s, size_type pos, size_type n) const {
+  if (n > length()) {
+    return npos;
+  }
+  pos = std::min(pos, length() - n);
+  if (n == 0) {
+    return pos;
+  }
+
+  for (const_iterator i(begin() + pos);; --i) {
+    if (traits_type::eq(*i, *s) && traits_type::compare(&*i, s, n) == 0) {
+      return i - begin();
+    }
+    if (i == begin()) {
+      break;
+    }
+  }
+  return npos;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::find_first_of(
+    const value_type* s, size_type pos, size_type n) const {
+  if (pos > length() || n == 0) {
+    return npos;
+  }
+  const_iterator i(begin() + pos), finish(end());
+  for (; i != finish; ++i) {
+    if (traits_type::find(s, n, *i) != nullptr) {
+      return i - begin();
+    }
+  }
+  return npos;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::find_last_of(
+    const value_type* s, size_type pos, size_type n) const {
+  if (!empty() && n > 0) {
+    pos = std::min(pos, length() - 1);
+    const_iterator i(begin() + pos);
+    for (;; --i) {
+      if (traits_type::find(s, n, *i) != nullptr) {
+        return i - begin();
+      }
+      if (i == begin()) {
+        break;
+      }
+    }
+  }
+  return npos;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::find_first_not_of(
+    const value_type* s, size_type pos, size_type n) const {
+  if (pos < length()) {
+    const_iterator i(begin() + pos), finish(end());
+    for (; i != finish; ++i) {
+      if (traits_type::find(s, n, *i) == nullptr) {
+        return i - begin();
+      }
+    }
+  }
+  return npos;
+}
+
+template <typename E, class T, class A, class S>
+inline typename basic_fbstring<E, T, A, S>::size_type
+basic_fbstring<E, T, A, S>::find_last_not_of(
+    const value_type* s, size_type pos, size_type n) const {
+  if (!this->empty()) {
+    pos = std::min(pos, size() - 1);
+    const_iterator i(begin() + pos);
+    for (;; --i) {
+      if (traits_type::find(s, n, *i) == nullptr) {
+        return i - begin();
+      }
+      if (i == begin()) {
+        break;
+      }
+    }
+  }
+  return npos;
+}
+
+// non-member functions
+// C++11 21.4.8.1/1
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  basic_fbstring<E, T, A, S> result;
+  result.reserve(lhs.size() + rhs.size());
+  result.append(lhs).append(rhs);
+  return result;
+}
+
+// C++11 21.4.8.1/2
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    basic_fbstring<E, T, A, S>&& lhs, const basic_fbstring<E, T, A, S>& rhs) {
+  return std::move(lhs.append(rhs));
+}
+
+// C++11 21.4.8.1/3
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const basic_fbstring<E, T, A, S>& lhs, basic_fbstring<E, T, A, S>&& rhs) {
+  if (rhs.capacity() >= lhs.size() + rhs.size()) {
+    // Good, at least we don't need to reallocate
+    return std::move(rhs.insert(0, lhs));
+  }
+  // Meh, no go. Forward to operator+(const&, const&).
+  auto const& rhsC = rhs;
+  return lhs + rhsC;
+}
+
+// C++11 21.4.8.1/4
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    basic_fbstring<E, T, A, S>&& lhs, basic_fbstring<E, T, A, S>&& rhs) {
+  return std::move(lhs.append(rhs));
+}
+
+// C++11 21.4.8.1/5
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const E* lhs, const basic_fbstring<E, T, A, S>& rhs) {
+  //
+  basic_fbstring<E, T, A, S> result;
+  const auto len = basic_fbstring<E, T, A, S>::traits_type::length(lhs);
+  result.reserve(len + rhs.size());
+  result.append(lhs, len).append(rhs);
+  return result;
+}
+
+// C++11 21.4.8.1/6
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const E* lhs, basic_fbstring<E, T, A, S>&& rhs) {
+  //
+  const auto len = basic_fbstring<E, T, A, S>::traits_type::length(lhs);
+  if (rhs.capacity() >= len + rhs.size()) {
+    // Good, at least we don't need to reallocate
+    rhs.insert(rhs.begin(), lhs, lhs + len);
+    return std::move(rhs);
+  }
+  // Meh, no go. Do it by hand since we have len already.
+  basic_fbstring<E, T, A, S> result;
+  result.reserve(len + rhs.size());
+  result.append(lhs, len).append(rhs);
+  return result;
+}
+
+// C++11 21.4.8.1/7
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    E lhs, const basic_fbstring<E, T, A, S>& rhs) {
+  basic_fbstring<E, T, A, S> result;
+  result.reserve(1 + rhs.size());
+  result.push_back(lhs);
+  result.append(rhs);
+  return result;
+}
+
+// C++11 21.4.8.1/8
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    E lhs, basic_fbstring<E, T, A, S>&& rhs) {
+  //
+  if (rhs.capacity() > rhs.size()) {
+    // Good, at least we don't need to reallocate
+    rhs.insert(rhs.begin(), lhs);
+    return std::move(rhs);
+  }
+  // Meh, no go. Forward to operator+(E, const&).
+  auto const& rhsC = rhs;
+  return lhs + rhsC;
+}
+
+// C++11 21.4.8.1/9
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const basic_fbstring<E, T, A, S>& lhs, const E* rhs) {
+  typedef typename basic_fbstring<E, T, A, S>::size_type size_type;
+  typedef typename basic_fbstring<E, T, A, S>::traits_type traits_type;
+
+  basic_fbstring<E, T, A, S> result;
+  const size_type len = traits_type::length(rhs);
+  result.reserve(lhs.size() + len);
+  result.append(lhs).append(rhs, len);
+  return result;
+}
+
+// C++11 21.4.8.1/10
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    basic_fbstring<E, T, A, S>&& lhs, const E* rhs) {
+  //
+  return std::move(lhs += rhs);
+}
+
+// C++11 21.4.8.1/11
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    const basic_fbstring<E, T, A, S>& lhs, E rhs) {
+  basic_fbstring<E, T, A, S> result;
+  result.reserve(lhs.size() + 1);
+  result.append(lhs);
+  result.push_back(rhs);
+  return result;
+}
+
+// C++11 21.4.8.1/12
+template <typename E, class T, class A, class S>
+inline basic_fbstring<E, T, A, S> operator+(
+    basic_fbstring<E, T, A, S>&& lhs, E rhs) {
+  //
+  return std::move(lhs += rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator==(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return lhs.size() == rhs.size() && lhs.compare(rhs) == 0;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator==(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs == lhs;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator==(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return lhs.compare(rhs) == 0;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator!=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator!=(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator!=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return lhs.compare(rhs) < 0;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return lhs.compare(rhs) < 0;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs.compare(lhs) > 0;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs < lhs;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return rhs < lhs;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs < lhs;
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(rhs < lhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return !(rhs < lhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator<=(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(rhs < lhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs < rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const typename basic_fbstring<E, T, A, S>::value_type* rhs) {
+  return !(lhs < rhs);
+}
+
+template <typename E, class T, class A, class S>
+inline bool operator>=(
+    const typename basic_fbstring<E, T, A, S>::value_type* lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs < rhs);
+}
+
+// C++11 21.4.8.8
+template <typename E, class T, class A, class S>
+void swap(basic_fbstring<E, T, A, S>& lhs, basic_fbstring<E, T, A, S>& rhs) {
+  lhs.swap(rhs);
+}
+
+// TODO: make this faster.
+template <typename E, class T, class A, class S>
+inline std::basic_istream<
+    typename basic_fbstring<E, T, A, S>::value_type,
+    typename basic_fbstring<E, T, A, S>::traits_type>&
+operator>>(
+    std::basic_istream<
+        typename basic_fbstring<E, T, A, S>::value_type,
+        typename basic_fbstring<E, T, A, S>::traits_type>& is,
+    basic_fbstring<E, T, A, S>& str) {
+  typedef std::basic_istream<
+      typename basic_fbstring<E, T, A, S>::value_type,
+      typename basic_fbstring<E, T, A, S>::traits_type>
+      _istream_type;
+  typename _istream_type::sentry sentry(is);
+  size_t extracted = 0;
+  typename _istream_type::iostate err = _istream_type::goodbit;
+  if (sentry) {
+    auto n = is.width();
+    if (n <= 0) {
+      n = str.max_size();
+    }
+    str.erase();
+    for (auto got = is.rdbuf()->sgetc(); extracted != size_t(n); ++extracted) {
+      if (got == T::eof()) {
+        err |= _istream_type::eofbit;
+        is.width(0);
+        break;
+      }
+      if (isspace(got)) {
+        break;
+      }
+      str.push_back(got);
+      got = is.rdbuf()->snextc();
+    }
+  }
+  if (!extracted) {
+    err |= _istream_type::failbit;
+  }
+  if (err) {
+    is.setstate(err);
+  }
+  return is;
+}
+
+template <typename E, class T, class A, class S>
+inline std::basic_ostream<
+    typename basic_fbstring<E, T, A, S>::value_type,
+    typename basic_fbstring<E, T, A, S>::traits_type>&
+operator<<(
+    std::basic_ostream<
+        typename basic_fbstring<E, T, A, S>::value_type,
+        typename basic_fbstring<E, T, A, S>::traits_type>& os,
+    const basic_fbstring<E, T, A, S>& str) {
+#ifdef _LIBCPP_VERSION
+  typedef std::basic_ostream<
+      typename basic_fbstring<E, T, A, S>::value_type,
+      typename basic_fbstring<E, T, A, S>::traits_type>
+      _ostream_type;
+  typename _ostream_type::sentry _s(os);
+  if (_s) {
+    typedef std::ostreambuf_iterator<
+        typename basic_fbstring<E, T, A, S>::value_type,
+        typename basic_fbstring<E, T, A, S>::traits_type>
+        _Ip;
+    size_t __len = str.size();
+    bool __left =
+        (os.flags() & _ostream_type::adjustfield) == _ostream_type::left;
+    if (__pad_and_output(
+            _Ip(os),
+            str.data(),
+            __left ? str.data() + __len : str.data(),
+            str.data() + __len,
+            os,
+            os.fill())
+            .failed()) {
+      os.setstate(_ostream_type::badbit | _ostream_type::failbit);
+    }
+  }
+#elif defined(_MSC_VER)
+  typedef decltype(os.precision()) streamsize;
+  // MSVC doesn't define __ostream_insert
+  os.write(str.data(), static_cast<streamsize>(str.size()));
+#else
+  std::__ostream_insert(os, str.data(), str.size());
+#endif
+  return os;
+}
+
+template <typename E1, class T, class A, class S>
+constexpr typename basic_fbstring<E1, T, A, S>::size_type
+    basic_fbstring<E1, T, A, S>::npos;
+
+// basic_string compatibility routines
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator==(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return lhs.compare(0, lhs.size(), rhs.data(), rhs.size()) == 0;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator==(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs == lhs;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator!=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator!=(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs == rhs);
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator<(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return lhs.compare(0, lhs.size(), rhs.data(), rhs.size()) < 0;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator>(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return lhs.compare(0, lhs.size(), rhs.data(), rhs.size()) > 0;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator<(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs > lhs;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator>(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return rhs < lhs;
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator<=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return !(lhs > rhs);
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator>=(
+    const basic_fbstring<E, T, A, S>& lhs,
+    const std::basic_string<E, T, A2>& rhs) {
+  return !(lhs < rhs);
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator<=(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs > rhs);
+}
+
+template <typename E, class T, class A, class S, class A2>
+inline bool operator>=(
+    const std::basic_string<E, T, A2>& lhs,
+    const basic_fbstring<E, T, A, S>& rhs) {
+  return !(lhs < rhs);
+}
+
+typedef basic_fbstring<char> fbstring;
+
+// Compatibility function, to make sure toStdString(s) can be called
+// to convert a std::string or fbstring variable s into type std::string
+// with very little overhead if s was already std::string
+inline std::string toStdString(const folly::fbstring& s) {
+  return std::string(s.data(), s.size());
+}
+
+inline const std::string& toStdString(const std::string& s) {
+  return s;
+}
+
+// If called with a temporary, the compiler will select this overload instead
+// of the above, so we don't return a (lvalue) reference to a temporary.
+inline std::string&& toStdString(std::string&& s) {
+  return std::move(s);
+}
+
+} // namespace folly
+
+// Hash functions to make fbstring usable with e.g. unordered_map
+
+#define FOLLY_FBSTRING_HASH1(T)                                        \
+  template <>                                                          \
+  struct hash<::folly::basic_fbstring<T>> {                            \
+    size_t operator()(const ::folly::basic_fbstring<T>& s) const {     \
+      return std::hash<std::string_view>()(std::string_view(s.data(), s.size())); \
+    }                                                                  \
+  };
+
+// The C++11 standard says that these four are defined for basic_string
+#define FOLLY_FBSTRING_HASH      \
+  FOLLY_FBSTRING_HASH1(char)
+
+namespace std {
+
+FOLLY_FBSTRING_HASH
+
+} // namespace std
+
+#undef FOLLY_FBSTRING_HASH
+#undef FOLLY_FBSTRING_HASH1
+
+FOLLY_POP_WARNING
+
+#undef FOLLY_SANITIZE_ADDRESS
+#undef FBSTRING_DISABLE_SSO
+
+namespace folly {
+template <class T>
+struct IsSomeString;
+
+template <>
+struct IsSomeString<fbstring> : std::true_type {};
+} // namespace folly
+// clang-format on

--- a/src/tech/include/simpletable.hpp
+++ b/src/tech/include/simpletable.hpp
@@ -9,6 +9,7 @@
 #include <variant>
 
 #include "cct_string.hpp"
+#include "cct_type_traits.hpp"
 #include "cct_vector.hpp"
 
 namespace cct {
@@ -40,6 +41,8 @@ class SimpleTable {
     explicit Cell(IntegralType v) : _data(v) {}
 
     size_type size() const noexcept;
+
+    using trivially_relocatable = is_trivially_relocatable<string>::type;
 
    private:
     friend class Row;
@@ -77,6 +80,8 @@ class SimpleTable {
     value_type &operator[](size_type cellPos) { return _cells[cellPos]; }
     const value_type &operator[](size_type cellPos) const { return _cells[cellPos]; }
 
+    using trivially_relocatable = is_trivially_relocatable<vector<value_type>>::type;
+
    private:
     friend class SimpleTable;
 
@@ -112,6 +117,8 @@ class SimpleTable {
   void reserve(size_type s) { _rows.reserve(s); }
 
   void print(std::ostream &os = std::cout) const;
+
+  using trivially_relocatable = is_trivially_relocatable<vector<Row>>::type;
 
  private:
   vector<Row> _rows;

--- a/src/tech/src/commandlineoption.cpp
+++ b/src/tech/src/commandlineoption.cpp
@@ -27,24 +27,28 @@ CommandLineOption::Duration CommandLineOption::ParseDuration(std::string_view du
     throw InvalidArgumentException(kInvalidTimeDurationUnitMsg);
   }
   std::string_view timeAmountStr(durationStr.begin(), durationStr.begin() + endAmountPos);
-  int64_t timeAmount{};
+  int64_t timeAmount = 0;
   std::from_chars(timeAmountStr.data(), timeAmountStr.data() + timeAmountStr.size(), timeAmount);
   std::string_view timeUnitStr(durationStr.begin() + startTimeUnit, durationStr.end());
   if (timeUnitStr == "h") {
     return std::chrono::hours(timeAmount);
-  } else if (timeUnitStr == "min") {
-    return std::chrono::minutes(timeAmount);
-  } else if (timeUnitStr == "s") {
-    return std::chrono::seconds(timeAmount);
-  } else if (timeUnitStr == "ms") {
-    return std::chrono::milliseconds(timeAmount);
-  } else if (timeUnitStr == "us") {
-    return std::chrono::microseconds(timeAmount);
-  } else if (timeUnitStr == "ns") {
-    return std::chrono::nanoseconds(timeAmount);
-  } else {
-    throw InvalidArgumentException(kInvalidTimeDurationUnitMsg);
   }
+  if (timeUnitStr == "min") {
+    return std::chrono::minutes(timeAmount);
+  }
+  if (timeUnitStr == "s") {
+    return std::chrono::seconds(timeAmount);
+  }
+  if (timeUnitStr == "ms") {
+    return std::chrono::milliseconds(timeAmount);
+  }
+  if (timeUnitStr == "us") {
+    return std::chrono::microseconds(timeAmount);
+  }
+  if (timeUnitStr == "ns") {
+    return std::chrono::nanoseconds(timeAmount);
+  }
+  throw InvalidArgumentException(kInvalidTimeDurationUnitMsg);
 }
 
 bool CommandLineOption::matches(std::string_view optName) const {

--- a/src/tech/test/cct_nonce_test.cpp
+++ b/src/tech/test/cct_nonce_test.cpp
@@ -27,7 +27,7 @@ TEST(NonceTest, LiteralDate) {
   EXPECT_LT(n1, n2);
 
   const std::regex dateRegex("[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}");
-  EXPECT_TRUE(std::regex_match(n1, dateRegex));
-  EXPECT_TRUE(std::regex_match(n2, dateRegex));
+  EXPECT_TRUE(std::regex_match(n1.begin(), n1.end(), dateRegex));
+  EXPECT_TRUE(std::regex_match(n2.begin(), n2.end(), dateRegex));
 }
 }  // namespace cct

--- a/src/tools/src/cct_file.cpp
+++ b/src/tools/src/cct_file.cpp
@@ -33,8 +33,8 @@ File::File(std::string_view dataDir, Type type, std::string_view name, IfNotFoun
 string File::read() const {
   log::debug("Opening file {} for reading", _filePath);
   string data;
-  if (_ifNotFound == IfNotFound::kThrow || std::filesystem::exists(_filePath)) {
-    std::ifstream file(_filePath);
+  if (_ifNotFound == IfNotFound::kThrow || std::filesystem::exists(_filePath.c_str())) {
+    std::ifstream file(_filePath.c_str());
     if (!file) {
       throw exception("Unable to open " + _filePath + " for reading");
     }
@@ -53,7 +53,7 @@ json File::readJson() const {
 
 void File::write(const json &data) const {
   log::debug("Opening file {} for writing", _filePath);
-  std::ofstream file(_filePath);
+  std::ofstream file(_filePath.c_str());
   if (!file) {
     throw exception("Unable to open " + _filePath + " for writing");
   }

--- a/src/tools/src/curlhandle.cpp
+++ b/src/tools/src/curlhandle.cpp
@@ -3,6 +3,7 @@
 #include <curl/curl.h>
 
 #include <cassert>
+#include <charconv>
 #include <iostream>
 #include <memory>
 #include <sstream>
@@ -13,6 +14,7 @@
 #include "abstractmetricgateway.hpp"
 #include "cct_exception.hpp"
 #include "cct_log.hpp"
+#include "cct_mathhelpers.hpp"
 #include "cct_proxy.hpp"
 
 namespace cct {
@@ -174,7 +176,11 @@ string CurlHandle::query(std::string_view url, const CurlOptions &opts) {
   // Actually make the query
   const CURLcode res = curl_easy_perform(curl);  // Get reply
   if (res != CURLE_OK) {
-    throw exception("Unexpected response from curl: Error " + std::to_string(res));
+    string ex("Unexpected response from curl: Error ");
+    const int nbDigitsRes = ndigits(static_cast<int>(res));
+    ex.resize(ex.size() + nbDigitsRes);
+    std::to_chars(ex.data() + ex.length() - nbDigitsRes, ex.data() + ex.length(), static_cast<int>(res));
+    throw exception(std::move(ex));
   }
 
   if (_pMetricGateway) {


### PR DESCRIPTION
Because it's lighter and slightly more efficient.
Also, it's trivially relocatable so optimized when used in amc::vector (see [this repo](https://github.com/AmadeusITGroup/amc) if you wish to know more information about trivial relocatibilty)