### PR TITLE
Heavy CurlOptions refactoring

### DIFF
--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -13,15 +13,11 @@ namespace cct {
 namespace api {
 namespace {
 string Query(CurlHandle& curlHandle, std::string_view method, CurlPostData&& postData = CurlPostData()) {
-  string method_url("https://api.cryptowat.ch");
-  method_url.push_back('/');
-  method_url.append(method);
-
-  CurlOptions opts(HttpRequestType::kGet);
-  opts.userAgent = "Cryptowatch C++ API Client";
-  opts.postdata = std::move(postData);
-
-  return curlHandle.query(method_url, opts);
+  string methodUrl("https://api.cryptowat.ch");
+  methodUrl.push_back('/');
+  methodUrl.append(method);
+  return curlHandle.query(methodUrl,
+                          CurlOptions(HttpRequestType::kGet, std::move(postData), "Cryptowatch C++ API Client"));
 }
 
 const json& CollectResults(const json& dataJson) {

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -36,8 +36,8 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
   url.append(method);
 
   CurlOptions opts(requestType, std::forward<CurlPostDataT>(curlPostData), BinancePublic::kUserAgent);
-  SetNonceAndSignature(apiKey, opts.postdata);
-  opts.httpHeaders.emplace_back("X-MBX-APIKEY: ").append(apiKey.key());
+  opts.appendHttpHeader("X-MBX-APIKEY", apiKey.key());
+  SetNonceAndSignature(apiKey, opts.getPostData());
 
   json dataJson = json::parse(curlHandle.query(url, opts));
   auto binanceError = [](const json& j) { return j.contains("code") && j.contains("msg"); };
@@ -51,7 +51,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
       sleepingTime = (3 * sleepingTime) / 2;
       log::trace("Wait {} ms...", std::chrono::duration_cast<std::chrono::milliseconds>(sleepingTime).count());
       std::this_thread::sleep_for(sleepingTime);
-      SetNonceAndSignature(apiKey, opts.postdata);
+      SetNonceAndSignature(apiKey, opts.getPostData());
       dataJson = json::parse(curlHandle.query(url, opts));
       if (!binanceError(dataJson)) {
         return dataJson;

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -30,9 +30,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view baseURL, std::string_v
     url.push_back('?');
     url.append(curlPostData.str());
   }
-  CurlOptions opts(HttpRequestType::kGet);
-  opts.userAgent = BinancePublic::kUserAgent;
-  json dataJson = json::parse(curlHandle.query(url, opts));
+  json dataJson = json::parse(curlHandle.query(url, CurlOptions(HttpRequestType::kGet, BinancePublic::kUserAgent)));
   auto foundErrorIt = dataJson.find("code");
   auto foundMsgIt = dataJson.find("msg");
   if (foundErrorIt != dataJson.end() && foundMsgIt != dataJson.end()) {

--- a/src/api/exchanges/src/bithumbpublicapi.cpp
+++ b/src/api/exchanges/src/bithumbpublicapi.cpp
@@ -21,23 +21,21 @@ namespace {
 
 json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurrencyCode base,
                  CurrencyCode quote = CurrencyCode(), std::string_view urlOpts = "") {
-  string method_url(BithumbPublic::kUrlBase);
-  method_url.append(endpoint);
-  method_url.push_back('/');
-  method_url.append(base.str());
+  string methodUrl(BithumbPublic::kUrlBase);
+  methodUrl.append(endpoint);
+  methodUrl.push_back('/');
+  methodUrl.append(base.str());
   if (!quote.isNeutral()) {
-    method_url.push_back('_');
-    method_url.append(quote.str());
+    methodUrl.push_back('_');
+    methodUrl.append(quote.str());
   }
   if (!urlOpts.empty()) {
-    method_url.push_back('?');
-    method_url.append(urlOpts);
+    methodUrl.push_back('?');
+    methodUrl.append(urlOpts);
   }
 
-  CurlOptions opts(HttpRequestType::kGet);
-  opts.userAgent = BithumbPublic::kUserAgent;
-
-  json dataJson = json::parse(curlHandle.query(method_url, opts));
+  json dataJson =
+      json::parse(curlHandle.query(methodUrl, CurlOptions(HttpRequestType::kGet, BithumbPublic::kUserAgent)));
   auto errorIt = dataJson.find("status");
   if (errorIt != dataJson.end()) {
     std::string_view statusCode = errorIt->get<std::string_view>();  // "5300" for instance
@@ -109,8 +107,7 @@ ExchangePublic::WithdrawalFeeMap BithumbPublic::WithdrawalFeesFunc::operator()()
   WithdrawalFeeMap ret;
   // This is not a published API and only a "standard" html page. We will capture the text information in it.
   // Warning, it's not in json format so we will need manual parsing.
-  CurlOptions opts(HttpRequestType::kGet);
-  string s = _curlHandle.query("https://www.bithumb.com/customer_support/info_fee", opts);
+  string s = _curlHandle.query("https://www.bithumb.com/customer_support/info_fee", CurlOptions(HttpRequestType::kGet));
   // Now, we have the big string containing the html data. The following should work as long as format is unchanged.
   // here is a line containing our coin with its additional withdrawal fees:
   //

--- a/src/api/exchanges/src/huobipublicapi.cpp
+++ b/src/api/exchanges/src/huobipublicapi.cpp
@@ -25,9 +25,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, const CurlPo
     url.push_back('?');
     url.append(curlPostData.str());
   }
-  CurlOptions opts(HttpRequestType::kGet);
-  opts.userAgent = HuobiPublic::kUserAgent;
-  json dataJson = json::parse(curlHandle.query(url, opts));
+  json dataJson = json::parse(curlHandle.query(url, CurlOptions(HttpRequestType::kGet, HuobiPublic::kUserAgent)));
   bool returnData = dataJson.contains("data");
   if (!returnData && !dataJson.contains("tick")) {
     throw exception("No data for Huobi public endpoint");

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -18,14 +18,14 @@ namespace api {
 namespace {
 
 string GetMethodUrl(std::string_view method) {
-  string method_url(KrakenPublic::kUrlBase);
-  method_url.append(method);
-  return method_url;
+  string methodUrl(KrakenPublic::kUrlBase);
+  methodUrl.append(method);
+  return methodUrl;
 }
 
 json PublicQuery(CurlHandle& curlHandle, std::string_view method, CurlPostData&& postData = CurlPostData()) {
-  CurlOptions opts(HttpRequestType::kGet, std::move(postData), KrakenPublic::kUserAgent);
-  json jsonData = json::parse(curlHandle.query(GetMethodUrl(method), opts));
+  json jsonData = json::parse(curlHandle.query(
+      GetMethodUrl(method), CurlOptions(HttpRequestType::kGet, std::move(postData), KrakenPublic::kUserAgent)));
   auto errorIt = jsonData.find("error");
   if (errorIt != jsonData.end() && !errorIt->empty()) {
     std::string_view msg = errorIt->front().get<std::string_view>();
@@ -145,8 +145,8 @@ MonetaryAmount KrakenPublic::queryWithdrawalFee(CurrencyCode currencyCode) {
 }
 
 KrakenPublic::WithdrawalFeesFunc::WithdrawalInfoMaps KrakenPublic::WithdrawalFeesFunc::updateFromSource1() {
-  CurlOptions opts(HttpRequestType::kGet);
-  string withdrawalFeesCsv = _curlHandle1.query("https://withdrawalfees.com/exchanges/kraken", opts);
+  string withdrawalFeesCsv =
+      _curlHandle1.query("https://withdrawalfees.com/exchanges/kraken", CurlOptions(HttpRequestType::kGet));
 
   static constexpr std::string_view kBeginWithdrawalFeeHtmlTag = "<td class=withdrawalFee>";
   static constexpr std::string_view kBeginMinWithdrawalHtmlTag = "<td class=minWithdrawal>";
@@ -194,8 +194,8 @@ KrakenPublic::WithdrawalFeesFunc::WithdrawalInfoMaps KrakenPublic::WithdrawalFee
 }
 
 KrakenPublic::WithdrawalFeesFunc::WithdrawalInfoMaps KrakenPublic::WithdrawalFeesFunc::updateFromSource2() {
-  CurlOptions opts(HttpRequestType::kGet);
-  string withdrawalFeesCsv = _curlHandle2.query("https://www.cryptofeesaver.com/exchanges/fees/kraken", opts);
+  string withdrawalFeesCsv =
+      _curlHandle2.query("https://www.cryptofeesaver.com/exchanges/fees/kraken", CurlOptions(HttpRequestType::kGet));
 
   static constexpr std::string_view kBeginTableTitle = "Kraken Deposit & Withdrawal fees</h2>";
 

--- a/src/api/exchanges/src/kucoinpublicapi.cpp
+++ b/src/api/exchanges/src/kucoinpublicapi.cpp
@@ -27,9 +27,7 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, const CurlPo
     url.push_back('?');
     url.append(curlPostData.str());
   }
-  CurlOptions opts(HttpRequestType::kGet);
-  opts.userAgent = KucoinPublic::kUserAgent;
-  json dataJson = json::parse(curlHandle.query(url, opts));
+  json dataJson = json::parse(curlHandle.query(url, CurlOptions(HttpRequestType::kGet, KucoinPublic::kUserAgent)));
   if (dataJson.contains("code") && dataJson["code"].get<std::string_view>() != "200000") {
     throw exception("Error in Kucoin REST API response");
   }

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -15,16 +15,15 @@ namespace api {
 namespace {
 
 string GetMethodUrl(std::string_view endpoint) {
-  string method_url(UpbitPublic::kUrlBase);
-  method_url.append("/v1/");
-  method_url.append(endpoint);
-  return method_url;
+  string methodUrl(UpbitPublic::kUrlBase);
+  methodUrl.append("/v1/");
+  methodUrl.append(endpoint);
+  return methodUrl;
 }
 
 json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurlPostData&& postData = CurlPostData()) {
-  CurlOptions opts(HttpRequestType::kGet, std::move(postData), UpbitPublic::kUserAgent);
-
-  json dataJson = json::parse(curlHandle.query(GetMethodUrl(endpoint), opts));
+  json dataJson = json::parse(curlHandle.query(
+      GetMethodUrl(endpoint), CurlOptions(HttpRequestType::kGet, std::move(postData), UpbitPublic::kUserAgent)));
   //{"error":{"name":400,"message":"Type mismatch error. Check the parameters type!"}}
   if (dataJson.contains("error")) {
     const long statusCode = dataJson["name"].get<long>();

--- a/src/api/exchanges/test/commonapi_test.hpp
+++ b/src/api/exchanges/test/commonapi_test.hpp
@@ -15,11 +15,19 @@
 
 namespace cct {
 
+/// For API tests, standard exchange config is not loaded, we have a dummy one instead.
 ExchangeInfoMap ComputeExchangeInfoMap(std::string_view) {
   ExchangeInfoMap ret;
   for (std::string_view exchangeName : kSupportedExchanges) {
-    ret.insert_or_assign(string(exchangeName), ExchangeInfo(exchangeName, "0.1", "0.1", std::span<const CurrencyCode>(),
-                                                            std::span<const CurrencyCode>(), 1000, 1000, false, false));
+    static constexpr bool kValidateDepositAddressesInFile = false;
+    static constexpr bool kPlaceSimulatedRealOrder = false;
+    static constexpr int kMinPublicDelayMs = 1000;
+    static constexpr int kMinPrivateDelayMs = 1000;
+
+    ret.insert_or_assign(
+        string(exchangeName),
+        ExchangeInfo(exchangeName, "0.1", "0.1", std::span<const CurrencyCode>(), std::span<const CurrencyCode>(),
+                     kMinPublicDelayMs, kMinPrivateDelayMs, kValidateDepositAddressesInFile, kPlaceSimulatedRealOrder));
   }
   return ret;
 }

--- a/src/monitoring/src/metric.cpp
+++ b/src/monitoring/src/metric.cpp
@@ -4,11 +4,9 @@
 
 namespace cct {
 MetricKey CreateMetricKey(std::string_view name, std::string_view help) {
-  string s("metric_name=");
-  s.reserve(s.size() + name.size() + help.size() + 13U);
-  s.append(name);
-  s.append(",metric_help=");
-  s.append(help);
-  return MetricKey(std::move(s));
+  MetricKey key;
+  key.append(kMetricNameKey, name);
+  key.append(kMetricHelpKey, help);
+  return key;
 }
 }  // namespace cct

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -75,15 +75,13 @@ void FiatConverter::updateCacheFile() const {
 std::optional<double> FiatConverter::queryCurrencyRate(Market m) {
   string url = "https://free.currconv.com/api/v7/convert?";
 
-  CurlOptions opts(HttpRequestType::kGet);
   string qStr(m.assetsPairStr('_'));
-  opts.postdata.append("q", qStr);
-  opts.postdata.append("apiKey", _apiKey);
+  CurlOptions opts(HttpRequestType::kGet, {{"q", qStr}, {"apiKey", _apiKey}});
 
-  url.append(opts.postdata.str());
-  opts.postdata.clear();
+  url.append(opts.getPostData().str());
+  opts.getPostData().clear();
 
-  json data = json::parse(_curlHandle.query(url, opts), nullptr, false /* allow exceptions */);
+  json data = json::parse(_curlHandle.query(url, std::move(opts)), nullptr, false /* allow exceptions */);
   //{"query":{"count":1},"results":{"EUR_KRW":{"id":"EUR_KRW","val":1329.475323,"to":"KRW","fr":"EUR"}}}
   if (data == json::value_t::discarded || !data.contains("results") || !data["results"].contains(qStr)) {
     log::error("No JSON data received from fiat currency converter service");

--- a/src/tools/include/curlhandle.hpp
+++ b/src/tools/include/curlhandle.hpp
@@ -49,7 +49,7 @@ class CurlHandle {
 
  private:
   void checkHandleOrInit();
-  void setUpProxy(const CurlOptions::ProxySettings &proxy);
+  void setUpProxy(const char *proxyUrl, bool reset);
 
   // void pointer instead of CURL to avoid having to forward declare (we don't know about the underlying definition)
   // and to avoid clients to pull unnecessary curl dependencies by just including the header

--- a/src/tools/include/curloptions.hpp
+++ b/src/tools/include/curloptions.hpp
@@ -14,37 +14,84 @@ using CurlPostData = FlatKeyValueString<'&', '='>;
 
 class CurlOptions {
  public:
-  template <class CurlPostDataT = CurlPostData>
-  explicit CurlOptions(HttpRequestType requestType, CurlPostDataT &&ipostData = CurlPostDataT(),
-                       const char *ua = nullptr, const char *pUrl = nullptr, bool v = false)
-      : userAgent(ua),
-        proxy(false, pUrl),
-        postdata(std::forward<CurlPostDataT>(ipostData)),
-        verbose(v),
-        _requestType(requestType) {}
+  // Trick: may get a null-terminated const char * for each kv pair.
+  // See usage in CurlHandle for more information.
+  using HttpHeaders = FlatKeyValueString<'\0', ':'>;
+
+  enum class Verbose : int8_t { kOff, kOn };
+  enum class PostDataFormat : int8_t { kString, kJson };
+
+  explicit CurlOptions(HttpRequestType requestType, const char *userAgent = nullptr, Verbose verbose = Verbose::kOff)
+      : _userAgent(userAgent), _verbose(verbose == Verbose::kOn), _requestType(requestType) {}
+
+  CurlOptions(HttpRequestType requestType, const CurlPostData &postData, const char *userAgent = nullptr,
+              PostDataFormat postDataFormat = PostDataFormat::kString, Verbose verbose = Verbose::kOff)
+      : _userAgent(userAgent), _postdata(postData), _verbose(verbose == Verbose::kOn), _requestType(requestType) {
+    if (postDataFormat == PostDataFormat::kJson) {
+      setPostDataInJsonFormat();
+    }
+  }
+
+  CurlOptions(HttpRequestType requestType, CurlPostData &&postData, const char *userAgent = nullptr,
+              PostDataFormat postDataFormat = PostDataFormat::kString, Verbose verbose = Verbose::kOff)
+      : _userAgent(userAgent),
+        _postdata(std::move(postData)),
+        _verbose(verbose == Verbose::kOn),
+        _requestType(requestType) {
+    if (postDataFormat == PostDataFormat::kJson) {
+      setPostDataInJsonFormat();
+    }
+  }
+
+  const HttpHeaders &getHttpHeaders() const { return _httpHeaders; }
+
+  const char *getUserAgent() const { return _userAgent; }
+
+  const char *getProxyUrl() const { return _proxyUrl; }
+
+  void setProxyUrl(const char *proxyUrl, bool reset = false) {
+    _proxyUrl = proxyUrl;
+    _proxyReset = reset;
+  }
+
+  CurlPostData &getPostData() { return _postdata; }
+  const CurlPostData &getPostData() const { return _postdata; }
+
+  bool isProxyReset() const { return _proxyReset; }
+
+  bool isVerbose() const { return _verbose; }
+
+  bool isPostDataInJsonFormat() const { return _postdataInJsonFormat; }
+
+  bool isFollowLocation() const { return _followLocation; }
 
   HttpRequestType requestType() const { return _requestType; }
 
-  std::string_view requestTypeStr() const { return ToString(_requestType); }
+  void clearHttpHeaders() { _httpHeaders.clear(); }
 
-  vector<string> httpHeaders;
+  void appendHttpHeader(std::string_view key, std::string_view value) { _httpHeaders.append(key, value); }
+  void appendHttpHeader(std::string_view key, std::integral auto value) { _httpHeaders.append(key, value); }
 
-  const char *userAgent;
+  void setHttpHeader(std::string_view key, std::string_view value) { _httpHeaders.set(key, value); }
+  void setHttpHeader(std::string_view key, std::integral auto value) { _httpHeaders.set(key, value); }
 
-  struct ProxySettings {
-    explicit ProxySettings(bool reset = false, const char *url = nullptr) : _reset(reset), _url(url) {}
-    // Required if at query level we want to avoid use of proxy
-    bool _reset;
-    const char *_url;
-  } proxy;
-
-  CurlPostData postdata;
-  bool verbose;
-  bool postdataInJsonFormat = false;
-  bool followLocation = false;
+  using trivially_relocatable = is_trivially_relocatable<HttpHeaders>::type;
 
  private:
-  HttpRequestType _requestType;
+  void setPostDataInJsonFormat() {
+    _httpHeaders.append("Content-Type", "application/json");
+    _postdataInJsonFormat = true;
+  }
+
+  HttpHeaders _httpHeaders;
+  const char *_userAgent = nullptr;
+  const char *_proxyUrl = nullptr;
+  CurlPostData _postdata;
+  bool _proxyReset = false;
+  bool _verbose = false;
+  bool _postdataInJsonFormat = false;
+  bool _followLocation = false;
+  HttpRequestType _requestType = HttpRequestType::kGet;
 };
 
 }  // namespace cct

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -4,7 +4,6 @@
 
 #include "cct_proxy.hpp"
 
-// #define DEBUG
 /* URL available to test HTTPS, cf
  * https://support.nmi.com/hc/en-gb/articles/360021544791-How-to-Check-If-the-Correct-Certificates-Are-Installed-on-Linux
  */
@@ -12,48 +11,37 @@
 namespace cct {
 namespace {
 constexpr std::string_view kTestUrl = "https://live.cardeasexml.com/ultradns.php";
-}
+const CurlOptions kVerboseHttpGetOptions(HttpRequestType::kGet, "CurlHandle C++ Test", CurlOptions::Verbose::kOn);
+}  // namespace
 
 class CurlSetup : public ::testing::Test {
  protected:
-  CurlSetup() : handle(nullptr, Clock::duration::zero(), settings::RunMode::kProd) {}
-
   virtual void SetUp() {}
   virtual void TearDown() {}
 
   CurlHandle handle;
 };
 
-TEST_F(CurlSetup, BasicCurlTest) { EXPECT_EQ(handle.query(kTestUrl, CurlOptions(HttpRequestType::kGet)), "POOL_UP"); }
+TEST_F(CurlSetup, BasicCurlTest) { EXPECT_EQ(handle.query(kTestUrl, kVerboseHttpGetOptions), "POOL_UP"); }
 
 TEST_F(CurlSetup, QueryKrakenTime) {
-  CurlOptions opts(HttpRequestType::kGet);
-#ifdef DEBUG
-  opts.verbose = true;
-#endif
-  opts.httpHeaders.push_back("MyHeaderIsVeryLongToAvoidSSO");
+  CurlOptions opts = kVerboseHttpGetOptions;
+  opts.appendHttpHeader("MyHeaderIsVeryLongToAvoidSSO", "Val1");
 
   string s = handle.query("https://api.kraken.com/0/public/Time", opts);
   EXPECT_TRUE(s.find("unixtime") != string::npos);
 }
 
 TEST_F(CurlSetup, QueryKrakenSystemStatus) {
-  CurlOptions opts(HttpRequestType::kGet);
-#ifdef DEBUG
-  opts.verbose = true;
-#endif
-  string s = handle.query("https://api.kraken.com/0/public/SystemStatus", opts);
+  string s = handle.query("https://api.kraken.com/0/public/SystemStatus", kVerboseHttpGetOptions);
   EXPECT_TRUE(s.find("online") != string::npos || s.find("maintenance") != string::npos ||
               s.find("cancel_only") != string::npos || s.find("post_only") != string::npos);
 }
 
 TEST_F(CurlSetup, ProxyMockTest) {
   if (IsProxyAvailable()) {
-    CurlOptions opts(HttpRequestType::kGet);
-    opts.proxy._url = GetProxyURL();
-#ifdef DEBUG
-    opts.verbose = true;
-#endif
+    CurlOptions opts = kVerboseHttpGetOptions;
+    opts.setProxyUrl(GetProxyURL());
     string out = handle.query(kTestUrl, opts);
     EXPECT_EQ(out, "POOL_LEFT");
   }


### PR DESCRIPTION
Make members private, improve constructors, code clean up, use FlatKeyValueString instead of string vector for HTTP headers