### PR TITLE
Fix crash occurring after generate_address in Kucoin while reading memo which can be null

### DIFF
--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -97,7 +97,7 @@ class ExchangePrivate : public ExchangeBase {
   const ExchangeInfo &exchangeInfo() const { return _exchangePublic.exchangeInfo(); }
 
  protected:
-  ExchangePrivate(ExchangePublic &exchangePublic, const CoincenterInfo &coincenterInfo, const APIKey &apiKey)
+  ExchangePrivate(const CoincenterInfo &coincenterInfo, ExchangePublic &exchangePublic, const APIKey &apiKey)
       : ExchangeBase(),
         _exchangePublic(exchangePublic),
         _cachedResultVault(exchangePublic._cachedResultVault),

--- a/src/api/common/test/exchangeprivateapi_test.cpp
+++ b/src/api/common/test/exchangeprivateapi_test.cpp
@@ -9,7 +9,7 @@ namespace cct::api {
 class MockExchangePrivate : public ExchangePrivate {
  public:
   MockExchangePrivate(ExchangePublic &exchangePublic, const CoincenterInfo &config, const APIKey &apiKey)
-      : ExchangePrivate(exchangePublic, config, apiKey) {}
+      : ExchangePrivate(config, exchangePublic, apiKey) {}
 
   MOCK_METHOD(CurrencyExchangeFlatSet, queryTradableCurrencies, (), (override));
   MOCK_METHOD(BalancePortfolio, queryAccountBalance, (CurrencyCode equiCurrency), (override));

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -69,7 +69,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
 }  // namespace
 
 BinancePrivate::BinancePrivate(const CoincenterInfo& config, BinancePublic& binancePublic, const APIKey& apiKey)
-    : ExchangePrivate(binancePublic, config, apiKey),
+    : ExchangePrivate(config, binancePublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(binancePublic.name()).minPrivateQueryDelay(),
                   config.getRunMode()),
       _tradableCurrenciesCache(

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -218,7 +218,7 @@ File GetBithumbDecimalsCache(std::string_view dataDir) {
 }  // namespace
 
 BithumbPrivate::BithumbPrivate(const CoincenterInfo& config, BithumbPublic& bithumbPublic, const APIKey& apiKey)
-    : ExchangePrivate(bithumbPublic, config, apiKey),
+    : ExchangePrivate(config, bithumbPublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(bithumbPublic.name()).minPrivateQueryDelay(),
                   config.getRunMode()),
       _nbDecimalsRefreshTime(config.getAPICallUpdateFrequency(QueryTypeEnum::kNbDecimalsUnitsBithumb)),

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -80,7 +80,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
 }  // namespace
 
 HuobiPrivate::HuobiPrivate(const CoincenterInfo& config, HuobiPublic& huobiPublic, const APIKey& apiKey)
-    : ExchangePrivate(huobiPublic, config, apiKey),
+    : ExchangePrivate(config, huobiPublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(huobiPublic.name()).minPrivateQueryDelay(),
                   config.getRunMode()),
       _accountIdCache(CachedResultOptions(std::chrono::hours(96), _cachedResultVault), _curlHandle, apiKey),

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -89,7 +89,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, std::string_view
 }  // namespace
 
 KrakenPrivate::KrakenPrivate(const CoincenterInfo& config, KrakenPublic& krakenPublic, const APIKey& apiKey)
-    : ExchangePrivate(krakenPublic, config, apiKey),
+    : ExchangePrivate(config, krakenPublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo("kraken").minPrivateQueryDelay(), config.getRunMode()),
       _depositWalletsCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kDepositWallet), _cachedResultVault),

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -122,7 +122,7 @@ bool EnsureEnoughAmountIn(CurlHandle& curlHandle, const APIKey& apiKey, Monetary
 }  // namespace
 
 KucoinPrivate::KucoinPrivate(const CoincenterInfo& config, KucoinPublic& kucoinPublic, const APIKey& apiKey)
-    : ExchangePrivate(kucoinPublic, config, apiKey),
+    : ExchangePrivate(config, kucoinPublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(kucoinPublic.name()).minPrivateQueryDelay(),
                   config.getRunMode()),
       _depositWalletsCache(
@@ -155,7 +155,8 @@ Wallet KucoinPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
   }
 
   std::string_view address = result["address"].get<std::string_view>();
-  std::string_view tag = result["memo"].get<std::string_view>();
+  auto memoIt = result.find("memo");
+  std::string_view tag = (memoIt != result.end() && !memoIt->is_null()) ? memoIt->get<std::string_view>() : "";
 
   PrivateExchangeName privateExchangeName(_kucoinPublic.name(), _apiKey.name());
 

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -70,7 +70,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
 }  // namespace
 
 UpbitPrivate::UpbitPrivate(const CoincenterInfo& config, UpbitPublic& upbitPublic, const APIKey& apiKey)
-    : ExchangePrivate(upbitPublic, config, apiKey),
+    : ExchangePrivate(config, upbitPublic, apiKey),
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(upbitPublic.name()).minPrivateQueryDelay(),
                   config.getRunMode()),
       _tradableCurrenciesCache(

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -43,6 +43,8 @@ class CurrencyExchange {
   bool operator==(const CurrencyExchange &o) const { return _standardCode == o._standardCode; }
   bool operator!=(const CurrencyExchange &o) const { return !(*this == o); }
 
+  operator CurrencyCode() const { return _standardCode; }
+
  private:
   CurrencyCode _standardCode;
   CurrencyCode _exchangeCode;


### PR DESCRIPTION
Also exchanged two parameters for `ExchangePrivate` constructor to be consistent with `ExchangePrivate` implementations.