### PR TITLE
Implementation of command line option get Deposit information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.15)
 
-project(coincenter VERSION 3.5.0
+project(coincenter VERSION 3.6.0
                    DESCRIPTION "A C++ library centralizing several crypto currencies exchanges REST API into a single all in one tool with a unified interface"
                    LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Main features:
 **Private requests**
  - Balance
  - Trade (in several flavors)
+ - Deposit information (address & tag)
  - Withdraw (with check at destination that funds are well received)
   
 **Supported exchanges**
@@ -76,6 +77,7 @@ Main features:
     - [Single Trade](#single-trade)
     - [Multi Trade](#multi-trade)
       - [Trade simulation](#trade-simulation)
+    - [Deposit information](#deposit-information)
     - [Withdraw coin](#withdraw-coin)
   - [Monitoring options](#monitoring-options)
     - [Repeat](#repeat)
@@ -483,14 +485,24 @@ If you want to trade coin *AAA* into *CCC* but exchange does not have a *AAA-CCC
 
 Some exchanges (**Kraken** and **Binance** for instance) allow to actually query their REST API in simulation mode to validate the query and not perform the trade. It is possible to do this with `--trade-sim` option. For exchanges which do not support this validation mode, `coincenter` will simply directly finish the trade entirely (taking fees into account) ignoring the trade strategy.
 
+### Deposit information
+
+You can retrieve one deposit address and tag from your accounts on a given currency provided that the exchange can receive it with `--deposit-info` option. It requires a currency code, and an optional list of exchanges (private or public names, see [Handle several accounts per exchange](#handle-several-accounts-per-exchange)). If no exchanges are given, program will query all accounts and retrieve the possible ones.
+
+If for a given exchange account a deposit address is not created yet, `coincenter` will create one automatically.
+
+Only one deposit address per currency / account is returned.
+
+**Important note**: only addresses which are validated against the `depositaddresses.json` file will be returned (unless option `validatedepositaddressesinfile` is set to `false` in `static/exchangeconfig.json` file). This file allows you to control addresses to which `coincenter` can send funds, even if you have more deposit addresses already configured.
+
 ### Withdraw coin
 
 It is possible to withdraw coin with `coincenter` as well, in a synchronized mode (withdraw will check that funds are well received at destination).
 Some exchanges require that external addresses are validated prior to their usage in the API (*Kraken* and *Huobi* for instance).
 
 To ensure maximum safety, there are two checks performed by `coincenter` prior to all withdraw launches:
- - External address is not taken as an input parameter, but instead dynamically retrieved from the REST API `getDepositAddress` of the destination exchange
- - By default (can be configured in `static/exchangeconfig.json`) deposit address is validated in `<DataDir>/secret/depositaddresses.json` which serves as a *portfolio* of trusted addresses
+ - External address is not taken as an input parameter, but instead dynamically retrieved from the REST API `getDepositAddress` of the destination exchange (see [Deposit information](#deposit-information))
+ - By default (can be configured in `static/exchangeconfig.json` with boolean value `validatedepositaddressesinfile`) deposit address is validated in `<DataDir>/secret/depositaddresses.json` which serves as a *portfolio* of trusted addresses
 
 Example: Withdraw 10000 XLM (Stellar) from Bithumb to Huobi:
 ```

--- a/src/api/common/include/cryptowatchapi.hpp
+++ b/src/api/common/include/cryptowatchapi.hpp
@@ -81,7 +81,7 @@ class CryptowatchAPI : public ExchangeBase {
   };
 
   CachedResultVault _cachedResultVault;
-  const CoincenterInfo &_config;
+  const CoincenterInfo &_coincenterInfo;
   CurlHandle _curlHandle;
   std::mutex _pricesMutex, _fiatsMutex, _exchangesMutex;
   CachedResult<FiatsFunc> _fiatsCache;

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -83,12 +83,18 @@ class ExchangePrivate : public ExchangeBase {
     return _exchangePublic.queryWithdrawalFee(currencyCode);
   }
 
+  PrivateExchangeName createPrivateExchangeName() const {
+    return PrivateExchangeName(_exchangePublic.name(), _apiKey.name());
+  }
+
+  const ExchangeInfo &exchangeInfo() const { return _coincenterInfo.exchangeInfo(_exchangePublic.name()); }
+
  protected:
-  ExchangePrivate(ExchangePublic &exchangePublic, const CoincenterInfo &config, const APIKey &apiKey)
+  ExchangePrivate(ExchangePublic &exchangePublic, const CoincenterInfo &coincenterInfo, const APIKey &apiKey)
       : ExchangeBase(),
         _exchangePublic(exchangePublic),
         _cachedResultVault(exchangePublic._cachedResultVault),
-        _coincenterInfo(config),
+        _coincenterInfo(coincenterInfo),
         _apiKey(apiKey) {}
 
   virtual BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) = 0;

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -88,7 +88,7 @@ class ExchangePrivate : public ExchangeBase {
       : ExchangeBase(),
         _exchangePublic(exchangePublic),
         _cachedResultVault(exchangePublic._cachedResultVault),
-        _config(config),
+        _coincenterInfo(config),
         _apiKey(apiKey) {}
 
   virtual BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) = 0;
@@ -129,7 +129,7 @@ class ExchangePrivate : public ExchangeBase {
 
   ExchangePublic &_exchangePublic;
   CachedResultVault &_cachedResultVault;
-  const CoincenterInfo &_config;
+  const CoincenterInfo &_coincenterInfo;
   const APIKey &_apiKey;
 };
 }  // namespace api

--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -45,13 +45,13 @@ File GetFiatCacheFile(std::string_view dataDir) {
 
 CryptowatchAPI::CryptowatchAPI(const CoincenterInfo& config, settings::RunMode runMode,
                                Clock::duration fiatsUpdateFrequency, bool loadFromFileCacheAtInit)
-    : _config(config),
+    : _coincenterInfo(config),
       _curlHandle(config.metricGatewayPtr(), Clock::duration::zero(), runMode),
       _fiatsCache(CachedResultOptions(fiatsUpdateFrequency, _cachedResultVault), _curlHandle),
       _supportedExchanges(CachedResultOptions(std::chrono::hours(96), _cachedResultVault), _curlHandle),
       _allPricesCache(CachedResultOptions(std::chrono::seconds(30), _cachedResultVault), _curlHandle) {
   if (loadFromFileCacheAtInit) {
-    json data = GetFiatCacheFile(_config.dataDir()).readJson();
+    json data = GetFiatCacheFile(_coincenterInfo.dataDir()).readJson();
     if (!data.empty()) {
       const int64_t timeepoch = data["timeepoch"].get<int64_t>();
       const auto& fiatsFile = data["fiats"];
@@ -127,7 +127,7 @@ json CryptowatchAPI::AllPricesFunc::operator()() {
 }
 
 void CryptowatchAPI::updateCacheFile() const {
-  File fiatsCacheFile = GetFiatCacheFile(_config.dataDir());
+  File fiatsCacheFile = GetFiatCacheFile(_coincenterInfo.dataDir());
   json data = fiatsCacheFile.readJson();
   auto fiatsPtrLastUpdatedTimePair = _fiatsCache.retrieve();
   auto timeEpochIt = data.find("timeepoch");

--- a/src/api/common/src/exchangeprivateapi.cpp
+++ b/src/api/common/src/exchangeprivateapi.cpp
@@ -99,7 +99,7 @@ MonetaryAmount ExchangePrivate::singleTrade(MonetaryAmount &from, CurrencyCode t
       MonetaryAmount toAmount = fromCurrencyCode == m.quote() ? volume : volume.convertTo(price);
       ExchangeInfo::FeeType feeType =
           options.isTakerStrategy() ? ExchangeInfo::FeeType::kTaker : ExchangeInfo::FeeType::kMaker;
-      toAmount = _config.exchangeInfo(_exchangePublic.name()).applyFee(toAmount, feeType);
+      toAmount = _coincenterInfo.exchangeInfo(_exchangePublic.name()).applyFee(toAmount, feeType);
       from -= fromCurrencyCode == m.quote() ? volume.toNeutral() * price : volume;
       return toAmount;
     }

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -19,7 +19,7 @@ class BinancePrivate : public ExchangePrivate {
  public:
   BinancePrivate(const CoincenterInfo& config, BinancePublic& binancePublic, const APIKey& apiKey);
 
-  CurrencyExchangeFlatSet queryTradableCurrencies() override;
+  CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode::kNeutral) override;
 
@@ -55,6 +55,17 @@ class BinancePrivate : public ExchangePrivate {
 
   TradedAmounts parseTrades(Market m, CurrencyCode fromCurrencyCode, const json& fillDetail) const;
 
+  struct TradableCurrenciesCache {
+    TradableCurrenciesCache(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& binancePublic)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _public(binancePublic) {}
+
+    CurrencyExchangeFlatSet operator()();
+
+    CurlHandle& _curlHandle;
+    const APIKey& _apiKey;
+    BinancePublic& _public;
+  };
+
   struct DepositWalletFunc {
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& binancePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _public(binancePublic) {}
@@ -89,6 +100,7 @@ class BinancePrivate : public ExchangePrivate {
   };
 
   CurlHandle _curlHandle;
+  CachedResult<TradableCurrenciesCache> _tradableCurrenciesCache;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;
   CachedResult<AllWithdrawFeesFunc> _allWithdrawFeesCache;
   CachedResult<WithdrawFeesFunc, CurrencyCode> _withdrawFeesCache;

--- a/src/api/exchanges/include/binancepublicapi.hpp
+++ b/src/api/exchanges/include/binancepublicapi.hpp
@@ -30,7 +30,9 @@ class BinancePublic : public ExchangePublic {
   BinancePublic(const CoincenterInfo& coincenterInfo, FiatConverter& fiatConverter,
                 api::CryptowatchAPI& cryptowatchAPI);
 
-  CurrencyExchangeFlatSet queryTradableCurrencies() override;
+  CurrencyExchangeFlatSet queryTradableCurrencies() override {
+    return queryTradableCurrencies(_globalInfosCache.get());
+  }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode standardCode) override {
     return *queryTradableCurrencies().find(standardCode);
@@ -60,6 +62,8 @@ class BinancePublic : public ExchangePublic {
 
  private:
   friend class BinancePrivate;
+
+  CurrencyExchangeFlatSet queryTradableCurrencies(const json& data) const;
 
   class CommonInfo {
    public:

--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -50,11 +50,11 @@ class BithumbPublic : public ExchangePublic {
 
   struct TradableCurrenciesFunc {
     TradableCurrenciesFunc(const CoincenterInfo& config, CurlHandle& curlHandle)
-        : _config(config), _curlHandle(curlHandle) {}
+        : _coincenterInfo(config), _curlHandle(curlHandle) {}
 
     CurrencyExchangeFlatSet operator()();
 
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
   };
 
@@ -70,22 +70,22 @@ class BithumbPublic : public ExchangePublic {
 
   struct AllOrderBooksFunc {
     AllOrderBooksFunc(const CoincenterInfo& config, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
-        : _config(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+        : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
 
     MarketOrderBookMap operator()(int depth);
 
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
     const ExchangeInfo& _exchangeInfo;
   };
 
   struct OrderBookFunc {
     OrderBookFunc(const CoincenterInfo& config, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
-        : _config(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+        : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
 
     MarketOrderBook operator()(Market m, int depth);
 
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
     const ExchangeInfo& _exchangeInfo;
   };

--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -49,12 +49,13 @@ class BithumbPublic : public ExchangePublic {
   friend class BithumbPrivate;
 
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(const CoincenterInfo& config, CurlHandle& curlHandle)
-        : _coincenterInfo(config), _curlHandle(curlHandle) {}
+    TradableCurrenciesFunc(const CoincenterInfo& config, CryptowatchAPI& cryptowatchAPI, CurlHandle& curlHandle)
+        : _coincenterInfo(config), _cryptowatchAPI(cryptowatchAPI), _curlHandle(curlHandle) {}
 
     CurrencyExchangeFlatSet operator()();
 
     const CoincenterInfo& _coincenterInfo;
+    CryptowatchAPI& _cryptowatchAPI;
     CurlHandle& _curlHandle;
   };
 

--- a/src/api/exchanges/include/krakenpublicapi.hpp
+++ b/src/api/exchanges/include/krakenpublicapi.hpp
@@ -57,11 +57,11 @@ class KrakenPublic : public ExchangePublic {
 
   struct TradableCurrenciesFunc {
     TradableCurrenciesFunc(const CoincenterInfo& config, const ExchangeInfo& exchangeInfo, CurlHandle& curlHandle)
-        : _config(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+        : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
 
     CurrencyExchangeFlatSet operator()();
 
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
     const ExchangeInfo& _exchangeInfo;
   };
@@ -71,11 +71,12 @@ class KrakenPublic : public ExchangePublic {
     using WithdrawalInfoMaps = std::pair<WithdrawalFeeMap, WithdrawalMinMap>;
 
     WithdrawalFeesFunc(const CoincenterInfo& config, Clock::duration minDurationBetweenQueries)
-        : _config(config), _curlHandle(config.metricGatewayPtr(), minDurationBetweenQueries, config.getRunMode()) {}
+        : _coincenterInfo(config),
+          _curlHandle(config.metricGatewayPtr(), minDurationBetweenQueries, config.getRunMode()) {}
 
     WithdrawalInfoMaps operator()();
 
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle _curlHandle;
   };
 
@@ -83,7 +84,7 @@ class KrakenPublic : public ExchangePublic {
     MarketsFunc(const CoincenterInfo& config, CachedResult<TradableCurrenciesFunc>& currenciesCache,
                 CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _tradableCurrenciesCache(currenciesCache),
-          _config(config),
+          _coincenterInfo(config),
           _curlHandle(curlHandle),
           _exchangeInfo(exchangeInfo) {}
 
@@ -97,7 +98,7 @@ class KrakenPublic : public ExchangePublic {
     std::pair<MarketSet, MarketInfoMap> operator()();
 
     CachedResult<TradableCurrenciesFunc>& _tradableCurrenciesCache;
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
     const ExchangeInfo& _exchangeInfo;
   };
@@ -107,14 +108,14 @@ class KrakenPublic : public ExchangePublic {
                       CachedResult<MarketsFunc>& marketsCache, CurlHandle& curlHandle)
         : _tradableCurrenciesCache(currenciesCache),
           _marketsCache(marketsCache),
-          _config(config),
+          _coincenterInfo(config),
           _curlHandle(curlHandle) {}
 
     MarketOrderBookMap operator()(int depth);
 
     CachedResult<TradableCurrenciesFunc>& _tradableCurrenciesCache;
     CachedResult<MarketsFunc>& _marketsCache;
-    const CoincenterInfo& _config;
+    const CoincenterInfo& _coincenterInfo;
     CurlHandle& _curlHandle;
   };
 

--- a/src/api/exchanges/include/krakenpublicapi.hpp
+++ b/src/api/exchanges/include/krakenpublicapi.hpp
@@ -56,12 +56,17 @@ class KrakenPublic : public ExchangePublic {
   friend class KrakenPrivate;
 
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(const CoincenterInfo& config, const ExchangeInfo& exchangeInfo, CurlHandle& curlHandle)
-        : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+    TradableCurrenciesFunc(const CoincenterInfo& config, CryptowatchAPI& cryptowatchApi,
+                           const ExchangeInfo& exchangeInfo, CurlHandle& curlHandle)
+        : _coincenterInfo(config),
+          _cryptowatchApi(cryptowatchApi),
+          _curlHandle(curlHandle),
+          _exchangeInfo(exchangeInfo) {}
 
     CurrencyExchangeFlatSet operator()();
 
     const CoincenterInfo& _coincenterInfo;
+    CryptowatchAPI& _cryptowatchApi;
     CurlHandle& _curlHandle;
     const ExchangeInfo& _exchangeInfo;
   };

--- a/src/api/exchanges/include/kucoinpublicapi.hpp
+++ b/src/api/exchanges/include/kucoinpublicapi.hpp
@@ -66,8 +66,8 @@ class KucoinPublic : public ExchangePublic {
   friend class KucoinPrivate;
 
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(CurlHandle& curlHandle, const CoincenterInfo& coincenterInfo)
-        : _curlHandle(curlHandle), _coincenterInfo(coincenterInfo) {}
+    TradableCurrenciesFunc(CurlHandle& curlHandle, const CoincenterInfo& coincenterInfo, CryptowatchAPI& cryptowatchApi)
+        : _curlHandle(curlHandle), _coincenterInfo(coincenterInfo), _cryptowatchApi(cryptowatchApi) {}
 
     struct CurrencyInfo {
       explicit CurrencyInfo(CurrencyCode c) : currencyExchange(c, c, c) {}
@@ -86,6 +86,7 @@ class KucoinPublic : public ExchangePublic {
 
     CurlHandle& _curlHandle;
     const CoincenterInfo& _coincenterInfo;
+    CryptowatchAPI& _cryptowatchApi;
   };
 
   struct MarketsFunc {

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -47,16 +47,16 @@ class UpbitPrivate : public ExchangePrivate {
 
  private:
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic,
-                           const ExchangeInfo& exchangeInfo)
-        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic), _exchangeInfo(exchangeInfo) {}
+    TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, const ExchangeInfo& exchangeInfo,
+                           CryptowatchAPI& cryptowatchApi)
+        : _curlHandle(curlHandle), _apiKey(apiKey), _exchangeInfo(exchangeInfo), _cryptowatchApi(cryptowatchApi) {}
 
     CurrencyExchangeFlatSet operator()();
 
     CurlHandle& _curlHandle;
     const APIKey& _apiKey;
-    UpbitPublic& _exchangePublic;
     const ExchangeInfo& _exchangeInfo;
+    CryptowatchAPI& _cryptowatchApi;
   };
 
   struct DepositWalletFunc {

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -159,7 +159,7 @@ BithumbPrivate::BithumbPrivate(const CoincenterInfo& config, BithumbPublic& bith
       _depositWalletsCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kDepositWallet), _cachedResultVault),
           _curlHandle, _apiKey, _maxNbDecimalsUnitMap, bithumbPublic) {
-  json data = GetBithumbDecimalsCache(_config.dataDir()).readJson();
+  json data = GetBithumbDecimalsCache(_coincenterInfo.dataDir()).readJson();
   _maxNbDecimalsUnitMap.reserve(data.size());
   for (const auto& [currencyStr, nbDecimalsAndTimeData] : data.items()) {
     CurrencyCode currencyCode(currencyStr);
@@ -241,7 +241,7 @@ PlaceOrderInfo BithumbPrivate::placeOrder(MonetaryAmount /*from*/, MonetaryAmoun
   // Volume is gross amount if from amount is in quote currency, we should remove the fees
   if (fromCurrencyCode == m.quote()) {
     ExchangeInfo::FeeType feeType = isTakerStrategy ? ExchangeInfo::FeeType::kTaker : ExchangeInfo::FeeType::kMaker;
-    const ExchangeInfo& exchangeInfo = _config.exchangeInfo(_exchangePublic.name());
+    const ExchangeInfo& exchangeInfo = _coincenterInfo.exchangeInfo(_exchangePublic.name());
     volume = exchangeInfo.applyFee(volume, feeType);
   }
 
@@ -411,7 +411,7 @@ void BithumbPrivate::updateCacheFile() const {
         std::chrono::duration_cast<std::chrono::seconds>(nbDecimalsTimeValue.lastUpdatedTime.time_since_epoch())
             .count();
   }
-  GetBithumbDecimalsCache(_config.dataDir()).write(data);
+  GetBithumbDecimalsCache(_coincenterInfo.dataDir()).write(data);
 }
 
 }  // namespace api

--- a/src/api/exchanges/src/bithumbpublicapi.cpp
+++ b/src/api/exchanges/src/bithumbpublicapi.cpp
@@ -149,7 +149,7 @@ CurrencyExchangeFlatSet BithumbPublic::TradableCurrenciesFunc::operator()() {
   CurrencyExchangeFlatSet currencies;
   currencies.reserve(static_cast<CurrencyExchangeFlatSet::size_type>(result.size() + 1));
   for (const auto& [asset, withdrawalDeposit] : result.items()) {
-    CurrencyCode currencyCode(_config.standardizeCurrencyCode(asset));
+    CurrencyCode currencyCode(_coincenterInfo.standardizeCurrencyCode(asset));
     CurrencyCode exchangeCode(asset);
     CurrencyExchange newCurrency(currencyCode, exchangeCode, exchangeCode,
                                  withdrawalDeposit["deposit_status"] == 1 ? CurrencyExchange::Deposit::kAvailable
@@ -254,11 +254,12 @@ ExchangePublic::MarketOrderBookMap GetOrderbooks(CurlHandle& curlHandle, const C
 }  // namespace
 
 ExchangePublic::MarketOrderBookMap BithumbPublic::AllOrderBooksFunc::operator()(int) {
-  return GetOrderbooks(_curlHandle, _config, _exchangeInfo);
+  return GetOrderbooks(_curlHandle, _coincenterInfo, _exchangeInfo);
 }
 
 MarketOrderBook BithumbPublic::OrderBookFunc::operator()(Market m, int count) {
-  ExchangePublic::MarketOrderBookMap marketOrderBookMap = GetOrderbooks(_curlHandle, _config, _exchangeInfo, m, count);
+  ExchangePublic::MarketOrderBookMap marketOrderBookMap =
+      GetOrderbooks(_curlHandle, _coincenterInfo, _exchangeInfo, m, count);
   auto it = marketOrderBookMap.find(m);
   if (it == marketOrderBookMap.end()) {
     throw exception("Unexpected answer from get OrderBooks");

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -107,12 +107,14 @@ Wallet HuobiPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
                              {{"currency", lowerCaseCur}});
   std::string_view address, tag;
   PrivateExchangeName privateExchangeName(_huobiPublic.name(), _apiKey.name());
-  std::string_view dataDir = _huobiPublic.coincenterInfo().dataDir();
+  const CoincenterInfo& coincenterInfo = _huobiPublic.coincenterInfo();
+  std::string_view dataDir = coincenterInfo.dataDir();
+  const bool validateWallet = coincenterInfo.exchangeInfo(_huobiPublic.name()).validateDepositAddressesInFile();
   for (const json& depositDetail : result["data"]) {
     address = depositDetail["address"].get<std::string_view>();
     tag = depositDetail["addressTag"].get<std::string_view>();
 
-    if (Wallet::IsAddressPresentInDepositFile(dataDir, privateExchangeName, currencyCode, address, tag)) {
+    if (!validateWallet || Wallet::ValidateWallet(dataDir, privateExchangeName, currencyCode, address, tag)) {
       break;
     }
     log::warn("{} & tag {} are not validated in the deposit addresses file", address, tag);

--- a/src/api/exchanges/src/huobipublicapi.cpp
+++ b/src/api/exchanges/src/huobipublicapi.cpp
@@ -88,7 +88,9 @@ CurrencyExchangeFlatSet HuobiPublic::queryTradableCurrencies() {
                                    depositAllowedStr == "allowed" ? CurrencyExchange::Deposit::kAvailable
                                                                   : CurrencyExchange::Deposit::kUnavailable,
                                    withdrawAllowedStr == "allowed" ? CurrencyExchange::Withdraw::kAvailable
-                                                                   : CurrencyExchange::Withdraw::kUnavailable);
+                                                                   : CurrencyExchange::Withdraw::kUnavailable,
+                                   _cryptowatchApi.queryIsCurrencyCodeFiat(cur) ? CurrencyExchange::Type::kFiat
+                                                                                : CurrencyExchange::Type::kCrypto);
       if (currencies.contains(newCurrency)) {
         log::error("Duplicated {}", newCurrency.str());
       } else {

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -102,7 +102,7 @@ BalancePortfolio KrakenPrivate::queryAccountBalance(CurrencyCode equiCurrency) {
   // Kraken returns an empty array in case of account with no balance at all
   for (const auto& [curCode, amountStr] : res.items()) {
     string amount = amountStr;
-    CurrencyCode currencyCode(_config.standardizeCurrencyCode(curCode));
+    CurrencyCode currencyCode(_coincenterInfo.standardizeCurrencyCode(curCode));
 
     addBalance(balancePortfolio, MonetaryAmount(std::move(amount), currencyCode), equiCurrency);
   }

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -83,7 +83,7 @@ KrakenPublic::KrakenPublic(const CoincenterInfo& config, FiatConverter& fiatConv
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(_name).minPublicQueryDelay(), config.getRunMode()),
       _tradableCurrenciesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kCurrencies), _cachedResultVault), config,
-          config.exchangeInfo(_name), _curlHandle),
+          cryptowatchAPI, config.exchangeInfo(_name), _curlHandle),
       _withdrawalFeesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kWithdrawalFees), _cachedResultVault),
           config, config.exchangeInfo(_name).minPublicQueryDelay()),
@@ -261,7 +261,10 @@ CurrencyExchangeFlatSet KrakenPublic::TradableCurrenciesFunc::operator()() {
     }
     CurrencyCode standardCode(_coincenterInfo.standardizeCurrencyCode(altCodeStr));
     CurrencyExchange newCurrency(standardCode, CurrencyCode(krakenAssetName), CurrencyCode(altCodeStr),
-                                 CurrencyExchange::Deposit::kAvailable, CurrencyExchange::Withdraw::kAvailable);
+                                 CurrencyExchange::Deposit::kAvailable, CurrencyExchange::Withdraw::kAvailable,
+                                 _cryptowatchApi.queryIsCurrencyCodeFiat(standardCode)
+                                     ? CurrencyExchange::Type::kFiat
+                                     : CurrencyExchange::Type::kCrypto);
 
     if (currencies.contains(newCurrency)) {
       log::error("Duplicated {}", newCurrency.str());

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -135,7 +135,7 @@ BalancePortfolio KucoinPrivate::queryAccountBalance(CurrencyCode equiCurrency) {
   for (const json& balanceDetail : result) {
     std::string_view typeStr = balanceDetail["type"].get<std::string_view>();
     CurrencyCode currencyCode(
-        _config.standardizeCurrencyCode(CurrencyCode(balanceDetail["currency"].get<std::string_view>())));
+        _coincenterInfo.standardizeCurrencyCode(CurrencyCode(balanceDetail["currency"].get<std::string_view>())));
     MonetaryAmount amount(balanceDetail["available"].get<std::string_view>(), currencyCode);
     log::debug("{} in account '{}' on {}", amount.str(), typeStr, _exchangePublic.name());
     this->addBalance(balancePortfolio, amount, equiCurrency);

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -153,17 +153,12 @@ Wallet KucoinPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
   } else {
     result = result.front();
   }
-  PrivateExchangeName privateExchangeName(_kucoinPublic.name(), _apiKey.name());
+
   std::string_view address = result["address"].get<std::string_view>();
   std::string_view tag = result["memo"].get<std::string_view>();
-  std::string_view dataDir = _kucoinPublic.coincenterInfo().dataDir();
-  if (!Wallet::IsAddressPresentInDepositFile(dataDir, privateExchangeName, currencyCode, address, tag)) {
-    log::warn("{} & tag {} are not validated in the deposit addresses file", address, tag);
-    address = std::string_view();
-    tag = std::string_view();
-  }
 
-  Wallet w(privateExchangeName, currencyCode, address, tag, _kucoinPublic.coincenterInfo());
+  Wallet w(PrivateExchangeName(_kucoinPublic.name(), _apiKey.name()), currencyCode, address, tag,
+           _kucoinPublic.coincenterInfo());
   log::info("Retrieved {}", w.str());
   return w;
 }

--- a/src/api/exchanges/src/kucoinpublicapi.cpp
+++ b/src/api/exchanges/src/kucoinpublicapi.cpp
@@ -45,7 +45,7 @@ KucoinPublic::KucoinPublic(const CoincenterInfo& config, FiatConverter& fiatConv
       _curlHandle(config.metricGatewayPtr(), _exchangeInfo.minPublicQueryDelay(), config.getRunMode()),
       _tradableCurrenciesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kCurrencies), _cachedResultVault),
-          _curlHandle, _coincenterInfo),
+          _curlHandle, _coincenterInfo, cryptowatchAPI),
       _marketsCache(CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kMarkets), _cachedResultVault),
                     _curlHandle, _exchangeInfo),
       _allOrderBooksCache(
@@ -72,7 +72,9 @@ KucoinPublic::TradableCurrenciesFunc::CurrencyInfoSet KucoinPublic::TradableCurr
                          curDetail["isDepositEnabled"].get<bool>() ? CurrencyExchange::Deposit::kAvailable
                                                                    : CurrencyExchange::Deposit::kUnavailable,
                          curDetail["isWithdrawEnabled"].get<bool>() ? CurrencyExchange::Withdraw::kAvailable
-                                                                    : CurrencyExchange::Withdraw::kUnavailable));
+                                                                    : CurrencyExchange::Withdraw::kUnavailable,
+                         _cryptowatchApi.queryIsCurrencyCodeFiat(cur) ? CurrencyExchange::Type::kFiat
+                                                                      : CurrencyExchange::Type::kCrypto));
     currencyInfo.withdrawalMinFee = MonetaryAmount(curDetail["withdrawalMinFee"].get<std::string_view>(), cur);
     currencyInfo.withdrawalMinSize = MonetaryAmount(curDetail["withdrawalMinSize"].get<std::string_view>(), cur);
 

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -181,7 +181,7 @@ PlaceOrderInfo UpbitPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volu
   if (fromCurrencyCode == m.quote()) {
     // For 'buy', from amount is fee excluded
     ExchangeInfo::FeeType feeType = isTakerStrategy ? ExchangeInfo::FeeType::kTaker : ExchangeInfo::FeeType::kMaker;
-    const ExchangeInfo& exchangeInfo = _config.exchangeInfo(_exchangePublic.name());
+    const ExchangeInfo& exchangeInfo = _coincenterInfo.exchangeInfo(_exchangePublic.name());
     if (isTakerStrategy) {
       from = exchangeInfo.applyFee(from, feeType);
     } else {

--- a/src/api/exchanges/test/bithumbapi_test.cpp
+++ b/src/api/exchanges/test/bithumbapi_test.cpp
@@ -52,7 +52,7 @@ void PublicTest(BithumbPublic &bithumbPublic) {
 void PrivateTest(BithumbPrivate &bithumbPrivate) {
   // We cannot expect anything from the balance, it may be empty and this is a valid response.
   EXPECT_NO_THROW(bithumbPrivate.getAccountBalance());
-  EXPECT_FALSE(bithumbPrivate.queryDepositWallet("ETH").hasDestinationTag());
+  EXPECT_FALSE(bithumbPrivate.queryDepositWallet("ETH").hasTag());
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("13.567XRP");
   EXPECT_NO_THROW(bithumbPrivate.trade(smallFrom, "KRW", tradeOptions));

--- a/src/api/exchanges/test/krakenapi_test.cpp
+++ b/src/api/exchanges/test/krakenapi_test.cpp
@@ -60,7 +60,7 @@ void PublicTest(KrakenPublic &krakenPublic) {
 void PrivateTest(KrakenPrivate &krakenPrivate) {
   // We cannot expect anything from the balance, it may be empty if you are poor and this is a valid response.
   EXPECT_NO_THROW(krakenPrivate.getAccountBalance());
-  EXPECT_FALSE(krakenPrivate.queryDepositWallet("BCH").hasDestinationTag());
+  EXPECT_FALSE(krakenPrivate.queryDepositWallet("BCH").hasTag());
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("0.001BTC");
   EXPECT_NO_THROW(krakenPrivate.trade(smallFrom, "EUR", tradeOptions));

--- a/src/api/exchanges/test/upbitapi_test.cpp
+++ b/src/api/exchanges/test/upbitapi_test.cpp
@@ -50,7 +50,7 @@ void PublicTest(UpbitPublic &upbitPublic) {
 void PrivateTest(UpbitPrivate &upbitPrivate, UpbitPublic &upbitPublic) {
   // We cannot expect anything from the balance, it may be empty if you are poor and this is a valid response.
   EXPECT_NO_THROW(upbitPrivate.getAccountBalance());
-  EXPECT_TRUE(upbitPrivate.queryDepositWallet("XRP").hasDestinationTag());
+  EXPECT_TRUE(upbitPrivate.queryDepositWallet("XRP").hasTag());
   EXPECT_NO_THROW(upbitPrivate.queryTradableCurrencies());
   EXPECT_EQ(upbitPrivate.queryWithdrawalFee("ADA"), upbitPublic.queryWithdrawalFee("ADA"));
 

--- a/src/api/interface/test/exchangeretrieverbase_test.cpp
+++ b/src/api/interface/test/exchangeretrieverbase_test.cpp
@@ -27,7 +27,7 @@ using Order = ExchangeRetriever::Order;
 TEST(ExchangeRetriever, Empty) {
   EXPECT_TRUE(ExchangeRetriever().exchanges().empty());
   PublicExchangeNames names;
-  EXPECT_TRUE(ExchangeRetriever().retrieveSelectedExchanges(Order::kInitial, names).empty());
+  EXPECT_TRUE(ExchangeRetriever().select(Order::kInitial, names).empty());
 }
 
 TEST(ExchangeRetriever, RetrieveUniqueCandidate) {
@@ -50,12 +50,11 @@ TEST(ExchangeRetriever, RetrieveSelectedExchangesInitialOrder) {
   ExchangeRetriever exchangeRetriever(kAllExchanges);
   EXPECT_FALSE(exchangeRetriever.exchanges().empty());
   PublicExchangeNames names{"kraken"};
-  ExchangeRetriever::SelectedExchanges selectedExchanges =
-      exchangeRetriever.retrieveSelectedExchanges(Order::kInitial, names);
+  ExchangeRetriever::SelectedExchanges selectedExchanges = exchangeRetriever.select(Order::kInitial, names);
   ASSERT_EQ(selectedExchanges.size(), 2U);
   EXPECT_EQ(selectedExchanges.front()->name(), "kraken");
   EXPECT_EQ(selectedExchanges.back()->name(), "kraken");
-  selectedExchanges = exchangeRetriever.retrieveSelectedExchanges(Order::kInitial);
+  selectedExchanges = exchangeRetriever.select(Order::kInitial, PublicExchangeNames());
   ASSERT_EQ(selectedExchanges.size(), 3U);
   EXPECT_EQ(selectedExchanges[0]->name(), "kraken");
   EXPECT_EQ(selectedExchanges[1]->name(), "bithumb");
@@ -69,8 +68,7 @@ TEST(ExchangeRetriever, RetrieveSelectedExchangesSelectedOrder) {
                                     ExchangeTest(first, "user2")};
     ExchangeRetriever exchangeRetriever(kAllExchanges);
     PublicExchangeNames names{second, first};
-    ExchangeRetriever::SelectedExchanges selectedExchanges =
-        exchangeRetriever.retrieveSelectedExchanges(Order::kSelection, names);
+    ExchangeRetriever::SelectedExchanges selectedExchanges = exchangeRetriever.select(Order::kSelection, names);
     ASSERT_EQ(selectedExchanges.size(), 3U);
     EXPECT_EQ(selectedExchanges[0]->name(), second);
     EXPECT_EQ(selectedExchanges[1]->name(), first);
@@ -85,8 +83,7 @@ TEST(ExchangeRetriever, RetrieveAtMostOneAccountSelectedExchanges) {
                                     ExchangeTest(first, "user2")};
     ExchangeRetriever exchangeRetriever(kAllExchanges);
     PublicExchangeNames names{second, first};
-    ExchangeRetriever::UniquePublicSelectedExchanges selectedExchanges =
-        exchangeRetriever.retrieveAtMostOneAccountSelectedExchanges(names);
+    ExchangeRetriever::UniquePublicSelectedExchanges selectedExchanges = exchangeRetriever.selectOneAccount(names);
     ASSERT_EQ(selectedExchanges.size(), 2U);
     EXPECT_EQ(selectedExchanges.front()->name(), second);
     EXPECT_EQ(selectedExchanges.back()->name(), first);
@@ -99,7 +96,7 @@ TEST(ExchangeRetriever, RetrieveUniquePublicExchange) {
     ExchangeTest kAllExchanges[] = {ExchangeTest(first, "user1"), ExchangeTest(second, "user1")};
     ExchangeRetriever exchangeRetriever(kAllExchanges);
     PublicExchangeNames names{second, first};
-    ExchangeRetriever::UniquePublicExchanges selectedExchanges = exchangeRetriever.retrieveUniquePublicExchanges(names);
+    ExchangeRetriever::PublicExchangesVec selectedExchanges = exchangeRetriever.selectPublicExchanges(names);
     ASSERT_EQ(selectedExchanges.size(), 2U);
     EXPECT_EQ(selectedExchanges.front()->name(), second);
     EXPECT_EQ(selectedExchanges.back()->name(), first);

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -93,6 +93,8 @@ class Coincenter {
   BalancePerExchange getBalance(std::span<const PrivateExchangeName> privateExchangeNames,
                                 CurrencyCode equiCurrency = CurrencyCode::kNeutral);
 
+  json getAllDepositInfo();
+
   WalletPerExchange getDepositInfo(std::span<const PrivateExchangeName> privateExchangeNames,
                                    CurrencyCode depositCurrency);
 

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -64,6 +64,7 @@ struct CoincenterCmdLineOptions {
   Duration trade_updateprice{TradeOptions().minTimeBetweenPriceUpdates()};
   bool trade_sim{TradeOptions().isSimulation()};
 
+  string deposit_info;
   string withdraw;
   string withdraw_fee;
 
@@ -163,13 +164,16 @@ CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser(
                                          .append(isSimulationModeByDefault ? "true" : "false")
                                          .append("). For some exchanges, API can even be queried in this "
                                          "mode to ensure deeper and more realistic trading inputs")}, &OptValueType::trade_sim},
-
-       {{{"Withdraw crypto", 5}, "--withdraw", 'w', "<amt cur,from-to>", string("Withdraw amount from exchange 'from' to exchange 'to'."
+       {{{"Withdraw and deposit", 5}, "--deposit-info", "<cur[,exch1,...]>", "Get deposit wallet information for given currency."
+                                                                             " If no exchange accounts are given, will query all of them by default"},
+                                                                             &OptValueType::deposit_info},
+       {{{"Withdraw and deposit", 5}, "--withdraw", 'w', "<amt cur,from-to>", string("Withdraw amount from exchange 'from' to exchange 'to'."
                                                                          " Amount is gross, including fees. Address and tag will be retrieved"
                                                                          " automatically from destination exchange and should match an entry in '")
                                                                         .append(kDepositAddressesFileName)
-                                                                        .append("' file.")}, &OptValueType::withdraw},
-       {{{"Withdraw crypto", 5}, "--withdraw-fee", "<cur[,exch1,...]>", string("Prints withdraw fees of given currency on all supported exchanges,"
+                                                                        .append("' file.")}, 
+                                                                        &OptValueType::withdraw},
+       {{{"Withdraw and deposit", 5}, "--withdraw-fee", "<cur[,exch1,...]>", string("Prints withdraw fees of given currency on all supported exchanges,"
                                                                          " or only for the list of specified ones if provided (comma separated).")}, 
                                                                 &OptValueType::withdraw_fee},
        {{{"Monitoring", 6}, "--monitoring", "", "Progressively send metrics to external instance provided that it's correctly set up "

--- a/src/engine/include/coincenterparsedoptions.hpp
+++ b/src/engine/include/coincenterparsedoptions.hpp
@@ -48,6 +48,9 @@ class CoincenterParsedOptions {
   bool noSecretsForAll = false;
   PublicExchangeNames noSecretsExchanges;
 
+  CurrencyCode depositCurrency;
+  PrivateExchangeNames depositInfoPrivateExchanges;
+
   MonetaryAmount amountToWithdraw;
   PrivateExchangeName withdrawFromExchangeName, withdrawToExchangeName;
   CurrencyCode withdrawFeeCur;

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -20,12 +20,15 @@ class StringOptionParser {
   using MonetaryAmountFromToPrivateExchange = std::tuple<MonetaryAmount, PrivateExchangeName, PrivateExchangeName>;
   using MonetaryAmountFromToPublicExchangeToCurrency = std::tuple<MonetaryAmount, PublicExchangeNames, CurrencyCode>;
   using CurrencyCodePublicExchanges = std::pair<CurrencyCode, PublicExchangeNames>;
+  using CurrencyPrivateExchanges = std::pair<CurrencyCode, PrivateExchangeNames>;
 
   explicit StringOptionParser(std::string_view optFullStr) : _opt(optFullStr) {}
 
   PublicExchangeNames getExchanges() const;
 
   PrivateExchangeNames getPrivateExchanges() const;
+
+  CurrencyPrivateExchanges getCurrencyPrivateExchanges() const;
 
   MarketExchanges getMarketExchanges() const;
 

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -282,9 +282,9 @@ json Coincenter::getAllDepositInfo() {
       if (curExchange.canDeposit() && !curExchange.isFiat()) {
         Wallet w = e->apiPrivate().queryDepositWallet(curExchange.standardCode());
         string addressAndTag(w.address());
-        if (w.hasDestinationTag()) {
+        if (w.hasTag()) {
           addressAndTag.push_back(',');
-          addressAndTag.append(w.destinationTag());
+          addressAndTag.append(w.tag());
         }
         string curCodeStr(curExchange.standardCode().str());
         ret[privateExchangeNameStr][curCodeStr] = std::move(addressAndTag);
@@ -496,7 +496,7 @@ void Coincenter::printDepositInfo(const PrivateExchangeNames &privateExchangeNam
   walletStr.append(" address");
   SimpleTable t("Exchange", "Account", std::move(walletStr), "Destination Tag");
   for (const auto &[exchangePtr, wallet] : walletPerExchange) {
-    t.emplace_back(exchangePtr->name(), exchangePtr->keyName(), wallet.address(), wallet.destinationTag());
+    t.emplace_back(exchangePtr->name(), exchangePtr->keyName(), wallet.address(), wallet.tag());
   }
   t.print();
 }

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -114,6 +114,11 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
                                 cmdLineOptions.trade_updateprice, tradeType);
   }
 
+  if (!cmdLineOptions.deposit_info.empty()) {
+    StringOptionParser anyParser(cmdLineOptions.deposit_info);
+    std::tie(depositCurrency, depositInfoPrivateExchanges) = anyParser.getCurrencyPrivateExchanges();
+  }
+
   if (!cmdLineOptions.withdraw.empty()) {
     StringOptionParser anyParser(cmdLineOptions.withdraw);
     std::tie(amountToWithdraw, withdrawFromExchangeName, withdrawToExchangeName) =

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -16,17 +16,29 @@ PublicExchangeNames GetExchanges(std::string_view str) {
   }
   return exchanges;
 }
-}  // namespace
 
-PublicExchangeNames StringOptionParser::getExchanges() const { return GetExchanges(_opt); }
-
-PrivateExchangeNames StringOptionParser::getPrivateExchanges() const {
-  PublicExchangeNames fullNames = GetExchanges(_opt);
+PrivateExchangeNames GetPrivateExchanges(std::string_view str) {
+  PublicExchangeNames fullNames = GetExchanges(str);
   PrivateExchangeNames ret;
   ret.reserve(fullNames.size());
   std::transform(fullNames.begin(), fullNames.end(), std::back_inserter(ret),
                  [](std::string_view exchangeName) { return PrivateExchangeName(exchangeName); });
   return ret;
+}
+}  // namespace
+
+PublicExchangeNames StringOptionParser::getExchanges() const { return GetExchanges(_opt); }
+
+PrivateExchangeNames StringOptionParser::getPrivateExchanges() const { return GetPrivateExchanges(_opt); }
+
+StringOptionParser::CurrencyPrivateExchanges StringOptionParser::getCurrencyPrivateExchanges() const {
+  std::size_t commaPos = getNextCommaPos(0, false);
+  std::string_view curStr(_opt.data(), commaPos == string::npos ? _opt.size() : commaPos);
+  std::string_view exchangesStr;
+  if (commaPos != string::npos) {
+    exchangesStr = std::string_view(_opt.data() + commaPos + 1, _opt.data() + _opt.size());
+  }
+  return CurrencyPrivateExchanges(CurrencyCode(curStr), GetPrivateExchanges(exchangesStr));
 }
 
 StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() const {

--- a/src/objects/CMakeLists.txt
+++ b/src/objects/CMakeLists.txt
@@ -71,3 +71,12 @@ add_unit_test(
     DEFINITIONS
     CCT_DISABLE_SPDLOG
 )
+
+add_unit_test(
+    wallet_test 
+    test/wallet_test.cpp 
+    LIBRARIES 
+    coincenter_objects 
+    DEFINITIONS 
+    CCT_DISABLE_SPDLOG
+)

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -12,13 +12,14 @@ class CurrencyExchange {
  public:
   enum class Deposit { kAvailable, kUnavailable };  // use scoped enums to ensure type checks and increase readability
   enum class Withdraw { kAvailable, kUnavailable };
+  enum class Type { kFiat, kCrypto };
 
   /// Constructs a CurrencyExchange with up to two alternative codes, with unknown withdrawal / deposit statuses
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode);
 
   /// Constructs a CurrencyExchange with up to two alternative codes, with known withdrawal / deposit statuses
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode, Deposit deposit,
-                   Withdraw withdraw);
+                   Withdraw withdraw, Type type);
 
   std::string_view standardStr() const { return _standardCode.str(); }
   std::string_view exchangeStr() const { return _exchangeCode.str(); }
@@ -35,6 +36,8 @@ class CurrencyExchange {
 
   bool unknownDepositWithdrawalStatus() const { return _unknownDepositWithdrawalStatus; }
 
+  bool isFiat() const { return _isFiat; }
+
   bool operator<(const CurrencyExchange &o) const { return _standardCode < o._standardCode; }
   bool operator==(const CurrencyExchange &o) const { return _standardCode == o._standardCode; }
   bool operator!=(const CurrencyExchange &o) const { return !(*this == o); }
@@ -46,6 +49,7 @@ class CurrencyExchange {
   bool _canDeposit;
   bool _canWithdraw;
   bool _unknownDepositWithdrawalStatus;
+  bool _isFiat;
 };
 
 }  // namespace cct

--- a/src/objects/include/exchangename.hpp
+++ b/src/objects/include/exchangename.hpp
@@ -10,8 +10,8 @@
 
 namespace cct {
 
-using PublicExchangeName = string;
-using PublicExchangeNames = FixedCapacityVector<PublicExchangeName, kNbSupportedExchanges>;
+using ExchangeName = string;
+using PublicExchangeNames = FixedCapacityVector<ExchangeName, kNbSupportedExchanges>;
 
 class PrivateExchangeName {
  public:
@@ -48,4 +48,7 @@ class PrivateExchangeName {
 };
 
 using PrivateExchangeNames = SmallVector<PrivateExchangeName, kTypicalNbPrivateAccounts>;
+
+inline std::string_view ToString(const ExchangeName &exchangeName) { return exchangeName; }
+inline std::string_view ToString(const PrivateExchangeName &exchangeName) { return exchangeName.str(); }
 }  // namespace cct

--- a/src/objects/include/wallet.hpp
+++ b/src/objects/include/wallet.hpp
@@ -2,6 +2,8 @@
 
 #include <string_view>
 
+#include "cct_config.hpp"
+#include "cct_exception.hpp"
 #include "cct_string.hpp"
 #include "cct_type_traits.hpp"
 #include "currencycode.hpp"
@@ -11,27 +13,33 @@ namespace cct {
 class CoincenterInfo;
 class Wallet {
  public:
-  /// Empty wallet
+  /// Empty wallet that should not be used, just for temporary purposes.
   Wallet() noexcept = default;
 
   /// Build a wallet with all information.
   Wallet(const PrivateExchangeName &privateExchangeName, CurrencyCode currency, std::string_view address,
          std::string_view tag, const CoincenterInfo &coincenterInfo);
 
-  Wallet(PrivateExchangeName &&privateExchangeName, CurrencyCode currency, std::string_view address,
-         std::string_view tag, const CoincenterInfo &coincenterInfo);
+  Wallet(PrivateExchangeName &&privateExchangeName, CurrencyCode currency, string &&address, string &&tag,
+         const CoincenterInfo &coincenterInfo);
 
   const PrivateExchangeName &privateExchangeName() const { return _privateExchangeName; }
 
   std::string_view exchangeName() const { return _privateExchangeName.name(); }
 
-  std::string_view address() const { return _address; }
+  std::string_view address() const {
+    check();
+    return _address;
+  }
 
-  std::string_view destinationTag() const { return _tag; }
+  std::string_view destinationTag() const {
+    check();
+    return _tag;
+  }
 
   CurrencyCode currencyCode() const { return _currency; }
 
-  bool hasDestinationTag() const { return !_tag.empty(); }
+  bool hasDestinationTag() const { return !destinationTag().empty(); }
 
   string str() const;
 
@@ -41,14 +49,19 @@ class Wallet {
   }
   bool operator!=(const Wallet &w) const { return !(*this == w); }
 
-  static bool IsAddressPresentInDepositFile(std::string_view dataDir, const PrivateExchangeName &privateExchangeName,
-                                            CurrencyCode currency, std::string_view expectedAddress,
-                                            std::string_view expectedTag);
+  static bool ValidateWallet(std::string_view dataDir, const PrivateExchangeName &privateExchangeName,
+                             CurrencyCode currency, std::string_view expectedAddress, std::string_view expectedTag);
 
   using trivially_relocatable = std::integral_constant<bool, is_trivially_relocatable_v<PrivateExchangeName> &&
                                                                  is_trivially_relocatable_v<string> >::type;
 
  private:
+  inline void check() const {
+    if (CCT_UNLIKELY(_address.empty())) {
+      throw exception("Cannot use an empty wallet address!");
+    }
+  }
+
   PrivateExchangeName _privateExchangeName;
   string _address;
   string _tag;

--- a/src/objects/include/wallet.hpp
+++ b/src/objects/include/wallet.hpp
@@ -11,6 +11,9 @@ namespace cct {
 class CoincenterInfo;
 class Wallet {
  public:
+  /// Empty wallet
+  Wallet() noexcept = default;
+
   /// Build a wallet with all information.
   Wallet(const PrivateExchangeName &privateExchangeName, CurrencyCode currency, std::string_view address,
          std::string_view tag, const CoincenterInfo &coincenterInfo);

--- a/src/objects/include/wallet.hpp
+++ b/src/objects/include/wallet.hpp
@@ -10,7 +10,23 @@
 #include "exchangename.hpp"
 
 namespace cct {
-class CoincenterInfo;
+class WalletCheck {
+ public:
+  /// Deposit wallet will not be checked in file
+  WalletCheck() noexcept = default;
+
+  /// Deposit wallet will be checked in file
+  WalletCheck(std::string_view dataDir, bool validateInDepositAddress)
+      : _dataDir(validateInDepositAddress ? dataDir : std::string_view()) {}
+
+  bool doCheck() const { return !_dataDir.empty(); }
+
+  std::string_view dataDir() const { return _dataDir; }
+
+ private:
+  std::string_view _dataDir;
+};
+
 class Wallet {
  public:
   /// Empty wallet that should not be used, just for temporary purposes.
@@ -18,10 +34,10 @@ class Wallet {
 
   /// Build a wallet with all information.
   Wallet(const PrivateExchangeName &privateExchangeName, CurrencyCode currency, std::string_view address,
-         std::string_view tag, const CoincenterInfo &coincenterInfo);
+         std::string_view tag, WalletCheck walletCheck);
 
-  Wallet(PrivateExchangeName &&privateExchangeName, CurrencyCode currency, string &&address, string &&tag,
-         const CoincenterInfo &coincenterInfo);
+  Wallet(PrivateExchangeName &&privateExchangeName, CurrencyCode currency, string &&address, std::string_view tag,
+         WalletCheck walletCheck);
 
   const PrivateExchangeName &privateExchangeName() const { return _privateExchangeName; }
 
@@ -29,42 +45,44 @@ class Wallet {
 
   std::string_view address() const {
     check();
-    return _address;
+    return std::string_view(_addressAndTag.data(), startTag());
   }
 
-  std::string_view destinationTag() const {
+  std::string_view tag() const {
     check();
-    return _tag;
+    return std::string_view(startTag(), _addressAndTag.data() + _addressAndTag.size());
   }
 
   CurrencyCode currencyCode() const { return _currency; }
 
-  bool hasDestinationTag() const { return !destinationTag().empty(); }
+  bool hasTag() const { return _tagPos != string::npos; }
 
   string str() const;
 
   bool operator==(const Wallet &w) const {
-    return _currency == w._currency && _privateExchangeName == w._privateExchangeName && _address == w._address &&
-           _tag == w._tag;
+    return _currency == w._currency && _privateExchangeName == w._privateExchangeName &&
+           _addressAndTag == w._addressAndTag;
   }
   bool operator!=(const Wallet &w) const { return !(*this == w); }
 
-  static bool ValidateWallet(std::string_view dataDir, const PrivateExchangeName &privateExchangeName,
+  static bool ValidateWallet(WalletCheck walletCheck, const PrivateExchangeName &privateExchangeName,
                              CurrencyCode currency, std::string_view expectedAddress, std::string_view expectedTag);
 
   using trivially_relocatable = std::integral_constant<bool, is_trivially_relocatable_v<PrivateExchangeName> &&
                                                                  is_trivially_relocatable_v<string> >::type;
 
  private:
-  inline void check() const {
-    if (CCT_UNLIKELY(_address.empty())) {
+  const char *startTag() const { return _addressAndTag.data() + (hasTag() ? _tagPos : _addressAndTag.size()); }
+
+  void check() const {
+    if (CCT_UNLIKELY(_addressAndTag.empty())) {
       throw exception("Cannot use an empty wallet address!");
     }
   }
 
   PrivateExchangeName _privateExchangeName;
-  string _address;
-  string _tag;
+  string _addressAndTag;
+  std::size_t _tagPos = string::npos;
   CurrencyCode _currency;
 };
 

--- a/src/objects/src/currencyexchange.cpp
+++ b/src/objects/src/currencyexchange.cpp
@@ -8,16 +8,18 @@ CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode excha
       _altCode(altCode),
       _canDeposit(false),
       _canWithdraw(false),
-      _unknownDepositWithdrawalStatus(true) {}
+      _unknownDepositWithdrawalStatus(true),
+      _isFiat(false) {}
 
 CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode,
-                                   Deposit deposit, Withdraw withdraw)
+                                   Deposit deposit, Withdraw withdraw, Type type)
     : _standardCode(standardCode),
       _exchangeCode(exchangeCode),
       _altCode(altCode),
       _canDeposit(deposit == Deposit::kAvailable),
       _canWithdraw(withdraw == Withdraw::kAvailable),
-      _unknownDepositWithdrawalStatus(false) {}
+      _unknownDepositWithdrawalStatus(false),
+      _isFiat(type == Type::kFiat) {}
 
 string CurrencyExchange::str() const {
   string ret(_standardCode.str());

--- a/src/objects/src/wallet.cpp
+++ b/src/objects/src/wallet.cpp
@@ -47,10 +47,7 @@ bool Wallet::ValidateWallet(std::string_view dataDir, const PrivateExchangeName 
         }
         std::string_view tag(tagPos == string::npos ? addressAndTag.end() : (addressAndTag.begin() + tagPos + 1),
                              addressAndTag.end());
-        if (expectedTag != tag) {
-          return false;
-        }
-        return true;
+        return expectedTag == tag;
       }
     }
   }

--- a/src/objects/test/wallet_test.cpp
+++ b/src/objects/test/wallet_test.cpp
@@ -1,0 +1,38 @@
+#include "wallet.hpp"
+
+#include <gtest/gtest.h>
+
+namespace cct {
+
+class WalletTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {}
+  virtual void TearDown() {}
+
+  WalletCheck walletCheck;
+};
+
+TEST_F(WalletTest, NoDestinationTag) {
+  Wallet w(PrivateExchangeName("kraken", "user1"), "ETH", "MyAddress", "", walletCheck);
+  EXPECT_EQ(w.address(), "MyAddress");
+  EXPECT_FALSE(w.hasTag());
+  EXPECT_EQ(w.tag(), "");
+  EXPECT_EQ(w.currencyCode(), CurrencyCode("ETH"));
+}
+
+TEST_F(WalletTest, DestinationTag1) {
+  Wallet w(PrivateExchangeName("kraken", "user1"), "ETH", "023432423423xxxx54645654", "346723423", walletCheck);
+  EXPECT_EQ(w.address(), "023432423423xxxx54645654");
+  EXPECT_TRUE(w.hasTag());
+  EXPECT_EQ(w.tag(), "346723423");
+}
+
+TEST_F(WalletTest, DestinationTag2) {
+  string address("023432423423xxxx5464565sd234657dsfsdfnnMMSERwedfsas");
+  Wallet w(PrivateExchangeName("kraken", "user1"), "XRP", std::move(address), "superTAG4576", walletCheck);
+  EXPECT_EQ(w.address(), "023432423423xxxx5464565sd234657dsfsdfnnMMSERwedfsas");
+  EXPECT_TRUE(w.hasTag());
+  EXPECT_EQ(w.tag(), "superTAG4576");
+}
+
+}  // namespace cct


### PR DESCRIPTION
This new option prints deposit address (and tag if applicable) for a given currency for each exchange where the deposit of such a currency is possible (from a list of user provided exchanges as usual, or all exchange if list is empty).