### PR TITLE
Fix wrong json field read in Upbit deposit

### DIFF
--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -415,9 +415,10 @@ SentWithdrawInfo HuobiPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
       }
       netEmittedAmount = MonetaryAmount(withdrawDetail["amount"].get<double>(), currencyCode);
       MonetaryAmount fee(withdrawDetail["fee"].get<double>(), currencyCode);
-      if (netEmittedAmount + fee != initiatedWithdrawInfo.grossEmittedAmount()) {
-        log::error("{} + {} != {}, maybe a change in API", netEmittedAmount.amountStr(), fee.amountStr(),
-                   initiatedWithdrawInfo.grossEmittedAmount().amountStr());
+      double diffExpected = (netEmittedAmount + fee - initiatedWithdrawInfo.grossEmittedAmount()).toDouble();
+      if (diffExpected > 0.001 || diffExpected < -0.001) {
+        log::error("Unexpected fee - {} + {} != {}, maybe a change in API", netEmittedAmount.amountStr(),
+                   fee.amountStr(), initiatedWithdrawInfo.grossEmittedAmount().amountStr());
       }
       break;
     }

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -469,8 +469,7 @@ bool UpbitPrivate::isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWith
       }
     }
     log::debug("Deposit {} with amount {} is similar, but different amount than {}",
-               trx["refid"].get<std::string_view>(), netAmountReceived.str(),
-               sentWithdrawInfo.netEmittedAmount().str());
+               trx["txid"].get<std::string_view>(), netAmountReceived.str(), sentWithdrawInfo.netEmittedAmount().str());
   }
   return false;
 }


### PR DESCRIPTION
It should be `txid` instead of `refid` (probably copy pasted from `Kraken`).