### PR TITLE
Trade option is now possible on list of exchanges

### DIFF
--- a/src/api/common/CMakeLists.txt
+++ b/src/api/common/CMakeLists.txt
@@ -35,7 +35,7 @@ add_common_test(
   exchangeprivateapi_test
   src/exchangeprivateapi.cpp
   src/exchangepublicapi.cpp
-  src/tradeinfo.cpp
+  src/tradedamounts.cpp
   src/tradeoptions.cpp
   test/exchangeprivateapi_test.cpp
 )

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -11,6 +11,7 @@
 #include "exchangebase.hpp"
 #include "exchangepublicapi.hpp"
 #include "market.hpp"
+#include "tradedamounts.hpp"
 #include "tradeinfo.hpp"
 #include "wallet.hpp"
 #include "withdrawinfo.hpp"
@@ -54,11 +55,10 @@ class ExchangePrivate : public ExchangeBase {
   /// This function is necessarily a blocking call (synchronous) as it returns the converted amount.
   /// Because of this, it needs to expire at some point (and thus returning a non fully converted amount, or even 0 if
   /// nothing was traded).
-  /// @param from the starting amount from which conversion will be done.
-  ///             Will be modified containing the remaining (untraded) amount (0 if trade is complete)
+  /// @param from the starting amount from which conversion will be done
   /// @param toCurrencyCode the destination currency
-  /// @return converted net amount (fees deduced)
-  MonetaryAmount trade(MonetaryAmount &from, CurrencyCode toCurrencyCode, const TradeOptions &options);
+  /// @return trade amounts (fees deduced)
+  TradedAmounts trade(MonetaryAmount from, CurrencyCode toCurrencyCode, const TradeOptions &options);
 
   /// The waiting time between each query of withdraw info to check withdraw status from an exchange.
   /// A very small value is not relevant as withdraw time order of magnitude are minutes (or hours with Bitcoin)
@@ -135,9 +135,9 @@ class ExchangePrivate : public ExchangeBase {
   virtual bool isWithdrawReceived(const InitiatedWithdrawInfo &initiatedWithdrawInfo,
                                   const SentWithdrawInfo &sentWithdrawInfo) = 0;
 
-  MonetaryAmount singleTrade(MonetaryAmount &from, CurrencyCode toCurrencyCode, const TradeOptions &options, Market m);
+  TradedAmounts singleTrade(MonetaryAmount from, CurrencyCode toCurrencyCode, const TradeOptions &options, Market m);
 
-  MonetaryAmount multiTrade(MonetaryAmount &from, CurrencyCode toCurrencyCode, const TradeOptions &options);
+  TradedAmounts multiTrade(MonetaryAmount from, CurrencyCode toCurrencyCode, const TradeOptions &options);
 
   ExchangePublic &_exchangePublic;
   CachedResultVault &_cachedResultVault;

--- a/src/api/common/include/tradedamounts.hpp
+++ b/src/api/common/include/tradedamounts.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "cct_string.hpp"
+#include "currencycode.hpp"
+#include "monetaryamount.hpp"
+
+namespace cct {
+
+struct TradedAmounts {
+  TradedAmounts() = default;
+
+  TradedAmounts(CurrencyCode fromCurrencyCode, CurrencyCode toCurrencyCode)
+      : tradedFrom(0, fromCurrencyCode), tradedTo(0, toCurrencyCode) {}
+
+  TradedAmounts(MonetaryAmount fromAmount, MonetaryAmount toAmount) : tradedFrom(fromAmount), tradedTo(toAmount) {}
+
+  TradedAmounts operator+(const TradedAmounts &o) const;
+  TradedAmounts &operator+=(const TradedAmounts &o) {
+    *this = *this + o;
+    return *this;
+  }
+
+  bool operator==(const TradedAmounts &) const = default;
+
+  bool isZero() const { return tradedFrom.isZero() && tradedTo.isZero(); }
+
+  string str() const;
+
+  MonetaryAmount tradedFrom;  // In currency of 'from' amount
+  MonetaryAmount tradedTo;    // In the opposite currency
+};
+
+}  // namespace cct

--- a/src/api/common/include/tradeinfo.hpp
+++ b/src/api/common/include/tradeinfo.hpp
@@ -3,6 +3,7 @@
 #include "cct_string.hpp"
 #include "market.hpp"
 #include "monetaryamount.hpp"
+#include "tradedamounts.hpp"
 #include "tradeoptions.hpp"
 
 namespace cct::api {
@@ -18,26 +19,6 @@ struct TradeInfo {
   Market m;
   TradeOptions options;
   int64_t userRef;  // Used by Kraken for instance, used to group orders queries context
-};
-
-struct TradedAmounts {
-  TradedAmounts(CurrencyCode fromCurrencyCode, CurrencyCode toCurrencyCode)
-      : tradedFrom(0, fromCurrencyCode), tradedTo(0, toCurrencyCode) {}
-
-  TradedAmounts(MonetaryAmount fromAmount, MonetaryAmount toAmount) : tradedFrom(fromAmount), tradedTo(toAmount) {}
-
-  TradedAmounts operator+(const TradedAmounts &o) const;
-  TradedAmounts &operator+=(const TradedAmounts &o) {
-    *this = *this + o;
-    return *this;
-  }
-
-  bool isZero() const { return tradedFrom.isZero() && tradedTo.isZero(); }
-
-  string str() const;
-
-  MonetaryAmount tradedFrom;  // In currency of 'from' amount
-  MonetaryAmount tradedTo;    // In the opposite currency
 };
 
 struct OrderInfo {

--- a/src/api/common/src/tradedamounts.cpp
+++ b/src/api/common/src/tradedamounts.cpp
@@ -1,7 +1,6 @@
-#include "tradeinfo.hpp"
+#include "tradedamounts.hpp"
 
 namespace cct {
-namespace api {
 TradedAmounts TradedAmounts::operator+(const TradedAmounts &o) const {
   return TradedAmounts(tradedFrom + o.tradedFrom, tradedTo + o.tradedTo);
 }
@@ -13,5 +12,4 @@ string TradedAmounts::str() const {
   ret.append(tradedTo.str());
   return ret;
 }
-}  // namespace api
 }  // namespace cct

--- a/src/api/common/test/exchangeprivateapi_test.cpp
+++ b/src/api/common/test/exchangeprivateapi_test.cpp
@@ -63,10 +63,6 @@ inline bool operator==(const TradeInfo &lhs, const TradeInfo &rhs) {
   return lhs.fromCurrencyCode == rhs.fromCurrencyCode && lhs.toCurrencyCode == rhs.toCurrencyCode && lhs.m == rhs.m;
 }
 
-inline bool operator==(const TradedAmounts &lhs, const TradedAmounts &rhs) {
-  return lhs.tradedFrom == rhs.tradedFrom && lhs.tradedTo == rhs.tradedTo;
-}
-
 inline bool operator==(const OrderInfo &lhs, const OrderInfo &rhs) {
   return lhs.isClosed == rhs.isClosed && lhs.tradedAmounts == rhs.tradedAmounts;
 }
@@ -91,7 +87,7 @@ TEST_F(ExchangePrivateTest, TakerTradeBaseToQuote) {
   EXPECT_CALL(exchangePrivate, placeOrder(from, vol, pri, tradeInfo))
       .WillOnce(testing::Return(PlaceOrderInfo(OrderInfo(TradedAmounts(from, tradedTo), true))));
 
-  EXPECT_EQ(exchangePrivate.trade(from, m.quote(), tradeOptions), tradedTo);
+  EXPECT_EQ(exchangePrivate.trade(from, m.quote(), tradeOptions), TradedAmounts(from, tradedTo));
 }
 
 TEST_F(ExchangePrivateTest, TakerTradeQuoteToBase) {
@@ -110,7 +106,7 @@ TEST_F(ExchangePrivateTest, TakerTradeQuoteToBase) {
   EXPECT_CALL(exchangePrivate, placeOrder(from, vol, pri, tradeInfo))
       .WillOnce(testing::Return(PlaceOrderInfo(OrderInfo(TradedAmounts(from, tradedTo), true))));
 
-  EXPECT_EQ(exchangePrivate.trade(from, m.base(), tradeOptions), tradedTo);
+  EXPECT_EQ(exchangePrivate.trade(from, m.base(), tradeOptions), TradedAmounts(from, tradedTo));
 }
 
 }  // namespace cct::api

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -147,7 +147,7 @@ CurrencyExchangeFlatSet BinancePublic::queryTradableCurrencies(const json& data)
     bool isFiat = el["isLegalMoney"];
     const auto& networkList = el["networkList"];
     if (networkList.size() > 1) {
-      log::debug("Several networks found for {}, considering only default network");
+      log::debug("Several networks found for {}, considering only default network", cur.str());
     }
     for (const json& networkDetail : networkList) {
       bool isDefault = networkDetail["isDefault"].get<bool>();

--- a/src/api/exchanges/test/binanceapi_test.cpp
+++ b/src/api/exchanges/test/binanceapi_test.cpp
@@ -45,8 +45,8 @@ void PrivateTest(BinancePrivate &binancePrivate, BinancePublic &binancePublic) {
     EXPECT_NO_THROW(binancePrivate.trade(smallFrom, "BNB", tradeOptions));
   }
   MonetaryAmount bigFrom("13567.1234BNB");
-  EXPECT_NO_THROW(binancePrivate.trade(bigFrom, currencies.back().standardCode(), tradeOptions));
-  EXPECT_LT(bigFrom, MonetaryAmount("13567.1234BNB"));
+  TradedAmounts tradedAmounts = binancePrivate.trade(bigFrom, currencies.back().standardCode(), tradeOptions);
+  EXPECT_EQ(tradedAmounts.tradedFrom, MonetaryAmount("13567.1234BNB"));
 
   EXPECT_EQ(binancePrivate.queryWithdrawalFee(currencies.front().standardCode()),
             binancePublic.queryWithdrawalFee(currencies.front().standardCode()));

--- a/src/api/exchanges/test/bithumbapi_test.cpp
+++ b/src/api/exchanges/test/bithumbapi_test.cpp
@@ -9,8 +9,7 @@
 #include "fiatconverter.hpp"
 #include "tradeoptions.hpp"
 
-namespace cct {
-namespace api {
+namespace cct::api {
 
 using BithumbAPI = TestAPI<BithumbPublic>;
 
@@ -36,7 +35,7 @@ void PublicTest(BithumbPublic &bithumbPublic) {
   EXPECT_GT(withdrawalFees.size(), 10U);
   EXPECT_TRUE(withdrawalFees.contains(markets.begin()->base()));
   EXPECT_TRUE(withdrawalFees.contains(std::next(markets.begin(), 1)->base()));
-  const CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
+  static constexpr CurrencyCode kCurrencyCodesToTest[] = {"BAT", "ETH", "BTC", "XRP"};
   for (CurrencyCode code : kCurrencyCodesToTest) {
     if (currencies.contains(code) && currencies.find(code)->canWithdraw()) {
       EXPECT_FALSE(withdrawalFees.find(code)->second.isZero());
@@ -56,10 +55,9 @@ void PrivateTest(BithumbPrivate &bithumbPrivate) {
   EXPECT_FALSE(bithumbPrivate.queryDepositWallet("ETH").hasTag());
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("13.567XRP");
-  EXPECT_NO_THROW(bithumbPrivate.trade(smallFrom, "KRW", tradeOptions));
+  EXPECT_GT(bithumbPrivate.trade(smallFrom, "KRW", tradeOptions).tradedTo, MonetaryAmount(0, "KRW"));
   MonetaryAmount bigFrom("135670067.1234KRW");
-  EXPECT_NO_THROW(bithumbPrivate.trade(bigFrom, "ETH", tradeOptions));
-  EXPECT_LT(bigFrom, MonetaryAmount("13567.1234KRW"));
+  EXPECT_FALSE(bithumbPrivate.trade(bigFrom, "ETH", tradeOptions).tradedFrom.isZero());
 }
 }  // namespace
 
@@ -81,5 +79,4 @@ TEST_F(BithumbAPI, Public) {
   PrivateTest(bithumbPrivate);
 }
 
-}  // namespace api
-}  // namespace cct
+}  // namespace cct::api

--- a/src/api/exchanges/test/huobiapi_test.cpp
+++ b/src/api/exchanges/test/huobiapi_test.cpp
@@ -10,8 +10,7 @@
 #include "huobipublicapi.hpp"
 #include "tradeoptions.hpp"
 
-namespace cct {
-namespace api {
+namespace cct::api {
 using HuobiAPI = TestAPI<HuobiPublic>;
 
 namespace {
@@ -35,8 +34,7 @@ void PrivateTest(HuobiPrivate &huobiPrivate) {
   EXPECT_NO_THROW(huobiPrivate.queryDepositWallet("XRP"));
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("0.1ETH");
-  EXPECT_NO_THROW(huobiPrivate.trade(smallFrom, "BTC", tradeOptions));
-  EXPECT_EQ(smallFrom, MonetaryAmount("0ETH"));
+  EXPECT_EQ(huobiPrivate.trade(smallFrom, "BTC", tradeOptions).tradedFrom, smallFrom);
 }
 }  // namespace
 
@@ -58,5 +56,4 @@ TEST_F(HuobiAPI, Main) {
   PrivateTest(huobiPrivate);
 }
 
-}  // namespace api
-}  // namespace cct
+}  // namespace cct::api

--- a/src/api/exchanges/test/krakenapi_test.cpp
+++ b/src/api/exchanges/test/krakenapi_test.cpp
@@ -12,8 +12,7 @@
 #include "krakenpublicapi.hpp"
 #include "tradeoptions.hpp"
 
-namespace cct {
-namespace api {
+namespace cct::api {
 using KrakenAPI = TestAPI<KrakenPublic>;
 
 namespace {
@@ -64,10 +63,9 @@ void PrivateTest(KrakenPrivate &krakenPrivate) {
   EXPECT_FALSE(krakenPrivate.queryDepositWallet("BCH").hasTag());
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("0.001BTC");
-  EXPECT_NO_THROW(krakenPrivate.trade(smallFrom, "EUR", tradeOptions));
+  EXPECT_EQ(krakenPrivate.trade(smallFrom, "EUR", tradeOptions).tradedFrom, smallFrom);
   MonetaryAmount stdFrom("100.1234EUR");
-  EXPECT_NO_THROW(krakenPrivate.trade(stdFrom, "BTC", tradeOptions));
-  EXPECT_LT(stdFrom, MonetaryAmount("50EUR"));
+  EXPECT_GT(krakenPrivate.trade(stdFrom, "BTC", tradeOptions).tradedTo, MonetaryAmount(0, "BTC"));
 }
 }  // namespace
 
@@ -110,5 +108,4 @@ TEST_F(KrakenAPI, PrivateEmptyBalance) {
     log::info("Proxy not available.");
   }
 }
-}  // namespace api
-}  // namespace cct
+}  // namespace cct::api

--- a/src/api/exchanges/test/kucoinapi_test.cpp
+++ b/src/api/exchanges/test/kucoinapi_test.cpp
@@ -10,8 +10,7 @@
 #include "kucoinpublicapi.hpp"
 #include "tradeoptions.hpp"
 
-namespace cct {
-namespace api {
+namespace cct::api {
 using KucoinAPI = TestAPI<KucoinPublic>;
 
 namespace {
@@ -34,8 +33,7 @@ void PrivateTest(KucoinPrivate &kucoinPrivate) {
   EXPECT_NO_THROW(kucoinPrivate.queryDepositWallet("XRP"));
   TradeOptions tradeOptions(TradeMode::kSimulation);
   MonetaryAmount smallFrom("0.1ETH");
-  EXPECT_NO_THROW(kucoinPrivate.trade(smallFrom, "BTC", tradeOptions));
-  EXPECT_EQ(smallFrom, MonetaryAmount("0ETH"));
+  EXPECT_EQ(kucoinPrivate.trade(smallFrom, "BTC", tradeOptions).tradedFrom, smallFrom);
 }
 }  // namespace
 
@@ -57,5 +55,4 @@ TEST_F(KucoinAPI, Main) {
   PrivateTest(kucoinPrivate);
 }
 
-}  // namespace api
-}  // namespace cct
+}  // namespace cct::api

--- a/src/api/exchanges/test/upbitapi_test.cpp
+++ b/src/api/exchanges/test/upbitapi_test.cpp
@@ -8,8 +8,7 @@
 #include "upbitprivateapi.hpp"
 #include "upbitpublicapi.hpp"
 
-namespace cct {
-namespace api {
+namespace cct::api {
 using UpbitAPI = TestAPI<UpbitPublic>;
 
 namespace {
@@ -84,5 +83,4 @@ TEST_F(UpbitAPI, Public) {
   PrivateTest(upbitPrivate, exchangePublic);
 }
 
-}  // namespace api
-}  // namespace cct
+}  // namespace cct::api

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -16,6 +16,7 @@
 #include "monitoringinfo.hpp"
 #include "printqueryresults.hpp"
 #include "queryresulttypes.hpp"
+#include "tradedamounts.hpp"
 
 namespace cct {
 
@@ -76,15 +77,19 @@ class Coincenter {
   /// Get withdraw fees for all exchanges from given list (or all exchanges if list is empty)
   WithdrawFeePerExchange getWithdrawFees(CurrencyCode currencyCode, ExchangeNameSpan exchangeNames);
 
+  /// Trade a specified amount of a given currency into another one, using the market defined in the given exchanges.
+  /// If no exchange name is given, it will attempt to trade given amount on all exchanges with the sufficient balance.
+  /// If exactly one private exchange is given, balance will not be queried and trade will be launched without balance
+  /// check.
+  TradedAmounts trade(MonetaryAmount startAmount, CurrencyCode toCurrency,
+                      std::span<const PrivateExchangeName> privateExchangeNames, const TradeOptions &tradeOptions);
+
   /// A Multi trade is similar to a single trade, at the difference that it retrieves the fastest currency
   /// conversion path and will launch several 'single' trades to reach that final goal. Example:
   ///  - Convert XRP to XLM on an exchange only proposing XRP-BTC and BTC-XLM markets will make 2 trades on these
   ///    markets.
-  MonetaryAmount trade(MonetaryAmount &startAmount, CurrencyCode toCurrency,
-                       const PrivateExchangeName &privateExchangeName, const TradeOptions &tradeOptions);
-
-  MonetaryAmount tradeAll(CurrencyCode fromCurrency, CurrencyCode toCurrency,
-                          const PrivateExchangeName &privateExchangeName, const TradeOptions &tradeOptions);
+  TradedAmounts tradeAll(CurrencyCode fromCurrency, CurrencyCode toCurrency,
+                         std::span<const PrivateExchangeName> privateExchangeNames, const TradeOptions &tradeOptions);
 
   /// Single withdraw of 'grossAmount' from 'fromExchangeName' to 'toExchangeName'
   WithdrawInfo withdraw(MonetaryAmount grossAmount, const PrivateExchangeName &fromPrivateExchangeName,

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -150,17 +150,20 @@ CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser(
                                                                 "converted to given currency, plus a total summary in this currency"}, 
                                                                 &OptValueType::balance_cur},
 
-       {{{"Trade", 4}, "--trade", 't', "<amt cur1-cur2,exchange>", "Single trade from given start amount on an exchange.\n"
-                                                                   "Order will be placed at limit price by default"}, &OptValueType::trade},
-       {{{"Trade", 4}, "--trade-all", "<cur1-cur2,exchange>", "Single trade from available amount from given currency on an exchange.\n"
-                                                              "Order will be placed at limit price by default"}, &OptValueType::trade_all},
-       {{{"Trade", 4}, "--singletrade", "<amt cur1-cur2,exchange>", "Synonym for '--trade'"}, &OptValueType::trade},
-       {{{"Trade", 4}, "--multitrade", "<amt cur1-cur2,exchange>", "Multi trade from given start amount on an exchange.\n"
-                                                                   "Multi trade will first compute fastest path from cur1 to cur2 and "
-                                                                   "if possible reach cur2 by launching multiple single trades.\n"
-                                                                   "Options are same than for single trade, applied to each step trade.\n"
-                                                                   "If multi trade is used in conjonction with single trade, the latter is ignored."}, 
-                                                                   &OptValueType::trade_multi},
+       {{{"Trade", 4}, "--trade", 't', "<amt cur1-cur2[,exch1,...]>", "Single trade from given start amount on a list of exchanges, "
+                                                                      "or all that have sufficient balance on cur1 if none provided.\n"
+                                                                      "Order will be placed at limit price by default"}, &OptValueType::trade},
+       {{{"Trade", 4}, "--trade-all", "<cur1-cur2[,exch1,...]>", "Single trade from available amount from given currency on a list of exchanges,"
+                                                                 " or all that have some balance on cur1 if none provided\n"
+                                                                 "Order will be placed at limit price by default"}, &OptValueType::trade_all},
+       {{{"Trade", 4}, "--singletrade", "<amt cur1-cur2[,exch1,...]>", "Synonym for '--trade'"}, &OptValueType::trade},
+       {{{"Trade", 4}, "--multitrade", "<amt cur1-cur2[,exch1,...]>", "Multi trade from given start amount on a list of exchanges,"
+                                                                      " or all that have a sufficient balance on cur1 if none provided \n"
+                                                                      "Multi trade will first compute fastest path from cur1 to cur2 and "
+                                                                     "if possible reach cur2 by launching multiple single trades.\n"
+                                                                     "Options are same than for single trade, applied to each step trade.\n"
+                                                                     "If multi trade is used in conjonction with single trade, the latter is ignored."}, 
+                                                                     &OptValueType::trade_multi},
        {{{"Trade", 4}, "--multitrade-all", "<cur1-cur2,exchange>", "Multi trade from available amount from given currency on an exchange.\n"
                                                                    "Order will be placed at limit price by default"}, &OptValueType::trade_multi_all},
        {{{"Trade", 4}, "--trade-strategy", "<maker|nibble|taker>", "Customize the order price strategy of the trade\n"

--- a/src/engine/include/coincenterparsedoptions.hpp
+++ b/src/engine/include/coincenterparsedoptions.hpp
@@ -27,7 +27,7 @@ class CoincenterParsedOptions {
   MonetaryAmount startTradeAmount;
   CurrencyCode fromTradeCurrency;
   CurrencyCode toTradeCurrency;
-  PrivateExchangeName tradePrivateExchangeName;
+  PrivateExchangeNames tradePrivateExchangeNames;
   TradeOptions tradeOptions;
 
   CurrencyCode marketsCurrency;

--- a/src/engine/include/queryresulttypes.hpp
+++ b/src/engine/include/queryresulttypes.hpp
@@ -29,7 +29,7 @@ using LastTradesPerExchange =
     FixedCapacityVector<std::pair<const Exchange *, api::ExchangePublic::LastTradesVector>, kNbSupportedExchanges>;
 using ExchangeTickerMaps =
     FixedCapacityVector<std::pair<const Exchange *, api::ExchangePublic::MarketOrderBookMap>, kNbSupportedExchanges>;
-using BalancePerExchange = SmallVector<std::pair<const Exchange *, BalancePortfolio>, kTypicalNbPrivateAccounts>;
+using BalancePerExchange = SmallVector<std::pair<Exchange *, BalancePortfolio>, kTypicalNbPrivateAccounts>;
 using WalletPerExchange = SmallVector<std::pair<const Exchange *, Wallet>, kTypicalNbPrivateAccounts>;
 using ConversionPathPerExchange =
     FixedCapacityVector<std::pair<const Exchange *, api::ExchangePublic::ConversionPath>, kNbSupportedExchanges>;

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -16,8 +16,8 @@ class StringOptionParser {
  public:
   using MarketExchanges = std::pair<Market, PublicExchangeNames>;
   using MonetaryAmountExchanges = std::pair<MonetaryAmount, PublicExchangeNames>;
-  using CurrencyCodeFromToPrivateExchange = std::tuple<CurrencyCode, CurrencyCode, PrivateExchangeName>;
-  using MonetaryAmountCurrencyCodePrivateExchange = std::tuple<MonetaryAmount, CurrencyCode, PrivateExchangeName>;
+  using CurrencyCodeFromToPrivateExchanges = std::tuple<CurrencyCode, CurrencyCode, PrivateExchangeNames>;
+  using MonetaryAmountCurrencyCodePrivateExchanges = std::tuple<MonetaryAmount, CurrencyCode, PrivateExchangeNames>;
   using MonetaryAmountFromToPrivateExchange = std::tuple<MonetaryAmount, PrivateExchangeName, PrivateExchangeName>;
   using MonetaryAmountFromToPublicExchangeToCurrency = std::tuple<MonetaryAmount, PublicExchangeNames, CurrencyCode>;
   using CurrencyCodePublicExchanges = std::pair<CurrencyCode, PublicExchangeNames>;
@@ -35,9 +35,9 @@ class StringOptionParser {
 
   MonetaryAmountExchanges getMonetaryAmountExchanges() const;
 
-  CurrencyCodeFromToPrivateExchange getFromToCurrencyCodePrivateExchange() const;
+  CurrencyCodeFromToPrivateExchanges getFromToCurrencyCodePrivateExchanges() const;
 
-  MonetaryAmountCurrencyCodePrivateExchange getMonetaryAmountCurrencyCodePrivateExchange() const;
+  MonetaryAmountCurrencyCodePrivateExchanges getMonetaryAmountCurrencyCodePrivateExchanges() const;
 
   MonetaryAmountFromToPrivateExchange getMonetaryAmountFromToPrivateExchange() const;
 

--- a/src/engine/src/coincenterparsedoptions.cpp
+++ b/src/engine/src/coincenterparsedoptions.cpp
@@ -111,11 +111,11 @@ void CoincenterParsedOptions::setFromOptions(const CoincenterCmdLineOptions &cmd
   if (!tradeArgs.empty()) {
     StringOptionParser anyParser(tradeArgs);
     if (isTradeAll) {
-      std::tie(fromTradeCurrency, toTradeCurrency, tradePrivateExchangeName) =
-          anyParser.getFromToCurrencyCodePrivateExchange();
+      std::tie(fromTradeCurrency, toTradeCurrency, tradePrivateExchangeNames) =
+          anyParser.getFromToCurrencyCodePrivateExchanges();
     } else {
-      std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeName) =
-          anyParser.getMonetaryAmountCurrencyCodePrivateExchange();
+      std::tie(startTradeAmount, toTradeCurrency, tradePrivateExchangeNames) =
+          anyParser.getMonetaryAmountCurrencyCodePrivateExchanges();
     }
 
     TradeMode tradeMode = cmdLineOptions.trade_sim ? TradeMode::kSimulation : TradeMode::kReal;

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -25,6 +25,14 @@ PrivateExchangeNames GetPrivateExchanges(std::string_view str) {
                  [](std::string_view exchangeName) { return PrivateExchangeName(exchangeName); });
   return ret;
 }
+
+std::string_view StrBeforeComma(std::string_view opt, std::size_t startPos, std::size_t commaPos) {
+  return std::string_view(opt.begin() + startPos, commaPos == string::npos ? opt.end() : opt.begin() + commaPos);
+}
+
+std::string_view StrEnd(std::string_view opt, std::size_t startPos) {
+  return std::string_view(opt.begin() + startPos, opt.end());
+}
 }  // namespace
 
 PublicExchangeNames StringOptionParser::getExchanges() const { return GetExchanges(_opt); }
@@ -52,56 +60,54 @@ StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() con
 
   return MarketExchanges{Market(CurrencyCode(std::string_view(marketStr.begin(), marketStr.begin() + dashPos)),
                                 CurrencyCode(std::string_view(marketStr.begin() + dashPos + 1, marketStr.end()))),
-                         GetExchanges(std::string_view(_opt.begin() + startExchangesPos, _opt.end()))};
+                         GetExchanges(StrEnd(_opt, startExchangesPos))};
 }
 
 StringOptionParser::MonetaryAmountExchanges StringOptionParser::getMonetaryAmountExchanges() const {
   std::size_t commaPos = getNextCommaPos(0, false);
   std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
-  return MonetaryAmountExchanges{
-      MonetaryAmount(std::string_view(_opt.begin(), commaPos == string::npos ? _opt.end() : _opt.begin() + commaPos)),
-      GetExchanges(std::string_view(_opt.begin() + startExchangesPos, _opt.end()))};
+  return MonetaryAmountExchanges{MonetaryAmount(StrBeforeComma(_opt, 0, commaPos)),
+                                 GetExchanges(StrEnd(_opt, startExchangesPos))};
 }
 
-StringOptionParser::CurrencyCodeFromToPrivateExchange StringOptionParser::getFromToCurrencyCodePrivateExchange() const {
+StringOptionParser::CurrencyCodeFromToPrivateExchanges StringOptionParser::getFromToCurrencyCodePrivateExchanges()
+    const {
   std::size_t dashPos = _opt.find('-', 1);
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
-  CurrencyCode fromTradeCurrency(std::string_view(_opt.begin(), _opt.begin() + dashPos));
-  std::size_t commaPos = getNextCommaPos(dashPos + 1);
+  CurrencyCode fromTradeCurrency(std::string_view(_opt.data(), dashPos));
+  std::size_t commaPos = getNextCommaPos(dashPos + 1, false);
   std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
-  CurrencyCode toTradeCurrency(std::string_view(_opt.begin() + dashPos + 1, _opt.begin() + commaPos));
-  return std::make_tuple(fromTradeCurrency, toTradeCurrency,
-                         PrivateExchangeName(std::string_view(_opt.begin() + startExchangesPos, _opt.end())));
+  CurrencyCode toTradeCurrency(StrBeforeComma(_opt, dashPos + 1, commaPos));
+  return std::make_tuple(fromTradeCurrency, toTradeCurrency, GetPrivateExchanges(StrEnd(_opt, startExchangesPos)));
 }
 
-StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange
-StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchange() const {
+StringOptionParser::MonetaryAmountCurrencyCodePrivateExchanges
+StringOptionParser::getMonetaryAmountCurrencyCodePrivateExchanges() const {
   std::size_t dashPos = _opt.find('-', 1);
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
-  MonetaryAmount startTradeAmount(std::string_view(_opt.begin(), _opt.begin() + dashPos));
-  std::size_t commaPos = getNextCommaPos(dashPos + 1);
+  MonetaryAmount startTradeAmount(std::string_view(_opt.data(), dashPos));
+  std::size_t commaPos = getNextCommaPos(dashPos + 1, false);
   std::size_t startExchangesPos = commaPos == string::npos ? _opt.size() : _opt.find_first_not_of(' ', commaPos + 1);
-  CurrencyCode toTradeCurrency(std::string_view(_opt.begin() + dashPos + 1, _opt.begin() + commaPos));
-  return std::make_tuple(startTradeAmount, toTradeCurrency,
-                         PrivateExchangeName(std::string_view(_opt.begin() + startExchangesPos, _opt.end())));
+  CurrencyCode toTradeCurrency(StrBeforeComma(_opt, dashPos + 1, commaPos));
+  return std::make_tuple(startTradeAmount, toTradeCurrency, GetPrivateExchanges(StrEnd(_opt, startExchangesPos)));
 }
 
 StringOptionParser::MonetaryAmountFromToPrivateExchange StringOptionParser::getMonetaryAmountFromToPrivateExchange()
     const {
   std::size_t commaPos = getNextCommaPos();
   MonetaryAmount amountToWithdraw(std::string_view(_opt.begin(), _opt.begin() + commaPos));
-  std::string_view exchangeNames(_opt.begin() + commaPos + 1, _opt.end());
+  std::string_view exchangeNames = StrEnd(_opt, commaPos + 1);
   std::size_t dashPos = exchangeNames.find('-');
   if (dashPos == string::npos) {
     throw std::invalid_argument("Expected a dash");
   }
   return MonetaryAmountFromToPrivateExchange{
       amountToWithdraw, PrivateExchangeName(std::string_view(exchangeNames.begin(), exchangeNames.begin() + dashPos)),
-      PrivateExchangeName(std::string_view(exchangeNames.begin() + dashPos + 1, exchangeNames.end()))};
+      PrivateExchangeName(StrEnd(exchangeNames, dashPos + 1))};
 }
 
 std::size_t StringOptionParser::getNextCommaPos(std::size_t startPos, bool throwIfNone) const {
@@ -119,7 +125,7 @@ StringOptionParser::CurrencyCodePublicExchanges StringOptionParser::getCurrencyC
     ret.first = CurrencyCode(_opt);
   } else {
     ret.first = CurrencyCode(std::string_view(_opt.begin(), _opt.begin() + commaPos));
-    ret.second = GetExchanges(std::string_view(_opt.begin() + commaPos + 1, _opt.end()));
+    ret.second = GetExchanges(StrEnd(_opt, commaPos + 1));
   }
   return ret;
 }

--- a/src/engine/test/stringoptionparser_test.cpp
+++ b/src/engine/test/stringoptionparser_test.cpp
@@ -33,13 +33,18 @@ TEST(StringOptionParserTest, GetMonetaryAmountExchanges) {
             StringOptionParser::MonetaryAmountExchanges(MonetaryAmount("-0.6509BTC"), PublicExchangeNames({"kraken"})));
 }
 
-TEST(StringOptionParserTest, GetMonetaryAmountCurrencyCodePrivateExchange) {
-  EXPECT_EQ(StringOptionParser("45.09ADA-eur,bithumb").getMonetaryAmountCurrencyCodePrivateExchange(),
-            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange(
-                MonetaryAmount("45.09ADA"), CurrencyCode("EUR"), PrivateExchangeName("bithumb")));
-  EXPECT_EQ(StringOptionParser("0.02btc-xlm,upbit_user1").getMonetaryAmountCurrencyCodePrivateExchange(),
-            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchange(
-                MonetaryAmount("0.02BTC"), CurrencyCode("XLM"), PrivateExchangeName("upbit", "user1")));
+TEST(StringOptionParserTest, GetMonetaryAmountCurrencyCodePrivateExchanges) {
+  EXPECT_EQ(
+      StringOptionParser("45.09ADA-eur,bithumb").getMonetaryAmountCurrencyCodePrivateExchanges(),
+      StringOptionParser::MonetaryAmountCurrencyCodePrivateExchanges(
+          MonetaryAmount("45.09ADA"), CurrencyCode("EUR"), PrivateExchangeNames(1, PrivateExchangeName("bithumb"))));
+  EXPECT_EQ(StringOptionParser("0.02btc-xlm,upbit_user1,binance").getMonetaryAmountCurrencyCodePrivateExchanges(),
+            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchanges(
+                MonetaryAmount("0.02BTC"), CurrencyCode("XLM"),
+                PrivateExchangeNames({PrivateExchangeName("upbit", "user1"), PrivateExchangeName("binance")})));
+  EXPECT_EQ(StringOptionParser("2500.5 eur-sol").getMonetaryAmountCurrencyCodePrivateExchanges(),
+            StringOptionParser::MonetaryAmountCurrencyCodePrivateExchanges(
+                MonetaryAmount("2500.5 EUR"), CurrencyCode("SOL"), PrivateExchangeNames()));
 }
 
 TEST(StringOptionParserTest, GetMonetaryAmountFromToPrivateExchange) {

--- a/src/objects/include/balanceportfolio.hpp
+++ b/src/objects/include/balanceportfolio.hpp
@@ -27,6 +27,8 @@ class BalancePortfolio {
 
   MonetaryAmount get(CurrencyCode currencyCode) const;
 
+  bool hasAtLeast(MonetaryAmount amount) const { return get(amount.currencyCode()) >= amount; }
+
   const_iterator begin() const { return _sortedAmounts.begin(); }
   const_iterator end() const { return _sortedAmounts.end(); }
 

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -34,11 +34,9 @@ class CurrencyCode {
   constexpr CurrencyCode() noexcept : _data() {}
 
   /// Constructs a currency code from a static char array.
-  template <unsigned N, std::enable_if_t<N <= sizeof(AcronymType), bool> = true>
+  template <unsigned N, std::enable_if_t<N <= kAcronymMaxLen + 1, bool> = true>
   constexpr CurrencyCode(const char (&acronym)[N]) noexcept {
-    // Fill extra chars to 0 is important as we always read them for code generation
-    std::fill(std::transform(std::begin(acronym), std::end(acronym), _data.begin(), [](char c) { return toupper(c); }),
-              _data.end(), '\0');
+    set(acronym);
   }
 
   /// Constructs a currency code from given string.
@@ -49,8 +47,7 @@ class CurrencyCode {
       }
       acronym.remove_suffix(acronym.size() - _data.size());
     }
-    std::fill(std::transform(acronym.begin(), acronym.end(), _data.begin(), [](char c) { return toupper(c); }),
-              _data.end(), '\0');  // Fill extra chars to 0 is important as we always read them for code generation
+    set(acronym);
   }
 
   /// Get a string view of this CurrencyCode, trimmed.
@@ -76,11 +73,15 @@ class CurrencyCode {
 
   constexpr auto operator<=>(const CurrencyCode &) const = default;
 
-  constexpr bool operator==(CurrencyCode o) const { return std::equal(_data.begin(), _data.end(), o._data.begin()); }
-  constexpr bool operator!=(CurrencyCode o) const { return !(*this == o); }
+  constexpr bool operator==(const CurrencyCode &) const = default;
 
  private:
   AcronymType _data;
+
+  constexpr inline void set(std::string_view acronym) {
+    std::fill(std::transform(acronym.begin(), acronym.end(), _data.begin(), [](char c) { return toupper(c); }),
+              _data.end(), '\0');  // Fill extra chars to 0 is important as we always read them for code generation
+  }
 };
 
 std::ostream &operator<<(std::ostream &os, const CurrencyCode &c);

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -202,8 +202,8 @@ inline std::optional<MonetaryAmount> ComputeAvgPrice(Market m,
   if (amountsPerPrice.size() == 1) {
     return amountsPerPrice.front().price;
   }
-  MonetaryAmount ret("0", m.quote());
-  MonetaryAmount totalAmount("0", m.base());
+  MonetaryAmount ret(0, m.quote());
+  MonetaryAmount totalAmount(0, m.base());
   for (const MarketOrderBook::AmountAtPrice& amountAtPrice : amountsPerPrice) {
     ret += amountAtPrice.amount.toNeutral() * amountAtPrice.price;
     totalAmount += amountAtPrice.amount;

--- a/src/objects/test/currencycode_test.cpp
+++ b/src/objects/test/currencycode_test.cpp
@@ -31,6 +31,8 @@ TEST(CurrencyCodeTest, Equality) {
   EXPECT_EQ(sushi, sushi2);
   EXPECT_EQ(sushi2, sushi);
   EXPECT_NE(renbtc, doge2);
+  EXPECT_EQ(CurrencyCode("sol"), CurrencyCode("SOL"));
+  EXPECT_EQ(CurrencyCode("sol").code(), CurrencyCode("SOL").code());
 }
 
 TEST(CurrencyCodeTest, Comparison) {

--- a/src/tech/include/cct_config.hpp
+++ b/src/tech/include/cct_config.hpp
@@ -59,3 +59,10 @@
 #else
 #error "Unknown compiler"
 #endif
+
+#if !defined(__clang__)
+// Explicit constructor for this aggregate as clang does not implement CTAD yet (as of December 2021)
+// More information here:
+// https://stackoverflow.com/questions/70260994/automatic-template-deduction-c20-with-aggregate-type
+#define CCT_CTAD_SUPPORT
+#endif

--- a/src/tech/include/cct_hash.hpp
+++ b/src/tech/include/cct_hash.hpp
@@ -43,10 +43,7 @@ class HashTuple {
   struct Component {
     const T& value;
 
-#if defined(__clang__)
-    // Explicit constructor for this aggregate as clang does not implement CTAD yet (as of December 2021)
-    // More information here:
-    // https://stackoverflow.com/questions/70260994/automatic-template-deduction-c20-with-aggregate-type
+#ifndef CCT_CTAD_SUPPORT
     explicit Component(const T& v) : value(v) {}
 #endif
 


### PR DESCRIPTION
For a `trade-all`, there is no ambiguity about where we should trade, all amounts on exchanges supporting given market will trade all their amount.
However, for standard `trade` only a total of given amount will be traded, shared among the exchanges having some available amount.