### PR TITLE
Clean up code with toupper and tolower

### DIFF
--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -68,11 +68,8 @@ std::optional<double> CryptowatchAPI::queryPrice(std::string_view exchangeName, 
   std::lock_guard<std::mutex> guard(_pricesMutex);
 
   for (int marketPos = 0; marketPos < 2; ++marketPos) {
-    string lowerStrMarket = m.assetsPairStr();
-    std::transform(lowerStrMarket.begin(), lowerStrMarket.end(), lowerStrMarket.begin(),
-                   [](char c) { return tolower(c); });
     string mStr = marketPrefix;
-    mStr.append(lowerStrMarket);
+    mStr.append(m.assetsPairStrLower());
 
     const json& result = _allPricesCache.get();
     auto foundIt = result.find(mStr);

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -299,7 +299,7 @@ Market ExchangePublic::determineMarketFromFilterCurrencies(MarketSet &markets, C
   auto tryAppendQuoteCurrency = [&](CurrencyCode cur1, CurrencyCode cur2) {
     ret = Market(cur1, cur2);
     if (!markets.contains(ret)) {
-      log::debug("No market {} on {}", name(), ret.assetsPairStr('-'));
+      log::debug("No market {} on {}", name(), ret.str());
       ret = Market(cur1, CurrencyCode());
     }
   };

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -53,6 +53,8 @@ class UpbitPublic : public ExchangePublic {
  private:
   friend class UpbitPrivate;
 
+  static string ReverseMarketStr(Market m) { return m.reverse().assetsPairStrUpper('-'); }
+
   static bool CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies);
 
   struct MarketsFunc {

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -130,7 +130,7 @@ bool BinancePrivate::checkMarketAppendSymbol(Market m, CurlPostData& params) {
       return false;
     }
   }
-  params.append("symbol", m.assetsPairStr());
+  params.append("symbol", m.assetsPairStrUpper());
   return true;
 }
 
@@ -222,7 +222,7 @@ void BinancePrivate::cancelOpenedOrders(const OrdersConstraints& openedOrdersCon
                 [&ordersByMarketMap](Order&& o) { ordersByMarketMap[o.market()].push_back(std::move(o)); });
   for (const auto& [market, orders] : ordersByMarketMap) {
     if (!isMarketDefined) {
-      params.set("symbol", market.assetsPairStr());
+      params.set("symbol", market.assetsPairStrUpper());
     }
     if (orders.size() > 1 && canUseCancelAllEndpoint) {
       params.erase("orderid");
@@ -306,7 +306,7 @@ PlaceOrderInfo BinancePrivate::placeOrder(MonetaryAmount from, MonetaryAmount vo
   }
   volume = sanitizedVol;
   CurlPostData placePostData{
-      {"symbol", m.assetsPairStr()}, {"side", buyOrSell}, {"type", orderType}, {"quantity", volume.amountStr()}};
+      {"symbol", m.assetsPairStrUpper()}, {"side", buyOrSell}, {"type", orderType}, {"quantity", volume.amountStr()}};
 
   if (!isTakerStrategy) {
     placePostData.append("timeInForce", "GTC");
@@ -340,7 +340,7 @@ OrderInfo BinancePrivate::queryOrder(const OrderRef& orderRef, bool isCancel) {
   const CurrencyCode fromCurrencyCode = orderRef.side == TradeSide::kSell ? m.base() : m.quote();
   const CurrencyCode toCurrencyCode = orderRef.side == TradeSide::kBuy ? m.base() : m.quote();
   const HttpRequestType requestType = isCancel ? HttpRequestType::kDelete : HttpRequestType::kGet;
-  const string assetsStr = m.assetsPairStr();
+  const string assetsStr = m.assetsPairStrUpper();
   const std::string_view assets(assetsStr);
   BinancePublic& binancePublic = dynamic_cast<BinancePublic&>(_exchangePublic);
   json result = PrivateQuery(_curlHandle, _apiKey, requestType, binancePublic._commonInfo.getBestBaseURL(),

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -412,7 +412,7 @@ ExchangePublic::MarketOrderBookMap BinancePublic::AllOrderBooksFunc::operator()(
   BinanceAssetPairToStdMarketMap binanceAssetPairToStdMarketMap;
   binanceAssetPairToStdMarketMap.reserve(markets.size());
   for (Market m : markets) {
-    binanceAssetPairToStdMarketMap.insert_or_assign(m.assetsPairStr(), m);
+    binanceAssetPairToStdMarketMap.insert_or_assign(m.assetsPairStrUpper(), m);
   }
   for (const json& tickerDetails : result) {
     string assetsPairStr = tickerDetails["symbol"];
@@ -442,7 +442,7 @@ MarketOrderBook BinancePublic::OrderBookFunc::operator()(Market m, int depth) {
     lb = std::next(std::end(kAuthorizedDepths), -1);
     log::error("Invalid depth {}, default to {}", depth, *lb);
   }
-  CurlPostData postData{{"symbol", m.assetsPairStr()}, {"limit", *lb}};
+  CurlPostData postData{{"symbol", m.assetsPairStrUpper()}, {"limit", *lb}};
   json asksAndBids = PublicQuery(_commonInfo._curlHandle, _commonInfo.getBestBaseURL(), "/api/v3/depth", postData);
   const json& asks = asksAndBids["asks"];
   const json& bids = asksAndBids["bids"];
@@ -463,14 +463,14 @@ MarketOrderBook BinancePublic::OrderBookFunc::operator()(Market m, int depth) {
 
 MonetaryAmount BinancePublic::TradedVolumeFunc::operator()(Market m) {
   json result = PublicQuery(_commonInfo._curlHandle, _commonInfo.getBestBaseURL(), "/api/v3/ticker/24hr",
-                            {{"symbol", m.assetsPairStr()}});
+                            {{"symbol", m.assetsPairStrUpper()}});
   std::string_view last24hVol = result["volume"].get<std::string_view>();
   return MonetaryAmount(last24hVol, m.base());
 }
 
 BinancePublic::LastTradesVector BinancePublic::queryLastTrades(Market m, int nbTrades) {
   json result = PublicQuery(_commonInfo._curlHandle, _commonInfo.getBestBaseURL(), "/api/v3/trades",
-                            {{"symbol", m.assetsPairStr()}, {"limit", nbTrades}});
+                            {{"symbol", m.assetsPairStrUpper()}, {"limit", nbTrades}});
 
   LastTradesVector ret;
   ret.reserve(static_cast<LastTradesVector::size_type>(result.size()));
@@ -489,7 +489,7 @@ BinancePublic::LastTradesVector BinancePublic::queryLastTrades(Market m, int nbT
 
 MonetaryAmount BinancePublic::TickerFunc::operator()(Market m) {
   json result = PublicQuery(_commonInfo._curlHandle, _commonInfo.getBestBaseURL(), "/api/v3/ticker/price",
-                            {{"symbol", m.assetsPairStr()}});
+                            {{"symbol", m.assetsPairStrUpper()}});
   std::string_view lastPrice = result["price"].get<std::string_view>();
   return MonetaryAmount(lastPrice, m.quote());
 }

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -111,7 +111,7 @@ BalancePortfolio HuobiPrivate::queryAccountBalance(CurrencyCode equiCurrency) {
 }
 
 Wallet HuobiPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
-  string lowerCaseCur = tolower(currencyCode.str());
+  string lowerCaseCur = ToLower(currencyCode.str());
   json result = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v2/account/deposit/address",
                              {{"currency", lowerCaseCur}});
   std::string_view address, tag;
@@ -146,14 +146,14 @@ ExchangePrivate::Orders HuobiPrivate::queryOpenedOrders(const OrdersConstraints&
                                                                               openedOrdersConstraints.cur2());
 
     if (filterMarket.isDefined()) {
-      params.append("symbol", tolower(filterMarket.assetsPairStr()));
+      params.append("symbol", filterMarket.assetsPairStrLower());
     }
   }
 
   json data = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v1/order/openOrders", std::move(params));
   Orders openedOrders;
   for (const json& orderDetails : data["data"]) {
-    string marketStr = toupper(orderDetails["symbol"].get<std::string_view>());
+    string marketStr = ToUpper(orderDetails["symbol"].get<std::string_view>());
 
     std::optional<Market> optMarket =
         _exchangePublic.determineMarketFromMarketStr(marketStr, markets, openedOrdersConstraints.cur1());
@@ -242,7 +242,7 @@ PlaceOrderInfo HuobiPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volu
   PlaceOrderInfo placeOrderInfo(OrderInfo(TradedAmounts(fromCurrencyCode, toCurrencyCode)));
 
   const Market m = tradeInfo.m;
-  string lowerCaseMarket = tolower(m.assetsPairStr());
+  string lowerCaseMarket = m.assetsPairStrLower();
 
   const bool isTakerStrategy =
       tradeInfo.options.isTakerStrategy(_exchangePublic.exchangeInfo().placeSimulateRealOrder());
@@ -334,7 +334,7 @@ OrderInfo HuobiPrivate::queryOrderInfo(const OrderRef& orderRef) {
 
 InitiatedWithdrawInfo HuobiPrivate::launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) {
   const CurrencyCode currencyCode = grossAmount.currencyCode();
-  string lowerCaseCur = tolower(currencyCode.str());
+  string lowerCaseCur = ToLower(currencyCode.str());
 
   json queryWithdrawAddressJson = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet,
                                                "/v2/account/withdraw/address", {{"currency", lowerCaseCur}});
@@ -373,7 +373,7 @@ InitiatedWithdrawInfo HuobiPrivate::launchWithdraw(MonetaryAmount grossAmount, W
 
 SentWithdrawInfo HuobiPrivate::isWithdrawSuccessfullySent(const InitiatedWithdrawInfo& initiatedWithdrawInfo) {
   const CurrencyCode currencyCode = initiatedWithdrawInfo.grossEmittedAmount().currencyCode();
-  string lowerCaseCur = tolower(currencyCode.str());
+  string lowerCaseCur = ToLower(currencyCode.str());
   std::string_view withdrawIdStr = initiatedWithdrawInfo.withdrawId();
   int64_t withdrawId = FromString<int64_t>(withdrawIdStr);
   json withdrawJson = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v1/query/deposit-withdraw",
@@ -428,7 +428,7 @@ SentWithdrawInfo HuobiPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
 bool HuobiPrivate::isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWithdrawInfo,
                                       const SentWithdrawInfo& sentWithdrawInfo) {
   const CurrencyCode currencyCode = initiatedWithdrawInfo.grossEmittedAmount().currencyCode();
-  string lowerCaseCur = tolower(currencyCode.str());
+  string lowerCaseCur = ToLower(currencyCode.str());
 
   json depositJson = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v1/query/deposit-withdraw",
                                   {{"currency", lowerCaseCur}, {"type", "deposit"}});

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -272,7 +272,7 @@ PlaceOrderInfo KrakenPrivate::placeOrder(MonetaryAmount /*from*/, MonetaryAmount
   // This will not work if user has enough Kraken Fee Credits (in this case, they will be used instead).
   // Warning: this does not change the currency of the returned fee from Kraken in the get Closed / Opened orders,
   // which will be always in quote currency (as per the documentation)
-  CurlPostData placePostData{{"pair", krakenMarket.assetsPairStr()},
+  CurlPostData placePostData{{"pair", krakenMarket.assetsPairStrUpper()},
                              {"type", orderType},
                              {"ordertype", isTakerStrategy ? "market" : "limit"},
                              {"price", price.amountStr()},
@@ -386,8 +386,7 @@ InitiatedWithdrawInfo KrakenPrivate::launchWithdraw(MonetaryAmount grossAmount, 
   string krakenWalletName(wallet.exchangeName());
   krakenWalletName.push_back('_');
   krakenWalletName.append(currencyCode.str());
-  std::transform(krakenWalletName.begin(), krakenWalletName.end(), krakenWalletName.begin(),
-                 [](char c) { return tolower(c); });
+  std::ranges::transform(krakenWalletName, krakenWalletName.begin(), tolower);
 
   json withdrawData = PrivateQuery(
       _curlHandle, _apiKey, "/private/Withdraw",

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -175,7 +175,7 @@ ExchangePrivate::Orders KucoinPrivate::queryOpenedOrders(const OrdersConstraints
                                                                               openedOrdersConstraints.cur2());
 
     if (filterMarket.isDefined()) {
-      params.append("symbol", filterMarket.assetsPairStr('-'));
+      params.append("symbol", filterMarket.assetsPairStrUpper('-'));
     }
   }
   if (openedOrdersConstraints.isPlacedTimeAfterDefined()) {
@@ -227,7 +227,7 @@ void KucoinPrivate::cancelOpenedOrders(const OrdersConstraints& openedOrdersCons
   if (openedOrdersConstraints.isMarketOnlyDependent() || openedOrdersConstraints.noConstraints()) {
     CurlPostData params;
     if (openedOrdersConstraints.isMarketDefined()) {
-      params.append("symbol", openedOrdersConstraints.market().assetsPairStr('-'));
+      params.append("symbol", openedOrdersConstraints.market().assetsPairStrUpper('-'));
     }
     PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kDelete, "/api/v1/orders", std::move(params));
     return;
@@ -273,7 +273,7 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
   CurlPostData params;
   params.append("clientOid", Nonce_TimeSinceEpochInMs());
   params.append("side", buyOrSell);
-  params.append("symbol", m.assetsPairStr('-'));
+  params.append("symbol", m.assetsPairStrUpper('-'));
   params.append("type", strategyType);
   params.append("remark", "Placed by coincenter client");
   params.append("tradeType", "TRADE");

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -194,7 +194,7 @@ ExchangePrivate::Orders UpbitPrivate::queryOpenedOrders(const OrdersConstraints&
                                                                               openedOrdersConstraints.cur2());
 
     if (filterMarket.isDefined()) {
-      params.append("market", filterMarket.reverse().assetsPairStr('-'));
+      params.append("market", UpbitPublic::ReverseMarketStr(filterMarket));
     }
   }
   json data = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v1/orders", std::move(params));
@@ -254,7 +254,7 @@ PlaceOrderInfo UpbitPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volu
   const std::string_view askOrBid = fromCurrencyCode == m.base() ? "ask" : "bid";
   const std::string_view orderType = isTakerStrategy ? (fromCurrencyCode == m.base() ? "market" : "price") : "limit";
 
-  CurlPostData placePostData{{"market", m.reverse().assetsPairStr('-')}, {"side", askOrBid}, {"ord_type", orderType}};
+  CurlPostData placePostData{{"market", UpbitPublic::ReverseMarketStr(m)}, {"side", askOrBid}, {"ord_type", orderType}};
 
   PlaceOrderInfo placeOrderInfo(OrderInfo(TradedAmounts(fromCurrencyCode, toCurrencyCode)));
 
@@ -441,7 +441,7 @@ SentWithdrawInfo UpbitPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
   MonetaryAmount netEmittedAmount(result["amount"].get<std::string_view>(), currencyCode);
 
   std::string_view state(result["state"].get<std::string_view>());
-  string stateUpperStr = toupper(state);
+  string stateUpperStr = ToUpper(state);
   log::debug("{} withdrawal status {}", _exchangePublic.name(), state);
   // state values: {'submitting', 'submitted', 'almost_accepted', 'rejected', 'accepted', 'processing', 'done',
   // 'canceled'}
@@ -463,7 +463,7 @@ bool UpbitPrivate::isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWith
     if (netAmountReceived == sentWithdrawInfo.netEmittedAmount()) {
       std::string_view depositState(trx["state"].get<std::string_view>());
       log::debug("Deposit state {}", depositState);
-      string depositStateUpperStr = toupper(depositState);
+      string depositStateUpperStr = ToUpper(depositState);
       if (depositStateUpperStr == "ACCEPTED") {
         return true;
       }

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -187,14 +187,14 @@ ExchangePublic::MarketOrderBookMap UpbitPublic::AllOrderBooksFunc::operator()(in
     if (!marketsStr.empty()) {
       marketsStr.push_back(',');
     }
-    marketsStr.append(m.reverse().assetsPairStr('-'));
+    marketsStr.append(ReverseMarketStr(m));
   }
   return ParseOrderBooks(PublicQuery(_curlHandle, "orderbook", {{"markets", marketsStr}}), depth);
 }
 
 MarketOrderBook UpbitPublic::OrderBookFunc::operator()(Market m, int depth) {
   ExchangePublic::MarketOrderBookMap marketOrderBookMap =
-      ParseOrderBooks(PublicQuery(_curlHandle, "orderbook", {{"markets", m.reverse().assetsPairStr('-')}}), depth);
+      ParseOrderBooks(PublicQuery(_curlHandle, "orderbook", {{"markets", ReverseMarketStr(m)}}), depth);
   auto it = marketOrderBookMap.find(m);
   if (it == marketOrderBookMap.end()) {
     throw exception("Unexpected answer from get OrderBooks");
@@ -203,14 +203,13 @@ MarketOrderBook UpbitPublic::OrderBookFunc::operator()(Market m, int depth) {
 }
 
 MonetaryAmount UpbitPublic::TradedVolumeFunc::operator()(Market m) {
-  json result = PublicQuery(_curlHandle, "candles/days", {{"count", 1}, {"market", m.reverse().assetsPairStr('-')}});
+  json result = PublicQuery(_curlHandle, "candles/days", {{"count", 1}, {"market", ReverseMarketStr(m)}});
   double last24hVol = result.front()["candle_acc_trade_volume"].get<double>();
   return MonetaryAmount(last24hVol, m.base());
 }
 
 UpbitPublic::LastTradesVector UpbitPublic::queryLastTrades(Market m, int nbTrades) {
-  json result =
-      PublicQuery(_curlHandle, "trades/ticks", {{"count", nbTrades}, {"market", m.reverse().assetsPairStr('-')}});
+  json result = PublicQuery(_curlHandle, "trades/ticks", {{"count", nbTrades}, {"market", ReverseMarketStr(m)}});
   LastTradesVector ret;
   ret.reserve(static_cast<LastTradesVector::size_type>(result.size()));
   for (const json& detail : result) {
@@ -227,7 +226,7 @@ UpbitPublic::LastTradesVector UpbitPublic::queryLastTrades(Market m, int nbTrade
 }
 
 MonetaryAmount UpbitPublic::TickerFunc::operator()(Market m) {
-  json result = PublicQuery(_curlHandle, "trades/ticks", {{"count", 1}, {"market", m.reverse().assetsPairStr('-')}});
+  json result = PublicQuery(_curlHandle, "trades/ticks", {{"count", 1}, {"market", ReverseMarketStr(m)}});
   double lastPrice = result.front()["trade_price"].get<double>();
   return MonetaryAmount(lastPrice, m.quote());
 }

--- a/src/api/exchanges/test/commonapi_test.hpp
+++ b/src/api/exchanges/test/commonapi_test.hpp
@@ -96,7 +96,7 @@ class TestAPI {
   }
 
   void testMarket(Market m) {
-    log::info("Test {} market", m.assetsPairStr('-'));
+    log::info("Test {} market", m.str());
     ASSERT_FALSE(markets.empty());
     static constexpr int kCountDepthOrderBook = 5;
     MarketOrderBook marketOrderBook = exchangePublic.queryOrderBook(m, kCountDepthOrderBook);

--- a/src/engine/src/metricsexporter.cpp
+++ b/src/engine/src/metricsexporter.cpp
@@ -48,7 +48,7 @@ void MetricsExporter::exportTickerMetrics(const ExchangeTickerMaps &marketOrderB
     key.set(kMetricHelpKey, "Best bids and asks prices");
     key.set("exchange", e->name());
     for (const auto &[m, marketOrderbook] : marketOrderBookMap) {
-      key.set("market", m.assetsPairStr('-', true));
+      key.set("market", m.assetsPairStrLower('-'));
       key.set("side", "ask");
       _pMetricsGateway->add(MetricType::kGauge, MetricOperation::kSet, key,
                             marketOrderbook.lowestAskPrice().toDouble());
@@ -59,7 +59,7 @@ void MetricsExporter::exportTickerMetrics(const ExchangeTickerMaps &marketOrderB
     key.set(kMetricNameKey, "limit_volume");
     key.set(kMetricHelpKey, "Best bids and asks volumes");
     for (const auto &[m, marketOrderbook] : marketOrderBookMap) {
-      key.set("market", m.assetsPairStr('-', true));
+      key.set("market", m.assetsPairStrLower('-'));
       key.set("side", "ask");
       _pMetricsGateway->add(MetricType::kGauge, MetricOperation::kSet, key,
                             marketOrderbook.amountAtAskPrice().toDouble());
@@ -74,7 +74,7 @@ void MetricsExporter::exportOrderbookMetrics(Market m,
                                              const MarketOrderBookConversionRates &marketOrderBookConversionRates) {
   RETURN_IF_NO_MONITORING;
   MetricKey key = CreateMetricKey("limit_pri", "Best bids and asks prices");
-  string marketLowerCase = m.assetsPairStr('-', true);
+  string marketLowerCase = m.assetsPairStrLower('-');
   key.append("market", marketLowerCase);
   for (const auto &[exchangeName, marketOrderBook, optConversionRate] : marketOrderBookConversionRates) {
     key.set("exchange", exchangeName);
@@ -99,7 +99,7 @@ void MetricsExporter::exportOrderbookMetrics(Market m,
 void MetricsExporter::exportLastTradesMetrics(Market m, const LastTradesPerExchange &lastTradesPerExchange) {
   RETURN_IF_NO_MONITORING;
   MetricKey key = CreateMetricKey("", "All public trades that occurred on the market");
-  string marketLowerCase = m.assetsPairStr('-', true);
+  string marketLowerCase = m.assetsPairStrLower('-');
   key.append("market", marketLowerCase);
 
   for (const auto &[e, lastTrades] : lastTradesPerExchange) {

--- a/src/engine/src/printqueryresults.cpp
+++ b/src/engine/src/printqueryresults.cpp
@@ -32,7 +32,7 @@ void QueryResultPrinter::printTickerInformation(const ExchangeTickerMaps &exchan
   SimpleTable t("Exchange", "Market", "Bid price", "Bid volume", "Ask price", "Ask volume");
   for (const auto &[e, marketOrderBookMap] : exchangeTickerMaps) {
     for (const auto &[m, marketOrderBook] : marketOrderBookMap) {
-      t.emplace_back(e->name(), m.assetsPairStr('-'), marketOrderBook.highestBidPrice().str(),
+      t.emplace_back(e->name(), m.str(), marketOrderBook.highestBidPrice().str(),
                      marketOrderBook.amountAtBidPrice().str(), marketOrderBook.lowestAskPrice().str(),
                      marketOrderBook.amountAtAskPrice().str());
     }
@@ -87,7 +87,7 @@ void QueryResultPrinter::printConversionPath(Market m,
                                              const ConversionPathPerExchange &conversionPathsPerExchange) const {
   RETURN_IF_NO_PRINT;
   string conversionPathStrHeader("Fastest conversion path for ");
-  conversionPathStrHeader.append(m.assetsPairStr('-'));
+  conversionPathStrHeader.append(m.str());
   SimpleTable t("Exchange", std::move(conversionPathStrHeader));
   for (const auto &[e, conversionPath] : conversionPathsPerExchange) {
     if (!conversionPath.empty()) {
@@ -96,7 +96,7 @@ void QueryResultPrinter::printConversionPath(Market m,
         if (!conversionPathStr.empty()) {
           conversionPathStr.push_back(',');
         }
-        conversionPathStr.append(market.assetsPairStr('-'));
+        conversionPathStr.append(market.str());
       }
       t.emplace_back(e->name(), std::move(conversionPathStr));
     }

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "cct_cctype.hpp"
 #include "cct_const.hpp"
 
 namespace cct {
@@ -38,8 +39,8 @@ std::string_view StrEnd(std::string_view opt, std::size_t startPos) {
 }
 
 bool IsExchangeName(std::string_view str) {
-  string lowerStr = tolower(str);
-  return std::any_of(std::begin(kSupportedExchanges), std::end(kSupportedExchanges), [&lowerStr](std::string_view ex) {
+  string lowerStr = ToLower(str);
+  return std::ranges::any_of(kSupportedExchanges, [&lowerStr](std::string_view ex) {
     return lowerStr.starts_with(ex) && (lowerStr.size() == ex.size() || lowerStr[ex.size()] == '_');
   });
 }
@@ -130,18 +131,18 @@ StringOptionParser::getMonetaryAmountCurrencyPrivateExchanges() const {
     throw std::invalid_argument("Cannot start with a negative amount");
   }
   std::size_t pos = 1;
-  while (pos < dashPos && ((_opt[pos] >= '0' && _opt[pos] <= '9') || _opt[pos] == '.')) {
+  while (pos < dashPos && (isdigit(_opt[pos]) || _opt[pos] == '.')) {
     ++pos;
   }
   std::string_view startAmountStr(_opt.data(), pos);
-  while (pos < dashPos && _opt[pos] == ' ') {
+  while (pos < dashPos && isblank(_opt[pos])) {
     ++pos;
   }
   bool isPercentage = pos < dashPos && _opt[pos] == '%';
   if (isPercentage) {
     do {
       ++pos;
-    } while (pos < dashPos && _opt[pos] == ' ');
+    } while (pos < dashPos && isblank(_opt[pos]));
   }
   std::string_view startCurStr(_opt.begin() + pos, _opt.begin() + dashPos);
   MonetaryAmount startAmount(startAmountStr, startCurStr);

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -77,8 +77,8 @@ class CurrencyCode {
   AcronymType _data;
 
   constexpr inline void set(std::string_view acronym) {
-    std::fill(std::transform(acronym.begin(), acronym.end(), _data.begin(), [](char c) { return toupper(c); }),
-              _data.end(), '\0');  // Fill extra chars to 0 is important as we always read them for code generation
+    // Fill extra chars to 0 is important as we always read them for code generation
+    std::fill(std::transform(acronym.begin(), acronym.end(), _data.begin(), toupper), _data.end(), '\0');
   }
 };
 

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -14,11 +14,18 @@ class CurrencyExchange {
   enum class Withdraw { kAvailable, kUnavailable };
   enum class Type { kFiat, kCrypto };
 
+  CurrencyExchange() noexcept = default;
+
   /// Constructs a CurrencyExchange with a standard code, with unknown withdrawal / deposit statuses
-  CurrencyExchange(CurrencyCode standardCode) : CurrencyExchange(standardCode, standardCode, standardCode) {}
+  CurrencyExchange(CurrencyCode standardCode)
+      : _standardCode(standardCode), _exchangeCode(standardCode), _altCode(standardCode) {}
 
   /// Constructs a CurrencyExchange with up to two alternative codes, with unknown withdrawal / deposit statuses
-  CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode);
+  CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode)
+      : _standardCode(standardCode), _exchangeCode(exchangeCode), _altCode(altCode) {}
+
+  /// Constructs a CurrencyExchange with known withdrawal / deposit statuses
+  CurrencyExchange(CurrencyCode standardCode, Deposit deposit, Withdraw withdraw, Type type);
 
   /// Constructs a CurrencyExchange with up to two alternative codes, with known withdrawal / deposit statuses
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode, Deposit deposit,
@@ -37,8 +44,6 @@ class CurrencyExchange {
   bool canDeposit() const { return _canDeposit; }
   bool canWithdraw() const { return _canWithdraw; }
 
-  bool unknownDepositWithdrawalStatus() const { return _unknownDepositWithdrawalStatus; }
-
   bool isFiat() const { return _isFiat; }
 
   auto operator<=>(const CurrencyExchange &o) const { return _standardCode <=> o._standardCode; }
@@ -52,10 +57,9 @@ class CurrencyExchange {
   CurrencyCode _standardCode;
   CurrencyCode _exchangeCode;
   CurrencyCode _altCode;
-  bool _canDeposit;
-  bool _canWithdraw;
-  bool _unknownDepositWithdrawalStatus;
-  bool _isFiat;
+  bool _canDeposit = false;
+  bool _canWithdraw = false;
+  bool _isFiat = false;
 };
 
 }  // namespace cct

--- a/src/objects/include/market.hpp
+++ b/src/objects/include/market.hpp
@@ -14,7 +14,7 @@ class Market {
 
   explicit Market(std::pair<CurrencyCode, CurrencyCode> curPair) : Market(curPair.first, curPair.second) {}
 
-  Market() = default;
+  Market() noexcept(std::is_nothrow_default_constructible_v<CurrencyCode>) = default;
 
   Market(CurrencyCode first, CurrencyCode second) : _assets({first, second}) {}
 
@@ -51,12 +51,19 @@ class Market {
 
   auto operator<=>(const Market&) const = default;
 
-  string str() const { return assetsPairStr('-'); }
-  string assetsPairStr(char sep = 0, bool lowerCase = false) const;
+  string str() const { return assetsPairStrUpper('-'); }
 
   friend std::ostream& operator<<(std::ostream& os, const Market& m);
 
+  /// Returns a string representing this Market in lower case
+  string assetsPairStrLower(char sep = 0) const { return assetsPairStr(sep, true); }
+
+  /// Returns a string representing this Market in upper case
+  string assetsPairStrUpper(char sep = 0) const { return assetsPairStr(sep, false); }
+
  private:
+  string assetsPairStr(char sep, bool lowerCase) const;
+
   TradableAssets _assets;
 };
 }  // namespace cct

--- a/src/objects/src/currencyexchange.cpp
+++ b/src/objects/src/currencyexchange.cpp
@@ -2,14 +2,13 @@
 
 namespace cct {
 
-CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode)
+CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, Deposit deposit, Withdraw withdraw, Type type)
     : _standardCode(standardCode),
-      _exchangeCode(exchangeCode),
-      _altCode(altCode),
-      _canDeposit(false),
-      _canWithdraw(false),
-      _unknownDepositWithdrawalStatus(true),
-      _isFiat(false) {}
+      _exchangeCode(standardCode),
+      _altCode(standardCode),
+      _canDeposit(deposit == Deposit::kAvailable),
+      _canWithdraw(withdraw == Withdraw::kAvailable),
+      _isFiat(type == Type::kFiat) {}
 
 CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode,
                                    Deposit deposit, Withdraw withdraw, Type type)
@@ -18,7 +17,6 @@ CurrencyExchange::CurrencyExchange(CurrencyCode standardCode, CurrencyCode excha
       _altCode(altCode),
       _canDeposit(deposit == Deposit::kAvailable),
       _canWithdraw(withdraw == Withdraw::kAvailable),
-      _unknownDepositWithdrawalStatus(false),
       _isFiat(type == Type::kFiat) {}
 
 string CurrencyExchange::str() const {

--- a/src/objects/src/exchangename.cpp
+++ b/src/objects/src/exchangename.cpp
@@ -9,12 +9,11 @@ PrivateExchangeName::PrivateExchangeName(std::string_view globalExchangeName)
   if (_dashPos == std::string_view::npos) {
     _dashPos = _nameWithKey.size();
   }
-  std::transform(_nameWithKey.begin(), _nameWithKey.begin() + _dashPos, _nameWithKey.begin(),
-                 [](char c) { return tolower(c); });
+  std::transform(_nameWithKey.begin(), _nameWithKey.begin() + _dashPos, _nameWithKey.begin(), tolower);
 }
 
 PrivateExchangeName::PrivateExchangeName(std::string_view exchangeName, std::string_view keyName)
-    : _nameWithKey(tolower(exchangeName)), _dashPos(_nameWithKey.size()) {
+    : _nameWithKey(ToLower(exchangeName)), _dashPos(_nameWithKey.size()) {
   if (_nameWithKey.find('_') != string::npos) {
     throw exception("Invalid exchange name " + _nameWithKey);
   }

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -64,7 +64,7 @@ FiatConverter::FiatConverter(const CoincenterInfo& coincenterInfo, Clock::durati
 void FiatConverter::updateCacheFile() const {
   json data;
   for (const auto& [market, priceTimeValue] : _pricesMap) {
-    string marketPairStr = market.assetsPairStr('-');
+    string marketPairStr = market.assetsPairStrUpper('-');
     data[marketPairStr]["rate"] = priceTimeValue.rate;
     data[marketPairStr]["timeepoch"] =
         std::chrono::duration_cast<std::chrono::seconds>(priceTimeValue.lastUpdatedTime.time_since_epoch()).count();
@@ -75,7 +75,7 @@ void FiatConverter::updateCacheFile() const {
 std::optional<double> FiatConverter::queryCurrencyRate(Market m) {
   string url = "https://free.currconv.com/api/v7/convert?";
 
-  string qStr(m.assetsPairStr('_'));
+  string qStr(m.assetsPairStrUpper('_'));
   CurlOptions opts(HttpRequestType::kGet, {{"q", qStr}, {"apiKey", _apiKey}});
 
   url.append(opts.getPostData().str());

--- a/src/objects/src/market.cpp
+++ b/src/objects/src/market.cpp
@@ -21,7 +21,7 @@ string Market::assetsPairStr(char sep, bool lowerCase) const {
   }
   ret.append(_assets.back().str());
   if (lowerCase) {
-    std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return tolower(c); });
+    std::ranges::transform(ret, ret.begin(), tolower);
   }
   return ret;
 }

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -7,6 +7,7 @@
 #include <ios>
 #include <sstream>
 
+#include "cct_cctype.hpp"
 #include "cct_config.hpp"
 #include "cct_exception.hpp"
 #include "stringhelpers.hpp"
@@ -29,7 +30,7 @@ inline std::pair<MonetaryAmount::AmountType, int8_t> AmountIntegralFromStr(std::
   if (firstChar == '-') {
     isNeg = true;
     amountStr.remove_prefix(1);
-  } else if (firstChar != '.' && (firstChar < '0' || firstChar > '9')) {
+  } else if (firstChar != '.' && !isdigit(firstChar)) {
     string ex("Parsing error, unexpected first char ");
     ex.push_back(firstChar);
     throw exception(std::move(ex));
@@ -102,7 +103,7 @@ MonetaryAmount::MonetaryAmount(std::string_view amountCurrencyStr) {
   assert(!amountCurrencyStr.empty());
   auto last = amountCurrencyStr.begin() + 1;  // skipping optional '-'
   auto endIt = amountCurrencyStr.end();
-  while (last != endIt && ((*last >= '0' && *last <= '9') || *last == '.')) {
+  while (last != endIt && (isdigit(*last) || *last == '.')) {
     ++last;
   }
   std::tie(_amount, _nbDecimals) = AmountIntegralFromStr(std::string_view(amountCurrencyStr.begin(), last));

--- a/src/tech/include/cct_cctype.hpp
+++ b/src/tech/include/cct_cctype.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cctype>
+
+namespace cct {
+/// Safe std::isalpha version. See https://en.cppreference.com/w/cpp/string/byte/isalpha
+inline bool isalpha(char c) { return std::isalpha(static_cast<unsigned char>(c)); }
+
+/// Safe std::isblank version. See https://en.cppreference.com/w/cpp/string/byte/isblank
+inline bool isblank(char c) { return std::isblank(static_cast<unsigned char>(c)); }
+
+/// Safe std::isdigit version. See https://en.cppreference.com/w/cpp/string/byte/isdigit
+inline bool isdigit(char c) { return std::isdigit(static_cast<unsigned char>(c)); }
+
+/// Safe std::isspace version. See https://en.cppreference.com/w/cpp/string/byte/isspace
+inline bool isspace(char c) { return std::isspace(static_cast<unsigned char>(c)); }
+
+}  // namespace cct

--- a/src/tech/include/toupperlower.hpp
+++ b/src/tech/include/toupperlower.hpp
@@ -78,15 +78,15 @@ constexpr char tolower(char c) noexcept {
   }
 }
 
-inline string toupper(std::string_view str) {
+inline string ToUpper(std::string_view str) {
   string ret(str);
-  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return toupper(c); });
+  std::ranges::transform(ret, ret.begin(), toupper);
   return ret;
 }
 
-inline string tolower(std::string_view str) {
+inline string ToLower(std::string_view str) {
   string ret(str);
-  std::transform(ret.begin(), ret.end(), ret.begin(), [](char c) { return tolower(c); });
+  std::ranges::transform(ret, ret.begin(), tolower);
   return ret;
 }
 }  // namespace cct

--- a/src/tech/src/cct_codec.cpp
+++ b/src/tech/src/cct_codec.cpp
@@ -74,7 +74,7 @@ string B64Decode(std::string_view ascdata) {
     bits_collected += 6;
     if (bits_collected >= 8) {
       bits_collected -= 8;
-      retval += static_cast<char>((accumulator >> bits_collected) & 0xffu);
+      retval.push_back(static_cast<char>((accumulator >> bits_collected) & 0xffu));
     }
   }
   return retval;


### PR DESCRIPTION
Use C++20 ranges for STL algorithms when applicable
Rename `cct::toupper(std::string_view)` into `cct::ToUpper` to avoid the need of `static_cast` when ambiguity. Also, `cct::toupper` is designed to mimick `std::toupper` so it's even better to disambiguate both flavors (the second one does not exist in `std`).
Same for `tolower`