### PR TITLE
Slightly optimize find shortest conversion path from exchange public API

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,6 @@ jobs:
       fail-fast: false
       matrix:
         language: ["cpp"]
-        compiler: [g++-11]
         buildmode: [Debug]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
         # Learn more:
@@ -53,14 +52,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install libssl-dev libcurl4-gnutls-dev ninja-build ${{matrix.compiler}}
+          sudo apt install libssl-dev libcurl4-gnutls-dev ninja-build
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -GNinja ..
+        run: cmake -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -GNinja ..
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Configure CMake
-        run: cmake -S . -B build -A x64 -DCMAKE_BUILD_TYPE=${{matrix.buildmode}}
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.buildmode}}
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/src/api/common/include/cryptowatchapi.hpp
+++ b/src/api/common/include/cryptowatchapi.hpp
@@ -19,6 +19,8 @@ namespace api {
 /// Public API connected to different exchanges, providing fast methods to retrieve huge amount of data.
 class CryptowatchAPI : public ExchangeBase {
  public:
+  using Fiats = FlatSet<CurrencyCode>;
+
   explicit CryptowatchAPI(const CoincenterInfo &config, settings::RunMode runMode = settings::RunMode::kProd,
                           Clock::duration fiatsUpdateFrequency = std::chrono::hours(96),
                           bool loadFromFileCacheAtInit = true);
@@ -39,6 +41,12 @@ class CryptowatchAPI : public ExchangeBase {
   /// Data may not be up to date, but should respond quickly.
   std::optional<double> queryPrice(std::string_view exchangeName, Market m);
 
+  /// Returns a new set of fiat currencies.
+  Fiats queryFiats() {
+    std::lock_guard<std::mutex> guard(_fiatsMutex);
+    return _fiatsCache.get();
+  }
+
   /// Tells whether given currency code is a fiat currency or not.
   /// Fiat currencies are traditionnal currencies, such as EUR, USD, GBP, KRW, etc.
   /// Information here: https://en.wikipedia.org/wiki/Fiat_money
@@ -50,14 +58,15 @@ class CryptowatchAPI : public ExchangeBase {
   void updateCacheFile() const override;
 
  private:
-  using Fiats = FlatSet<CurrencyCode>;
   using SupportedExchanges = FlatSet<string>;
   /// Cryptowatch markets are represented by one unique string pair, it's not trivial to split the two currencies
   /// acronyms. A second match will be needed to transform it to a final 'Market'
   using PricesPerMarketMap = std::unordered_map<string, double>;
 
   struct SupportedExchangesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit SupportedExchangesFunc(CurlHandle &curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     SupportedExchanges operator()();
 
@@ -65,7 +74,9 @@ class CryptowatchAPI : public ExchangeBase {
   };
 
   struct AllPricesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit AllPricesFunc(CurlHandle &curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     json operator()();
 
@@ -73,7 +84,9 @@ class CryptowatchAPI : public ExchangeBase {
   };
 
   struct FiatsFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit FiatsFunc(CurlHandle &curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     Fiats operator()();
 

--- a/src/api/common/include/tradeinfo.hpp
+++ b/src/api/common/include/tradeinfo.hpp
@@ -10,8 +10,10 @@
 namespace cct::api {
 
 struct OrderRef {
+#ifndef CCT_AGGR_INIT_CXX20
   OrderRef(const OrderId &orderId, int64_t nbSecondsSinceEpoch, Market market, TradeSide s)
       : id(orderId), userRef(nbSecondsSinceEpoch), m(market), side(s) {}
+#endif
 
   CurrencyCode fromCur() const { return side == TradeSide::kSell ? m.base() : m.quote(); }
   CurrencyCode toCur() const { return side == TradeSide::kBuy ? m.base() : m.quote(); }
@@ -23,7 +25,7 @@ struct OrderRef {
 };
 
 struct TradeInfo {
-#ifndef CCT_CTAD_SUPPORT
+#ifndef CCT_AGGR_INIT_CXX20
   TradeInfo(int64_t nbSecondsSinceEpoch, Market market, TradeSide s, const TradeOptions &opts)
       : userRef(nbSecondsSinceEpoch), m(market), side(s), options(opts) {}
 #endif
@@ -40,12 +42,12 @@ struct TradeInfo {
 };
 
 struct OrderInfo {
+#ifndef CCT_AGGR_INIT_CXX20
   explicit OrderInfo(TradedAmounts &&ta, bool closed = false) : tradedAmounts(std::move(ta)), isClosed(closed) {}
-
-  void setClosed() { isClosed = true; }
+#endif
 
   TradedAmounts tradedAmounts;
-  bool isClosed;
+  bool isClosed = false;
 };
 
 struct PlaceOrderInfo {
@@ -54,7 +56,7 @@ struct PlaceOrderInfo {
   PlaceOrderInfo(OrderInfo &&oInfo, OrderId orderId) : orderInfo(std::move(oInfo)), orderId(std::move(orderId)) {}
 
   bool isClosed() const { return orderInfo.isClosed; }
-  void setClosed() { orderInfo.setClosed(); }
+  void setClosed() { orderInfo.isClosed = true; }
 
   TradedAmounts &tradedAmounts() { return orderInfo.tradedAmounts; }
   const TradedAmounts &tradedAmounts() const { return orderInfo.tradedAmounts; }

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -62,8 +62,10 @@ class BinancePrivate : public ExchangePrivate {
   bool checkMarketAppendSymbol(Market m, CurlPostData& params);
 
   struct TradableCurrenciesCache {
+#ifndef CCT_AGGR_INIT_CXX20
     TradableCurrenciesCache(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& binancePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _public(binancePublic) {}
+#endif
 
     CurrencyExchangeFlatSet operator()();
 
@@ -73,8 +75,10 @@ class BinancePrivate : public ExchangePrivate {
   };
 
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& binancePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _public(binancePublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 
@@ -84,8 +88,10 @@ class BinancePrivate : public ExchangePrivate {
   };
 
   struct AllWithdrawFeesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllWithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& exchangePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+#endif
 
     WithdrawalFeeMap operator()();
 
@@ -95,8 +101,10 @@ class BinancePrivate : public ExchangePrivate {
   };
 
   struct WithdrawFeesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     WithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, BinancePublic& exchangePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+#endif
 
     MonetaryAmount operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/binancepublicapi.hpp
+++ b/src/api/exchanges/include/binancepublicapi.hpp
@@ -93,7 +93,9 @@ class BinancePublic : public ExchangePublic {
   struct ExchangeInfoFunc {
     using ExchangeInfoDataByMarket = std::unordered_map<Market, json>;
 
+#ifndef CCT_AGGR_INIT_CXX20
     explicit ExchangeInfoFunc(CommonInfo& commonInfo) : _commonInfo(commonInfo) {}
+#endif
 
     ExchangeInfoDataByMarket operator()();
 
@@ -111,9 +113,11 @@ class BinancePublic : public ExchangePublic {
   };
 
   struct MarketsFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     MarketsFunc(CachedResult<ExchangeInfoFunc>& exchangeInfoCache, CurlHandle& curlHandle,
                 const ExchangeInfo& exchangeInfo)
         : _exchangeInfoCache(exchangeInfoCache), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketSet operator()();
 
@@ -123,9 +127,11 @@ class BinancePublic : public ExchangePublic {
   };
 
   struct AllOrderBooksFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllOrderBooksFunc(CachedResult<ExchangeInfoFunc>& exchangeInfoCache, CachedResult<MarketsFunc>& marketsCache,
                       CommonInfo& commonInfo)
         : _exchangeInfoCache(exchangeInfoCache), _marketsCache(marketsCache), _commonInfo(commonInfo) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -135,7 +141,9 @@ class BinancePublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit OrderBookFunc(CommonInfo& commonInfo) : _commonInfo(commonInfo) {}
+#endif
 
     MarketOrderBook operator()(Market m, int depth = kDefaultDepth);
 
@@ -143,15 +151,18 @@ class BinancePublic : public ExchangePublic {
   };
 
   struct TradedVolumeFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradedVolumeFunc(CommonInfo& commonInfo) : _commonInfo(commonInfo) {}
-
+#endif
     MonetaryAmount operator()(Market m);
 
     CommonInfo& _commonInfo;
   };
 
   struct TickerFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TickerFunc(CommonInfo& commonInfo) : _commonInfo(commonInfo) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 

--- a/src/api/exchanges/include/bithumbprivateapi.hpp
+++ b/src/api/exchanges/include/bithumbprivateapi.hpp
@@ -60,12 +60,14 @@ class BithumbPrivate : public ExchangePrivate {
 
  private:
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, MaxNbDecimalsUnitMap& maxNbDecimalsUnitMap,
                       BithumbPublic& exchangePublic)
         : _curlHandle(curlHandle),
           _apiKey(apiKey),
           _maxNbDecimalsUnitMap(maxNbDecimalsUnitMap),
           _exchangePublic(exchangePublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -53,8 +53,10 @@ class BithumbPublic : public ExchangePublic {
   friend class BithumbPrivate;
 
   struct TradableCurrenciesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     TradableCurrenciesFunc(const CoincenterInfo& config, CryptowatchAPI& cryptowatchAPI, CurlHandle& curlHandle)
         : _coincenterInfo(config), _cryptowatchAPI(cryptowatchAPI), _curlHandle(curlHandle) {}
+#endif
 
     CurrencyExchangeFlatSet operator()();
 
@@ -74,8 +76,10 @@ class BithumbPublic : public ExchangePublic {
   };
 
   struct AllOrderBooksFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllOrderBooksFunc(const CoincenterInfo& config, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -85,8 +89,10 @@ class BithumbPublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     OrderBookFunc(const CoincenterInfo& config, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _coincenterInfo(config), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBook operator()(Market m, int depth);
 
@@ -96,7 +102,9 @@ class BithumbPublic : public ExchangePublic {
   };
 
   struct TradedVolumeFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradedVolumeFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 

--- a/src/api/exchanges/include/huobiprivateapi.hpp
+++ b/src/api/exchanges/include/huobiprivateapi.hpp
@@ -54,7 +54,9 @@ class HuobiPrivate : public ExchangePrivate {
   void cancelOrderProcess(const OrderId& id);
 
   struct AccountIdFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AccountIdFunc(CurlHandle& curlHandle, const APIKey& apiKey) : _curlHandle(curlHandle), _apiKey(apiKey) {}
+#endif
 
     int operator()();
 
@@ -63,8 +65,10 @@ class HuobiPrivate : public ExchangePrivate {
   };
 
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, const HuobiPublic& huobiPublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _huobiPublic(huobiPublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/huobipublicapi.hpp
+++ b/src/api/exchanges/include/huobipublicapi.hpp
@@ -75,7 +75,9 @@ class HuobiPublic : public ExchangePublic {
   friend class HuobiPrivate;
 
   struct TradableCurrenciesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradableCurrenciesFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     json operator()();
 
@@ -83,8 +85,10 @@ class HuobiPublic : public ExchangePublic {
   };
 
   struct MarketsFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     MarketsFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     struct MarketInfo {
       MarketInfo() noexcept : maxOrderValueUSDT(std::numeric_limits<MonetaryAmount::AmountType>::max(), "USDT") {}
@@ -112,8 +116,10 @@ class HuobiPublic : public ExchangePublic {
   };
 
   struct AllOrderBooksFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllOrderBooksFunc(CachedResult<MarketsFunc>& marketsCache, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _marketsCache(marketsCache), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -123,8 +129,10 @@ class HuobiPublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     OrderBookFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBook operator()(Market m, int depth);
 
@@ -133,7 +141,9 @@ class HuobiPublic : public ExchangePublic {
   };
 
   struct TradedVolumeFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradedVolumeFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 
@@ -141,7 +151,9 @@ class HuobiPublic : public ExchangePublic {
   };
 
   struct TickerFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TickerFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 

--- a/src/api/exchanges/include/krakenprivateapi.hpp
+++ b/src/api/exchanges/include/krakenprivateapi.hpp
@@ -55,8 +55,10 @@ class KrakenPrivate : public ExchangePrivate {
 
  private:
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, KrakenPublic& exchangePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/krakenpublicapi.hpp
+++ b/src/api/exchanges/include/krakenpublicapi.hpp
@@ -57,12 +57,14 @@ class KrakenPublic : public ExchangePublic {
   friend class KrakenPrivate;
 
   struct TradableCurrenciesFunc {
-    TradableCurrenciesFunc(const CoincenterInfo& config, CryptowatchAPI& cryptowatchApi,
-                           const ExchangeInfo& exchangeInfo, CurlHandle& curlHandle)
+#ifndef CCT_AGGR_INIT_CXX20
+    TradableCurrenciesFunc(const CoincenterInfo& config, CryptowatchAPI& cryptowatchApi, CurlHandle& curlHandle,
+                           const ExchangeInfo& exchangeInfo)
         : _coincenterInfo(config),
           _cryptowatchApi(cryptowatchApi),
           _curlHandle(curlHandle),
           _exchangeInfo(exchangeInfo) {}
+#endif
 
     CurrencyExchangeFlatSet operator()();
 
@@ -91,12 +93,14 @@ class KrakenPublic : public ExchangePublic {
   };
 
   struct MarketsFunc {
-    MarketsFunc(const CoincenterInfo& config, CachedResult<TradableCurrenciesFunc>& currenciesCache,
+#ifndef CCT_AGGR_INIT_CXX20
+    MarketsFunc(CachedResult<TradableCurrenciesFunc>& currenciesCache, const CoincenterInfo& config,
                 CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _tradableCurrenciesCache(currenciesCache),
           _coincenterInfo(config),
           _curlHandle(curlHandle),
           _exchangeInfo(exchangeInfo) {}
+#endif
 
     struct MarketInfo {
       VolAndPriNbDecimals volAndPriNbDecimals;
@@ -114,12 +118,14 @@ class KrakenPublic : public ExchangePublic {
   };
 
   struct AllOrderBooksFunc {
-    AllOrderBooksFunc(const CoincenterInfo& config, CachedResult<TradableCurrenciesFunc>& currenciesCache,
-                      CachedResult<MarketsFunc>& marketsCache, CurlHandle& curlHandle)
+#ifndef CCT_AGGR_INIT_CXX20
+    AllOrderBooksFunc(CachedResult<TradableCurrenciesFunc>& currenciesCache, CachedResult<MarketsFunc>& marketsCache,
+                      const CoincenterInfo& config, CurlHandle& curlHandle)
         : _tradableCurrenciesCache(currenciesCache),
           _marketsCache(marketsCache),
           _coincenterInfo(config),
           _curlHandle(curlHandle) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -130,9 +136,11 @@ class KrakenPublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     OrderBookFunc(CachedResult<TradableCurrenciesFunc>& currenciesCache, CachedResult<MarketsFunc>& marketsCache,
                   CurlHandle& curlHandle)
         : _tradableCurrenciesCache(currenciesCache), _marketsCache(marketsCache), _curlHandle(curlHandle) {}
+#endif
 
     MarketOrderBook operator()(Market m, int count);
 
@@ -144,8 +152,10 @@ class KrakenPublic : public ExchangePublic {
   struct TickerFunc {
     using Last24hTradedVolumeAndLatestPricePair = std::pair<MonetaryAmount, MonetaryAmount>;
 
+#ifndef CCT_AGGR_INIT_CXX20
     TickerFunc(CachedResult<TradableCurrenciesFunc>& tradableCurrenciesCache, CurlHandle& curlHandle)
         : _tradableCurrenciesCache(tradableCurrenciesCache), _curlHandle(curlHandle) {}
+#endif
 
     Last24hTradedVolumeAndLatestPricePair operator()(Market m);
 

--- a/src/api/exchanges/include/kucoinprivateapi.hpp
+++ b/src/api/exchanges/include/kucoinprivateapi.hpp
@@ -50,8 +50,10 @@ class KucoinPrivate : public ExchangePrivate {
 
  private:
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, const KucoinPublic& kucoinPublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _kucoinPublic(kucoinPublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/kucoinpublicapi.hpp
+++ b/src/api/exchanges/include/kucoinpublicapi.hpp
@@ -70,20 +70,24 @@ class KucoinPublic : public ExchangePublic {
   friend class KucoinPrivate;
 
   struct TradableCurrenciesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     TradableCurrenciesFunc(CurlHandle& curlHandle, const CoincenterInfo& coincenterInfo, CryptowatchAPI& cryptowatchApi)
         : _curlHandle(curlHandle), _coincenterInfo(coincenterInfo), _cryptowatchApi(cryptowatchApi) {}
+#endif
 
     struct CurrencyInfo {
-      explicit CurrencyInfo(CurrencyCode c) : currencyExchange(c, c, c) {}
+#ifndef CCT_AGGR_INIT_CXX20
+      explicit CurrencyInfo(CurrencyCode c) : currencyExchange(c) {}
 
       CurrencyInfo(CurrencyExchange&& c, MonetaryAmount wMS, MonetaryAmount wMF)
           : currencyExchange(std::move(c)), withdrawalMinSize(wMS), withdrawalMinFee(wMF) {}
+#endif
 
       auto operator<=>(const CurrencyInfo& o) const { return currencyExchange <=> o.currencyExchange; }
 
       CurrencyExchange currencyExchange;
-      MonetaryAmount withdrawalMinSize;
-      MonetaryAmount withdrawalMinFee;
+      MonetaryAmount withdrawalMinSize{};
+      MonetaryAmount withdrawalMinFee{};
     };
 
     using CurrencyInfoSet = FlatSet<CurrencyInfo>;
@@ -96,8 +100,10 @@ class KucoinPublic : public ExchangePublic {
   };
 
   struct MarketsFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     MarketsFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     struct MarketInfo {
       MonetaryAmount baseMinSize;
@@ -119,8 +125,10 @@ class KucoinPublic : public ExchangePublic {
   };
 
   struct AllOrderBooksFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllOrderBooksFunc(CachedResult<MarketsFunc>& marketsCache, CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _marketsCache(marketsCache), _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -130,8 +138,10 @@ class KucoinPublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     OrderBookFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBook operator()(Market m, int depth);
 
@@ -140,7 +150,9 @@ class KucoinPublic : public ExchangePublic {
   };
 
   struct TradedVolumeFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradedVolumeFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 
@@ -148,7 +160,9 @@ class KucoinPublic : public ExchangePublic {
   };
 
   struct TickerFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TickerFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -55,9 +55,11 @@ class UpbitPrivate : public ExchangePrivate {
 
  private:
   struct TradableCurrenciesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     TradableCurrenciesFunc(CurlHandle& curlHandle, const APIKey& apiKey, const ExchangeInfo& exchangeInfo,
                            CryptowatchAPI& cryptowatchApi)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangeInfo(exchangeInfo), _cryptowatchApi(cryptowatchApi) {}
+#endif
 
     CurrencyExchangeFlatSet operator()();
 
@@ -68,8 +70,10 @@ class UpbitPrivate : public ExchangePrivate {
   };
 
   struct DepositWalletFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     DepositWalletFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+#endif
 
     Wallet operator()(CurrencyCode currencyCode);
 
@@ -79,8 +83,10 @@ class UpbitPrivate : public ExchangePrivate {
   };
 
   struct WithdrawFeesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     WithdrawFeesFunc(CurlHandle& curlHandle, const APIKey& apiKey, UpbitPublic& exchangePublic)
         : _curlHandle(curlHandle), _apiKey(apiKey), _exchangePublic(exchangePublic) {}
+#endif
 
     MonetaryAmount operator()(CurrencyCode currencyCode);
 

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -56,8 +56,10 @@ class UpbitPublic : public ExchangePublic {
   static bool CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies);
 
   struct MarketsFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     MarketsFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketSet operator()();
 
@@ -66,8 +68,10 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct TradableCurrenciesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     TradableCurrenciesFunc(CurlHandle& curlHandle, CachedResult<MarketsFunc>& marketsCache)
         : _curlHandle(curlHandle), _marketsCache(marketsCache) {}
+#endif
 
     CurrencyExchangeFlatSet operator()();
 
@@ -76,17 +80,21 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct WithdrawalFeesFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     WithdrawalFeesFunc(const string& name, std::string_view dataDir) : _name(name), _dataDir(dataDir) {}
+#endif
 
     WithdrawalFeeMap operator()();
 
     const string& _name;
-    string _dataDir;
+    std::string_view _dataDir;
   };
 
   struct AllOrderBooksFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     AllOrderBooksFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo, CachedResult<MarketsFunc>& marketsCache)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo), _marketsCache(marketsCache) {}
+#endif
 
     MarketOrderBookMap operator()(int depth);
 
@@ -96,8 +104,10 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct OrderBookFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     OrderBookFunc(CurlHandle& curlHandle, const ExchangeInfo& exchangeInfo)
         : _curlHandle(curlHandle), _exchangeInfo(exchangeInfo) {}
+#endif
 
     MarketOrderBook operator()(Market m, int depth);
 
@@ -106,7 +116,9 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct TradedVolumeFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TradedVolumeFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 
@@ -114,7 +126,9 @@ class UpbitPublic : public ExchangePublic {
   };
 
   struct TickerFunc {
+#ifndef CCT_AGGR_INIT_CXX20
     explicit TickerFunc(CurlHandle& curlHandle) : _curlHandle(curlHandle) {}
+#endif
 
     MonetaryAmount operator()(Market m);
 

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -88,15 +88,15 @@ KrakenPublic::KrakenPublic(const CoincenterInfo& config, FiatConverter& fiatConv
       _curlHandle(config.metricGatewayPtr(), config.exchangeInfo(_name).minPublicQueryDelay(), config.getRunMode()),
       _tradableCurrenciesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kCurrencies), _cachedResultVault), config,
-          cryptowatchAPI, config.exchangeInfo(_name), _curlHandle),
+          cryptowatchAPI, _curlHandle, config.exchangeInfo(_name)),
       _withdrawalFeesCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kWithdrawalFees), _cachedResultVault),
           config, config.exchangeInfo(_name).minPublicQueryDelay()),
       _marketsCache(CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kMarkets), _cachedResultVault),
-                    config, _tradableCurrenciesCache, _curlHandle, config.exchangeInfo(_name)),
+                    _tradableCurrenciesCache, config, _curlHandle, config.exchangeInfo(_name)),
       _allOrderBooksCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kAllOrderBooks), _cachedResultVault),
-          config, _tradableCurrenciesCache, _marketsCache, _curlHandle),
+          _tradableCurrenciesCache, _marketsCache, config, _curlHandle),
       _orderBookCache(
           CachedResultOptions(config.getAPICallUpdateFrequency(QueryTypeEnum::kOrderBook), _cachedResultVault),
           _tradableCurrenciesCache, _marketsCache, _curlHandle),

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -14,6 +14,9 @@ class CurrencyExchange {
   enum class Withdraw { kAvailable, kUnavailable };
   enum class Type { kFiat, kCrypto };
 
+  /// Constructs a CurrencyExchange with a standard code, with unknown withdrawal / deposit statuses
+  CurrencyExchange(CurrencyCode standardCode) : CurrencyExchange(standardCode, standardCode, standardCode) {}
+
   /// Constructs a CurrencyExchange with up to two alternative codes, with unknown withdrawal / deposit statuses
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode);
 

--- a/src/objects/include/marketorderbook.hpp
+++ b/src/objects/include/marketorderbook.hpp
@@ -38,7 +38,7 @@ class MarketOrderBook {
   using OrderBookLineSpan = std::span<const OrderBookLine>;
 
   struct AmountAtPrice {
-#ifndef CCT_CTAD_SUPPORT
+#ifndef CCT_AGGR_INIT_CXX20
     AmountAtPrice(MonetaryAmount a, MonetaryAmount p) : amount(a), price(p) {}
 #endif
 

--- a/src/objects/include/volumeandpricenbdecimals.hpp
+++ b/src/objects/include/volumeandpricenbdecimals.hpp
@@ -5,9 +5,11 @@
 
 namespace cct {
 struct VolAndPriNbDecimals {
+#ifndef CCT_AGGR_INIT_CXX20
   constexpr VolAndPriNbDecimals() noexcept = default;
 
   constexpr VolAndPriNbDecimals(int8_t volNbDec, int8_t priNbDec) : volNbDecimals(volNbDec), priNbDecimals(priNbDec) {}
+#endif
 
   constexpr bool operator==(const VolAndPriNbDecimals &o) const = default;
 

--- a/src/tech/include/cct_config.hpp
+++ b/src/tech/include/cct_config.hpp
@@ -61,8 +61,9 @@
 #endif
 
 #if !defined(__clang__)
-// Explicit constructor for this aggregate as clang does not implement CTAD yet (as of December 2021)
-// More information here:
+// Clang does not support 'Allow initializing aggregates from a parenthesized list of values' (nor CTAD) yet.
+// Although it's a C++20 project, it's nice to support clang so let's keep this switch for now, until clang finally
+// implements it. More information here:
 // https://stackoverflow.com/questions/70260994/automatic-template-deduction-c20-with-aggregate-type
-#define CCT_CTAD_SUPPORT
+#define CCT_AGGR_INIT_CXX20
 #endif

--- a/src/tech/include/cct_hash.hpp
+++ b/src/tech/include/cct_hash.hpp
@@ -43,7 +43,7 @@ class HashTuple {
   struct Component {
     const T& value;
 
-#ifndef CCT_CTAD_SUPPORT
+#ifndef CCT_AGGR_INIT_CXX20
     explicit Component(const T& v) : value(v) {}
 #endif
 

--- a/src/tech/test/cct_hash_test.cpp
+++ b/src/tech/test/cct_hash_test.cpp
@@ -19,6 +19,12 @@ TEST(SSPHashTest, HashCombine) {
   }
 }
 
+TEST(SSPHashTest, EmptyTuple) {
+  using T = std::tuple<>;
+
+  EXPECT_EQ(HashTuple()(T()), HashTuple()(T()));
+}
+
 TEST(SSPHashTest, Pair) {
   using T = std::pair<int64_t, uint8_t>;
 


### PR DESCRIPTION
- Use `unordered_set` instead of `FlatSet` when there are a lot of new visited currencies
- Simplify some CI workflows
- Prepare for clean up of declared constructor for aggregates (only not supported by `clang` for now)