### PR TITLE
Allow currency option to be optional or mandatory depending on the needs

### DIFF
--- a/src/engine/include/stringoptionparser.hpp
+++ b/src/engine/include/stringoptionparser.hpp
@@ -22,13 +22,15 @@ class StringOptionParser {
   using CurrencyPublicExchanges = std::pair<CurrencyCode, ExchangeNames>;
   using CurrenciesPublicExchanges = std::tuple<CurrencyCode, CurrencyCode, ExchangeNames>;
 
+  enum class CurrencyIs : int8_t { kMandatory, kOptional };
+
   explicit StringOptionParser(std::string_view optFullStr) : _opt(optFullStr) {}
 
   ExchangeNames getExchanges() const;
 
   MarketExchanges getMarketExchanges() const;
 
-  CurrencyPrivateExchanges getCurrencyPrivateExchanges() const;
+  CurrencyPrivateExchanges getCurrencyPrivateExchanges(CurrencyIs currencyIs) const;
 
   auto getMonetaryAmountPrivateExchanges() const {
     auto ret = getMonetaryAmountCurrencyPrivateExchanges(false);

--- a/src/engine/src/coincentercommands.cpp
+++ b/src/engine/src/coincentercommands.cpp
@@ -105,7 +105,8 @@ bool CoincenterCommands::setFromOptions(const CoincenterCmdLineOptions &cmdLineO
 
   if (cmdLineOptions.balance) {
     StringOptionParser anyParser(*cmdLineOptions.balance);
-    auto [balanceCurrencyCode, exchanges] = anyParser.getCurrencyPrivateExchanges();
+    auto [balanceCurrencyCode, exchanges] =
+        anyParser.getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kOptional);
     _commands.emplace_back(CoincenterCommandType::kBalance)
         .setCur1(balanceCurrencyCode)
         .setExchangeNames(std::move(exchanges));
@@ -187,7 +188,8 @@ bool CoincenterCommands::setFromOptions(const CoincenterCmdLineOptions &cmdLineO
     StringOptionParser optParser(tradeArgs);
     if (isSmartTrade) {
       if (!cmdLineOptions.sellAll.empty()) {
-        auto [fromTradeCurrency, exchanges] = optParser.getCurrencyPrivateExchanges();
+        auto [fromTradeCurrency, exchanges] =
+            optParser.getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory);
         coincenterCommand.setAmount(MonetaryAmount(100, fromTradeCurrency))
             .setPercentageAmount(true)
             .setExchangeNames(std::move(exchanges));
@@ -219,7 +221,8 @@ bool CoincenterCommands::setFromOptions(const CoincenterCmdLineOptions &cmdLineO
 
   if (!cmdLineOptions.depositInfo.empty()) {
     StringOptionParser anyParser(cmdLineOptions.depositInfo);
-    auto [depositCurrency, exchanges] = anyParser.getCurrencyPrivateExchanges();
+    auto [depositCurrency, exchanges] =
+        anyParser.getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory);
     _commands.emplace_back(CoincenterCommandType::kDepositInfo)
         .setCur1(depositCurrency)
         .setExchangeNames(std::move(exchanges));

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -96,7 +96,8 @@ StringOptionParser::MarketExchanges StringOptionParser::getMarketExchanges() con
                          GetExchanges(StrEnd(_opt, startExchangesPos))};
 }
 
-StringOptionParser::CurrencyPrivateExchanges StringOptionParser::getCurrencyPrivateExchanges() const {
+StringOptionParser::CurrencyPrivateExchanges StringOptionParser::getCurrencyPrivateExchanges(
+    CurrencyIs currencyIs) const {
   std::string_view exchangesStr = _opt;
   std::string_view curStr;
   std::size_t commaPos = getNextCommaPos(0, false);
@@ -108,6 +109,9 @@ StringOptionParser::CurrencyPrivateExchanges StringOptionParser::getCurrencyPriv
     } else {
       exchangesStr = std::string_view(_opt.begin() + commaPos + 1, _opt.end());
     }
+  }
+  if (curStr.empty() && currencyIs == CurrencyIs::kMandatory) {
+    throw invalid_argument("Expected a currency code first");
   }
 
   return CurrencyPrivateExchanges(CurrencyCode(curStr), GetExchanges(exchangesStr));

--- a/src/engine/test/stringoptionparser_test.cpp
+++ b/src/engine/test/stringoptionparser_test.cpp
@@ -14,19 +14,26 @@ TEST(StringOptionParserTest, GetExchanges) {
 }
 
 TEST(StringOptionParserTest, GetCurrencyPrivateExchanges) {
-  EXPECT_EQ(StringOptionParser("").getCurrencyPrivateExchanges(), std::make_pair(CurrencyCode(), ExchangeNames()));
-  EXPECT_EQ(StringOptionParser("eur").getCurrencyPrivateExchanges(),
+  auto optionalCur = StringOptionParser::CurrencyIs::kOptional;
+  EXPECT_EQ(StringOptionParser("").getCurrencyPrivateExchanges(optionalCur),
+            std::make_pair(CurrencyCode(), ExchangeNames()));
+  EXPECT_EQ(StringOptionParser("eur").getCurrencyPrivateExchanges(optionalCur),
             std::make_pair(CurrencyCode("EUR"), ExchangeNames()));
-  EXPECT_EQ(StringOptionParser("kraken1").getCurrencyPrivateExchanges(),
+  EXPECT_EQ(StringOptionParser("kraken1").getCurrencyPrivateExchanges(optionalCur),
             std::make_pair(CurrencyCode("kraken1"), ExchangeNames()));
-  EXPECT_EQ(StringOptionParser("bithumb,binance_user1").getCurrencyPrivateExchanges(),
+  EXPECT_EQ(StringOptionParser("bithumb,binance_user1").getCurrencyPrivateExchanges(optionalCur),
             std::make_pair(CurrencyCode(), ExchangeNames({ExchangeName("bithumb"), ExchangeName("binance", "user1")})));
-  EXPECT_EQ(StringOptionParser("binance_user2,bithumb,binance_user1").getCurrencyPrivateExchanges(),
+  EXPECT_EQ(StringOptionParser("binance_user2,bithumb,binance_user1").getCurrencyPrivateExchanges(optionalCur),
             std::make_pair(CurrencyCode(), ExchangeNames({ExchangeName("binance", "user2"), ExchangeName("bithumb"),
                                                           ExchangeName("binance", "user1")})));
   EXPECT_EQ(
-      StringOptionParser("krw,Bithumb,binance_user1").getCurrencyPrivateExchanges(),
+      StringOptionParser("krw,Bithumb,binance_user1")
+          .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
       std::make_pair(CurrencyCode("KRW"), ExchangeNames({ExchangeName("bithumb"), ExchangeName("binance", "user1")})));
+
+  EXPECT_THROW(StringOptionParser("binance_user1,bithumb")
+                   .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
+               invalid_argument);
 }
 
 TEST(StringOptionParserTest, GetMarketExchanges) {


### PR DESCRIPTION
It's currently possible to not provide currency for some options requiring one, for instance `--deposit-info`.
This is not expected and this PR raises an exception when the currency is mandatory and not provided.