### PR TITLE
Do not create empty MarketOrderBook in AllOrderBooks computation for Kraken

### DIFF
--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -306,7 +306,9 @@ ExchangePublic::MarketOrderBookMap KrakenPublic::AllOrderBooksFunc::operator()(i
 
     const MarketsFunc::MarketInfo& marketInfo = marketInfoMap.find(m)->second;
 
-    ret.insert_or_assign(m, MarketOrderBook(askPri, askVol, bidPri, bidVol, marketInfo.volAndPriNbDecimals, depth));
+    if (!bidVol.isZero() && !askVol.isZero()) {
+      ret.insert_or_assign(m, MarketOrderBook(askPri, askVol, bidPri, bidVol, marketInfo.volAndPriNbDecimals, depth));
+    }
   }
 
   log::info("Retrieved ticker information from {} markets", ret.size());


### PR DESCRIPTION
Fixes invalid `MarketOrderBook` creation attempts after ticker information call.

```
[2022-01-11 17:02:11.823] [info] GET https://api.kraken.com/0/public/Ticker opts pair=1INCHEUR,1INCHUSD,AAVEAUD,AAVEXBT,AAVEETH,AAVEEUR,...
[2022-01-11 17:02:12.162] [critical] Bid pri 100 JPY, Ask pri 0 JPY, Bid vol 5 BAT, Ask vol 0 BAT
[2022-01-11 17:02:12.162] [critical] Invalid ticker information for MarketOrderBook
terminate called after throwing an instance of 'cct::exception'
  what():  Invalid ticker information for MarketOrderBook
```