### PR TITLE
For Binance, use only default network in tradable currencies

### DIFF
--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -106,6 +106,7 @@ BalancePortfolio BinancePrivate::queryAccountBalance(CurrencyCode equiCurrency) 
 }
 
 Wallet BinancePrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
+  // Limitation : we do not provide network here, we use default in accordance of getTradableCurrenciesService
   json result = PrivateQuery(_curlHandle, _apiKey, CurlOptions::RequestType::kGet, _public._commonInfo.getBestBaseURL(),
                              "sapi/v1/capital/deposit/address", {{"coin", currencyCode.str()}});
   std::string_view address(result["address"].get<std::string_view>());

--- a/src/api/exchanges/test/binanceapi_test.cpp
+++ b/src/api/exchanges/test/binanceapi_test.cpp
@@ -34,7 +34,11 @@ void PrivateTest(BinancePrivate &binancePrivate, BinancePublic &binancePublic) {
   EXPECT_NO_THROW(binancePrivate.getAccountBalance());
   auto currencies = binancePrivate.queryTradableCurrencies();
   EXPECT_FALSE(currencies.empty());
-  EXPECT_NO_THROW(binancePrivate.queryDepositWallet(currencies.front().standardCode()));
+  auto foundIt = std::find_if(currencies.begin(), currencies.end(),
+                              [](const CurrencyExchange &curExchange) { return curExchange.canDeposit(); });
+  if (foundIt != currencies.end()) {
+    EXPECT_NO_THROW(binancePrivate.queryDepositWallet(foundIt->standardCode()));
+  }
   TradeOptions tradeOptions(TradeMode::kSimulation);
   if (currencies.contains(CurrencyCode("BNB"))) {
     MonetaryAmount smallFrom("13.567ADA");


### PR DESCRIPTION
Get deposit addresses corresponds to correct default network