### PR TITLE
Addition of custom price picker command line option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.15)
 
-project(coincenter VERSION 3.11.0
+project(coincenter VERSION 3.12.0
                    DESCRIPTION "A C++ library centralizing several crypto currencies exchanges REST API into a single all in one tool with a unified interface"
                    LANGUAGES CXX)
 

--- a/src/api/common/include/exchangepublicapi.hpp
+++ b/src/api/common/include/exchangepublicapi.hpp
@@ -21,6 +21,7 @@
 namespace cct {
 
 class FiatConverter;
+class TradeOptions;
 
 namespace api {
 
@@ -113,10 +114,9 @@ class ExchangePublic : public ExchangeBase {
                                      considerStableCoinsAsFiats);
   }
 
-  MonetaryAmount computeLimitOrderPrice(Market m, MonetaryAmount from, TradePriceStrategy priceStrategy);
+  MonetaryAmount computeLimitOrderPrice(Market m, MonetaryAmount from, const TradeOptions &tradeOptions);
 
-  MonetaryAmount computeAvgOrderPrice(Market m, MonetaryAmount from, TradePriceStrategy priceStrategy,
-                                      int depth = kDefaultDepth);
+  MonetaryAmount computeAvgOrderPrice(Market m, MonetaryAmount from, const TradeOptions &tradeOptions);
 
   /// Retrieve the market in the correct order proposed by the exchange for given couple of currencies.
   Market retrieveMarket(CurrencyCode c1, CurrencyCode c2);

--- a/src/api/common/include/tradedefinitions.hpp
+++ b/src/api/common/include/tradedefinitions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 
 namespace cct {
 enum class TradePriceStrategy : int8_t {
@@ -32,4 +33,9 @@ enum class TradeType : int8_t {
                        //  trades on these
                        //    markets.
 };
+
+using TradeRelativePrice = int32_t;
+
+static constexpr TradeRelativePrice kTradeNoRelativePrice = std::numeric_limits<TradeRelativePrice>::min();
+
 }  // namespace cct

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -62,6 +62,7 @@ struct CoincenterCmdLineOptions {
   std::string_view tradeMulti;
   std::string_view tradeMultiAll;
   std::string_view tradePrice;
+  std::string_view tradeStrategy;
   bool tradeTimeoutMatch = false;
   Duration tradeTimeout{TradeOptions().maxTradeTime()};
   Duration tradeUpdatePrice{TradeOptions().minTimeBetweenPriceUpdates()};
@@ -191,11 +192,20 @@ CommandLineOptionsParser<OptValueType> CreateCoincenterCommandLineOptionsParser(
                                                                      &OptValueType::tradeMulti},
        {{{"Trade", 42}, "--multitrade-all", "<cur1-cur2,exchange>", "Multi trade from available amount from given currency on an exchange.\n"
                                                                    "Order will be placed at limit price by default"}, &OptValueType::tradeMultiAll},
-       {{{"Trade", 43}, "--trade-strategy", "<maker|nibble|taker>", "Customize the order price strategy of the trade\n"
-                                                                  " - 'maker': order price continuously set at limit price (default)\n"
-                                                                  " - 'nibble': order price continuously set at limit price + (buy)/- (sell) 1\n"
-                                                                  " - 'taker': order price will be at market price, expected to be matched directly"}, 
+       {{{"Trade", 43}, "--trade-price", "<n|amt cur>", "Manually select trade price, supporting two flavors.\n"
+                                                                  "  'n' (>= 0): price will be chosen according to the 'n'th price\n"
+                                                                  "              of the order book (limit price is for n = 0)\n"
+                                                                  "  'amt cur' : price will be fixed at given price\n"
+                                                                  "Order price will not be continuously updated.\n"
+                                                                  "This option is not compatible with '--trade-strategy'"}, 
                                                                   &OptValueType::tradePrice},
+       {{{"Trade", 43}, "--trade-strategy", "<maker|nibble|taker>", "Customize the order price strategy of the trade\n"
+                                                                  "  'maker' : order price set at limit price (default)\n"
+                                                                  "  'nibble': order price set at limit price +(buy)/-(sell) 1\n"
+                                                                  "  'taker' : order price will be at market price and matched immediately\n"
+                                                                  "Order price will be continuously updated and recomputed every '--trade-updateprice' step time.\n"
+                                                                  "This option is not compatible with '--trade-price'"}, 
+                                                                  &OptValueType::tradeStrategy},                                                         
        {{{"Trade", 43}, "--trade-timeout", "<time>", string("Adjust trade timeout (default: ")
                                                 .append(ToString(defaultTradeTimeout))
                                                 .append("s). Remaining orders will be cancelled after the timeout.")}, 

--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "cct_type_traits.hpp"
+#include "cct_vector.hpp"
 #include "commandlineoptionsparser.hpp"
 #include "currencycode.hpp"
 #include "exchangename.hpp"

--- a/src/objects/include/marketorderbook.hpp
+++ b/src/objects/include/marketorderbook.hpp
@@ -127,6 +127,12 @@ class MarketOrderBook {
   int nbAskPrices() const { return static_cast<int>(_orders.size()) - _lowestAskPricePos; }
   int nbBidPrices() const { return _lowestAskPricePos; }
 
+  /// Get a pair of {Price, Amount} of values positionned at given relative price from limit price.
+  /// At position 0, the pair will contain average limit prices and average amounts from both highest bid and lowest ask
+  /// prices.
+  /// No bounds check is made.
+  std::pair<MonetaryAmount, MonetaryAmount> operator[](int relativePosToLimitPrice) const;
+
   MonetaryAmount getHighestTheoreticalPrice() const;
   MonetaryAmount getLowestTheoreticalPrice() const;
 

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -164,7 +164,13 @@ class MonetaryAmount {
     return *this;
   }
 
-  constexpr MonetaryAmount toNeutral() const noexcept { return MonetaryAmount(_amount, CurrencyCode(), _nbDecimals); }
+  constexpr MonetaryAmount toNeutral() const noexcept { return MonetaryAmount(_amount, _nbDecimals); }
+
+  constexpr bool isDefault() const noexcept { return _amount == 0 && hasNeutralCurrency(); }
+
+  constexpr bool hasNeutralCurrency() const noexcept { return _currencyCode.isNeutral(); }
+
+  constexpr bool isAmountInteger() const noexcept { return _nbDecimals == 0; }
 
   /// Truncate the MonetaryAmount such that it will contain at most maxNbDecimals
   constexpr void truncate(int8_t maxNbDecimals) noexcept { sanitizeDecimals(maxNbDecimals); }
@@ -183,6 +189,9 @@ class MonetaryAmount {
   using UnsignedAmountType = uint64_t;
 
   static constexpr AmountType kMaxAmountFullNDigits = ipow(10, std::numeric_limits<AmountType>::digits10);
+
+  /// Private constructor used only to transform one MonetaryAmount in neutral currency
+  constexpr MonetaryAmount(AmountType amount, int8_t nbDecimals) noexcept : _amount(amount), _nbDecimals(nbDecimals) {}
 
   constexpr void simplifyDecimals() noexcept {
     if (_amount == 0) {

--- a/src/objects/test/marketorderbook_test.cpp
+++ b/src/objects/test/marketorderbook_test.cpp
@@ -48,6 +48,15 @@ TEST_F(MarketOrderBookTestCase1, MiddleElements) {
   EXPECT_EQ(marketOrderBook.highestBidPrice(), MonetaryAmount("1301", "EUR"));
 }
 
+TEST_F(MarketOrderBookTestCase1, OperatorBrackets) {
+  EXPECT_EQ(marketOrderBook[-2], std::make_pair(MonetaryAmount("1300.5EUR"), MonetaryAmount("0.65ETH")));
+  EXPECT_EQ(marketOrderBook[-1], std::make_pair(MonetaryAmount("1301EUR"), MonetaryAmount("0.24ETH")));
+  EXPECT_EQ(marketOrderBook[0], std::make_pair(MonetaryAmount("1301.5EUR"), MonetaryAmount("0.82045ETH")));
+  EXPECT_EQ(marketOrderBook[1], std::make_pair(MonetaryAmount("1302EUR"), MonetaryAmount("1.4009ETH")));
+  EXPECT_EQ(marketOrderBook[2], std::make_pair(MonetaryAmount("1302.5EUR"), MonetaryAmount("3.78ETH")));
+  EXPECT_EQ(marketOrderBook[3], std::make_pair(MonetaryAmount("1303EUR"), MonetaryAmount("56.10001267ETH")));
+}
+
 TEST_F(MarketOrderBookTestCase1, ComputeCumulAmountBoughtImmediately) {
   EXPECT_EQ(marketOrderBook.computeCumulAmountBoughtImmediatelyAt(MonetaryAmount("1302.25", "EUR")),
             MonetaryAmount("1.4009", "ETH"));


### PR DESCRIPTION
Support of `--trade-price` option allowing to place orders at relative (compared to limit price) or absolute price.