### PR TITLE
New --trade-all & --multitrade-all options

### DIFF
--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -93,8 +93,6 @@ class Coincenter {
   BalancePerExchange getBalance(std::span<const PrivateExchangeName> privateExchangeNames,
                                 CurrencyCode equiCurrency = CurrencyCode::kNeutral);
 
-  json getAllDepositInfo();
-
   WalletPerExchange getDepositInfo(std::span<const PrivateExchangeName> privateExchangeNames,
                                    CurrencyCode depositCurrency);
 
@@ -104,6 +102,9 @@ class Coincenter {
   ///    markets.
   MonetaryAmount trade(MonetaryAmount &startAmount, CurrencyCode toCurrency,
                        const PrivateExchangeName &privateExchangeName, const TradeOptions &tradeOptions);
+
+  MonetaryAmount tradeAll(CurrencyCode fromCurrency, CurrencyCode toCurrency,
+                          const PrivateExchangeName &privateExchangeName, const TradeOptions &tradeOptions);
 
   /// Single withdraw of 'grossAmount' from 'fromExchangeName' to 'toExchangeName'
   WithdrawInfo withdraw(MonetaryAmount grossAmount, const PrivateExchangeName &fromPrivateExchangeName,

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -57,7 +57,9 @@ struct CoincenterCmdLineOptions {
   string balance_cur{CurrencyCode::kNeutral.str()};
 
   string trade;
+  string trade_all;
   string trade_multi;
+  string trade_multi_all;
   string trade_price{TradeOptions().priceStrategyStr()};
   bool trade_timeout_match = false;
   Duration trade_timeout{TradeOptions().maxTradeTime()};
@@ -137,6 +139,8 @@ CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser(
 
        {{{"Trade", 4}, "--trade", 't', "<amt cur1-cur2,exchange>", "Single trade from given start amount on an exchange.\n"
                                                                    "Order will be placed at limit price by default"}, &OptValueType::trade},
+       {{{"Trade", 4}, "--trade-all", "<cur1-cur2,exchange>", "Single trade from available amount from given currency on an exchange.\n"
+                                                              "Order will be placed at limit price by default"}, &OptValueType::trade_all},
        {{{"Trade", 4}, "--singletrade", "<amt cur1-cur2,exchange>", "Synonym for '--trade'"}, &OptValueType::trade},
        {{{"Trade", 4}, "--multitrade", "<amt cur1-cur2,exchange>", "Multi trade from given start amount on an exchange.\n"
                                                                    "Multi trade will first compute fastest path from cur1 to cur2 and "
@@ -144,6 +148,8 @@ CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser(
                                                                    "Options are same than for single trade, applied to each step trade.\n"
                                                                    "If multi trade is used in conjonction with single trade, the latter is ignored."}, 
                                                                    &OptValueType::trade_multi},
+       {{{"Trade", 4}, "--multitrade-all", "<cur1-cur2,exchange>", "Multi trade from available amount from given currency on an exchange.\n"
+                                                                   "Order will be placed at limit price by default"}, &OptValueType::trade_multi_all},
        {{{"Trade", 4}, "--trade-strategy", "<maker|nibble|taker>", "Customize the order price strategy of the trade\n"
                                                                   " - 'maker': order price continuously set at limit price (default)\n"
                                                                   " - 'nibble': order price continuously set at limit price + (buy)/- (sell) 1\n"

--- a/src/engine/include/coincenterparsedoptions.hpp
+++ b/src/engine/include/coincenterparsedoptions.hpp
@@ -24,6 +24,7 @@ class CoincenterParsedOptions {
   CoincenterParsedOptions(int argc, const char *argv[]);
 
   MonetaryAmount startTradeAmount;
+  CurrencyCode fromTradeCurrency;
   CurrencyCode toTradeCurrency;
   PrivateExchangeName tradePrivateExchangeName;
   TradeOptions tradeOptions;

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -16,6 +16,7 @@ class StringOptionParser {
  public:
   using MarketExchanges = std::pair<Market, PublicExchangeNames>;
   using MonetaryAmountExchanges = std::pair<MonetaryAmount, PublicExchangeNames>;
+  using CurrencyCodeFromToPrivateExchange = std::tuple<CurrencyCode, CurrencyCode, PrivateExchangeName>;
   using MonetaryAmountCurrencyCodePrivateExchange = std::tuple<MonetaryAmount, CurrencyCode, PrivateExchangeName>;
   using MonetaryAmountFromToPrivateExchange = std::tuple<MonetaryAmount, PrivateExchangeName, PrivateExchangeName>;
   using MonetaryAmountFromToPublicExchangeToCurrency = std::tuple<MonetaryAmount, PublicExchangeNames, CurrencyCode>;
@@ -33,6 +34,8 @@ class StringOptionParser {
   MarketExchanges getMarketExchanges() const;
 
   MonetaryAmountExchanges getMonetaryAmountExchanges() const;
+
+  CurrencyCodeFromToPrivateExchange getFromToCurrencyCodePrivateExchange() const;
 
   MonetaryAmountCurrencyCodePrivateExchange getMonetaryAmountCurrencyCodePrivateExchange() const;
 

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -99,14 +99,26 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
     noSecretsForAll = noSecretsExchanges.empty();
   }
 
-  std::string_view tradeArgs = !cmdLineOptions.trade_multi.empty() ? cmdLineOptions.trade_multi : cmdLineOptions.trade;
+  std::string_view tradeArgs;
+  bool isMultiTrade = !cmdLineOptions.trade_multi.empty() || !cmdLineOptions.trade_multi_all.empty();
+  bool isTradeAll = !cmdLineOptions.trade_all.empty() || !cmdLineOptions.trade_multi_all.empty();
+  if (isMultiTrade) {
+    tradeArgs = isTradeAll ? cmdLineOptions.trade_multi_all : cmdLineOptions.trade_multi;
+  } else {
+    tradeArgs = isTradeAll ? cmdLineOptions.trade_all : cmdLineOptions.trade;
+  }
   if (!tradeArgs.empty()) {
     StringOptionParser anyParser(tradeArgs);
-    std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeName) =
-        anyParser.getMonetaryAmountCurrencyCodePrivateExchange();
+    if (isTradeAll) {
+      std::tie(fromTradeCurrency, toTradeCurrency, tradePrivateExchangeName) =
+          anyParser.getFromToCurrencyCodePrivateExchange();
+    } else {
+      std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeName) =
+          anyParser.getMonetaryAmountCurrencyCodePrivateExchange();
+    }
 
     TradeMode tradeMode = cmdLineOptions.trade_sim ? TradeMode::kSimulation : TradeMode::kReal;
-    TradeType tradeType = cmdLineOptions.trade_multi.empty() ? TradeType::kSingleTrade : TradeType::kMultiTradePossible;
+    TradeType tradeType = isMultiTrade ? TradeType::kMultiTradePossible : TradeType::kSingleTrade;
     TradeTimeoutAction timeoutAction =
         cmdLineOptions.trade_timeout_match ? TradeTimeoutAction::kForceMatch : TradeTimeoutAction::kCancel;
 

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -63,9 +63,22 @@ StringOptionParser::MonetaryAmountExchanges StringOptionParser::getMonetaryAmoun
       GetExchanges(std::string_view(_opt.begin() + startExchangesPos, _opt.end()))};
 }
 
+StringOptionParser::CurrencyCodeFromToPrivateExchange StringOptionParser::getFromToCurrencyCodePrivateExchange() const {
+  std::size_t dashPos = _opt.find('-', 1);
+  if (dashPos == string::npos) {
+    throw std::invalid_argument("Expected a dash");
+  }
+  CurrencyCode fromTradeCurrency(std::string_view(_opt.begin(), _opt.begin() + dashPos));
+  std::size_t commaPos = getNextCommaPos(dashPos + 1);
+  std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
+  CurrencyCode toTradeCurrency(std::string_view(_opt.begin() + dashPos + 1, _opt.begin() + commaPos));
+  return std::make_tuple(fromTradeCurrency, toTradeCurrency,
+                         PrivateExchangeName(std::string_view(_opt.begin() + startExchangesPos, _opt.end())));
+}
+
 StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange
 StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchange() const {
-  std::size_t dashPos = _opt.find('-');
+  std::size_t dashPos = _opt.find('-', 1);
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
@@ -73,9 +86,8 @@ StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchange() const {
   std::size_t commaPos = getNextCommaPos(dashPos + 1);
   std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
   CurrencyCode toTradeCurrency(std::string_view(_opt.begin() + dashPos + 1, _opt.begin() + commaPos));
-  return MonetaryAmountCurrencyCodePrivateExchange{
-      startTradeAmount, toTradeCurrency,
-      PrivateExchangeName(std::string_view(_opt.begin() + startExchangesPos, _opt.end()))};
+  return std::make_tuple(startTradeAmount, toTradeCurrency,
+                         PrivateExchangeName(std::string_view(_opt.begin() + startExchangesPos, _opt.end())));
 }
 
 StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getMonetaryAmountFromToPrivateExchange()


### PR DESCRIPTION
New `--trade-all` and `--multittrade-all` options making it more user friendly to sell all available amount from a currency to another on a given exchange.