### PR TITLE
Fix Bithumb check of withdraw received json parsing error

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,8 +79,9 @@ Then, locate where curl is installed (by default, should be in `C:\ProgramData\c
 
 ### External libraries
 
-`coincenter` uses various external open source libraries. 
-In all cases, they do not need to be installed. If they are not found at configure time, `cmake` will fetch sources and compile them automatically. If you are building frequently `coincenter` you can install them to speed up its compilation.
+`coincenter` uses various external open source libraries.
+In all cases, they do not need to be installed. If they are not found at configure time, `cmake` will fetch sources and compile them automatically. 
+If you are building frequently `coincenter` you can install them to speed up its compilation.
 
 | Library                                                        | Description                                        | License              |
 | -------------------------------------------------------------- | -------------------------------------------------- | -------------------- |
@@ -104,11 +105,12 @@ Other compilers have not been tested yet.
 
 #### cmake build options
 
-| Option             | Default              | Description                                     |
-| ------------------ | -------------------- | ----------------------------------------------- |
-| `CCT_ENABLE_TESTS` | `ON` if main project | Build and launch unit tests                     |
-| `CCT_BUILD_EXEC`   | `ON` if main project | Build an executable instead of a static library |
-| `CCT_ENABLE_ASAN`  | `ON` if Debug mode   | Compile with AddressSanitizer                   |
+| Option                  | Default                                                | Description                                     |
+| ----------------------- | ------------------------------------------------------ | ----------------------------------------------- |
+| `CCT_ENABLE_TESTS`      | `ON` if main project                                   | Build and launch unit tests                     |
+| `CCT_BUILD_EXEC`        | `ON` if main project                                   | Build an executable instead of a static library |
+| `CCT_ENABLE_ASAN`       | `ON` if Debug mode                                     | Compile with AddressSanitizer                   |
+| `CCT_ENABLE_CLANG_TIDY` | `ON` if Debug mode and `clang-tidy` is found in `PATH` | Compile with clang-tidy checks                  |
 
 Example on Linux: to compile it in `Release` mode and `ninja` generator
 ```

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -26,12 +26,14 @@ class CurrencyCode {
   constexpr CurrencyCode() noexcept : _data() {}
 
   /// Constructs a currency code from a static char array.
+  /// Note: spaces are not skipped. If any, there will be captured as part of the code, which is probably unexpected.
   template <unsigned N, std::enable_if_t<N <= kAcronymMaxLen + 1, bool> = true>
   constexpr CurrencyCode(const char (&acronym)[N]) noexcept {
     set(acronym);
   }
 
   /// Constructs a currency code from given string.
+  /// Note: spaces are not skipped. If any, there will be captured as part of the code, which is probably unexpected.
   constexpr CurrencyCode(std::string_view acronym) {
     if (_data.size() < acronym.size()) {
       if (!std::is_constant_evaluated()) {

--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -297,4 +297,10 @@ TEST(MonetaryAmountTest, NegativeAmountStr) {
   EXPECT_EQ(MonetaryAmount("-0.0").amountStr(), "0");
 }
 
+TEST(MonetaryAmountTest, ExoticInput) {
+  EXPECT_EQ(MonetaryAmount(" + 4.6   EUr "), MonetaryAmount("4.6EUR"));
+  EXPECT_EQ(MonetaryAmount(" - .9   f&g "), MonetaryAmount("-0.9F&G"));
+  EXPECT_THROW(MonetaryAmount("--.9"), exception);
+}
+
 }  // namespace cct


### PR DESCRIPTION
- [More robust MonetaryAmount construct from string](https://github.com/sjanel/coincenter/pull/298/commits/4b7b2588d8502d51574b46eb5ffde83eabd2842d)
- [Fix Bithumb check of withdraw received json parsing error](https://github.com/sjanel/coincenter/pull/298/commits/af1cf093399816b524f76b4e73b7ca183fd1427a)
- [Addition of documentation of clang-tidy activation in cmake](https://github.com/sjanel/coincenter/pull/298/commits/46d79cb12655dabe387b0b130b499c2541cc888f)