### PR TITLE
Throw invalid argument if MonetaryAmount is built with a CurrencyCode too long, and in CLI as well

### DIFF
--- a/src/engine/test/stringoptionparser_test.cpp
+++ b/src/engine/test/stringoptionparser_test.cpp
@@ -31,6 +31,8 @@ TEST(StringOptionParserTest, GetCurrencyPrivateExchanges) {
           .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
       std::make_pair(CurrencyCode("KRW"), ExchangeNames({ExchangeName("bithumb"), ExchangeName("binance", "user1")})));
 
+  EXPECT_THROW(StringOptionParser("toolongcur,Bithumb,binance_user1").getCurrencyPrivateExchanges(optionalCur),
+               invalid_argument);
   EXPECT_THROW(StringOptionParser("binance_user1,bithumb")
                    .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
                invalid_argument);
@@ -42,6 +44,8 @@ TEST(StringOptionParserTest, GetMarketExchanges) {
   EXPECT_EQ(StringOptionParser("dash-krw,bithumb,upbit").getMarketExchanges(),
             StringOptionParser::MarketExchanges(Market("DASH", "KRW"),
                                                 ExchangeNames({ExchangeName("bithumb"), ExchangeName("upbit")})));
+
+  EXPECT_THROW(StringOptionParser("dash-toolongcur,bithumb,upbit").getMarketExchanges(), invalid_argument);
 }
 
 TEST(StringOptionParserTest, GetMonetaryAmountPrivateExchanges) {

--- a/src/objects/CMakeLists.txt
+++ b/src/objects/CMakeLists.txt
@@ -75,7 +75,7 @@ add_unit_test(
     wallet_test 
     test/wallet_test.cpp 
     LIBRARIES 
-    coincenter_objects 
+    coincenter_objects
     DEFINITIONS 
     CCT_DISABLE_SPDLOG
 )

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -20,8 +20,6 @@ class CurrencyCode {
  public:
   static constexpr int kAcronymMaxLen = 7;
 
-  using AcronymType = std::array<char, kAcronymMaxLen>;  // warning: not null terminated
-
   /// Constructs a neutral currency code.
   constexpr CurrencyCode() noexcept : _data() {}
 
@@ -33,6 +31,7 @@ class CurrencyCode {
   }
 
   /// Constructs a currency code from given string.
+  /// If number of chars in 'acronym' is higher than 'kAcronymMaxLen', currency code will be truncated silently.
   /// Note: spaces are not skipped. If any, there will be captured as part of the code, which is probably unexpected.
   constexpr CurrencyCode(std::string_view acronym) {
     if (_data.size() < acronym.size()) {
@@ -44,7 +43,12 @@ class CurrencyCode {
     set(acronym);
   }
 
+  /// Constructs a currency code from given string, with no truncation possible.
+  /// If str is too long, invalid_argument exception will be thrown
+  static CurrencyCode fromStrSafe(std::string_view acronym);
+
   constexpr uint64_t size() const { return std::ranges::find(_data, '\0') - _data.begin(); }
+  constexpr uint64_t length() const { return size(); }
 
   /// Get a string view of this CurrencyCode, trimmed.
   constexpr std::string_view str() const { return std::string_view(_data.begin(), std::ranges::find(_data, '\0')); }
@@ -73,7 +77,7 @@ class CurrencyCode {
   }
 
  private:
-  AcronymType _data;
+  std::array<char, kAcronymMaxLen> _data;  // warning: not always null terminated
 
   constexpr inline void set(std::string_view acronym) {
     // Fill extra chars to 0 is important as we always read them for code generation

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -16,10 +16,11 @@
 namespace cct {
 
 /// Represents a fixed-precision decimal amount with a currency (fiat or coin).
-///
-/// This object aims to provide high performance operations as well as predictive and precise basic arithmetic (as
-/// opposed to double).
-/// In addition, it is light (only 16 bytes) and can be passed by copy instead of reference.
+/// It is designed to be
+///  - fast
+///  - small (16 bytes only). Thus can be passed by copy instead of reference
+///  - precise (amount is stored in a int64_t)
+///  - optimized, predictive and exact for additions and subtractions (if no overflow during the operation)
 ///
 /// It is easy and straightforward to use with string_view constructor and partial constexpr support.
 ///
@@ -29,7 +30,7 @@ namespace cct {
 class MonetaryAmount {
  public:
   using AmountType = int64_t;
-  enum class RoundType { kDown, kUp, kNearest };
+  enum class RoundType : int8_t { kDown, kUp, kNearest };
 
   /// Constructs a MonetaryAmount with a value of 0 of neutral currency.
   constexpr MonetaryAmount() noexcept : _amount(0), _nbDecimals(0) {}
@@ -62,6 +63,7 @@ class MonetaryAmount {
 
   /// Constructs a new MonetaryAmount from a string, containing an optional CurrencyCode.
   /// If it's not present, assume default CurrencyCode.
+  /// If the currency is too long to fit in a CurrencyCode, exception invalid_argument will be raised
   /// If given string is empty, it is equivalent to a default constructor.
   /// Examples: "10.5EUR" -> 10.5 units of currency EUR
   ///           "45 KRW" -> 45 units of currency KRW
@@ -250,7 +252,7 @@ class MonetaryAmount {
 };
 
 static_assert(sizeof(MonetaryAmount) <= 16, "MonetaryAmount size should stay small");
-static_assert(std::is_trivially_copyable_v<MonetaryAmount>, "MonetaryAmount should be fast to copy");
+static_assert(std::is_trivially_copyable_v<MonetaryAmount>, "MonetaryAmount should be trivially copyable");
 
 inline MonetaryAmount operator*(MonetaryAmount::AmountType mult, MonetaryAmount rhs) { return rhs * mult; }
 

--- a/src/objects/src/currencycode.cpp
+++ b/src/objects/src/currencycode.cpp
@@ -1,0 +1,14 @@
+#include "currencycode.hpp"
+
+#include "cct_invalid_argument_exception.hpp"
+
+namespace cct {
+CurrencyCode CurrencyCode::fromStrSafe(std::string_view acronym) {
+  if (acronym.length() > kAcronymMaxLen) {
+    string msg("Currency ");
+    msg.append(acronym).append(" is too long");
+    throw invalid_argument(std::move(msg));
+  }
+  return CurrencyCode(acronym);
+}
+}  // namespace cct

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -144,7 +144,7 @@ MonetaryAmount::MonetaryAmount(std::string_view amountCurrencyStr) {
   std::string_view amountStr(amountCurrencyStr.begin(), last);
   RemoveTrailing(amountStr, ' ');
   std::tie(_amount, _nbDecimals) = AmountIntegralFromStr(amountStr);
-  _currencyCode = CurrencyCode(std::string_view(last, endIt));
+  _currencyCode = CurrencyCode::fromStrSafe(std::string_view(last, endIt));
   assert(isSane());
 }
 

--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "cct_exception.hpp"
+#include "cct_invalid_argument_exception.hpp"
 
 namespace cct {
 
@@ -188,6 +189,11 @@ TEST(MonetaryAmountTest, StringConstructor) {
   EXPECT_EQ(MonetaryAmount("-210.50 CAKE"), MonetaryAmount("-210.50", "CAKE"));
   EXPECT_EQ(MonetaryAmount("05AUD"), MonetaryAmount(5, "AUD"));
   EXPECT_EQ(MonetaryAmount("746REPV2"), MonetaryAmount("746", "REPV2"));
+}
+
+TEST(MonetaryAmountTest, CurrencyTooLong) {
+  EXPECT_THROW(MonetaryAmount("804.62 toolongcur"), invalid_argument);
+  EXPECT_THROW(MonetaryAmount("-210.50iamtoolo"), invalid_argument);
 }
 
 TEST(MonetaryAmountTest, Zero) {


### PR DESCRIPTION
Protect against invalid currency code input in the CLI.
Also throw if `MonetaryAmount` is built with a `CurrencyCode` too long in the unique `std::string_view` constructor.