### PR TITLE
Increase maximum number of characters of currency code to 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(coincenter VERSION 3.16.1
+project(coincenter VERSION 3.17.0
   DESCRIPTION "A C++ library centralizing several crypto currencies exchanges REST API into a single all in one tool with a unified interface"
   LANGUAGES CXX)
 

--- a/src/api-objects/include/ordersconstraints.hpp
+++ b/src/api-objects/include/ordersconstraints.hpp
@@ -80,8 +80,8 @@ class OrdersConstraints {
 
   Market market() const { return Market(_cur1, _cur2); }
 
-  std::string_view curStr1() const { return _cur1.str(); }
-  std::string_view curStr2() const { return _cur2.str(); }
+  string curStr1() const { return _cur1.str(); }
+  string curStr2() const { return _cur2.str(); }
 
   CurrencyCode cur1() const { return _cur1; }
   CurrencyCode cur2() const { return _cur2; }

--- a/src/api-objects/src/ordersconstraints.cpp
+++ b/src/api-objects/src/ordersconstraints.cpp
@@ -34,11 +34,11 @@ OrdersConstraints::OrdersConstraints(CurrencyCode cur1, CurrencyCode cur2, Durat
 string OrdersConstraints::str() const {
   string ret;
   if (isCur1Defined()) {
-    ret.append(_cur1.str());
+    _cur1.appendStr(ret);
   }
   if (isCur2Defined()) {
     ret.push_back('-');
-    ret.append(_cur2.str());
+    _cur2.appendStr(ret);
   }
   if (ret.empty()) {
     ret.append("any");

--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -88,7 +88,7 @@ CryptowatchAPI::Fiats CryptowatchAPI::FiatsFunc::operator()() {
     auto foundIt = assetDetails.find("fiat");
     if (foundIt != assetDetails.end() && foundIt->get<bool>()) {
       CurrencyCode fiatCode(assetDetails["symbol"].get<std::string_view>());
-      log::debug("Storing fiat {}", fiatCode.str());
+      log::debug("Storing fiat {}", fiatCode);
       fiats.insert(std::move(fiatCode));
     }
   }

--- a/src/api/common/src/exchangeprivateapi.cpp
+++ b/src/api/common/src/exchangeprivateapi.cpp
@@ -29,7 +29,7 @@ void ExchangePrivate::addBalance(BalancePortfolio &balancePortfolio, MonetaryAmo
       if (optConvertedAmountEquiCurrency) {
         equivalentInMainCurrency = *optConvertedAmountEquiCurrency;
       } else {
-        log::warn("Cannot convert {} into {} on {}", amount.currencyStr(), equiCurrency.str(), _exchangePublic.name());
+        log::warn("Cannot convert {} into {} on {}", amount.currencyStr(), equiCurrency, _exchangePublic.name());
         equivalentInMainCurrency = MonetaryAmount(0, equiCurrency);
       }
       log::debug("{} Balance {} (eq. {})", _exchangePublic.name(), amount.str(), equivalentInMainCurrency.str());
@@ -45,22 +45,22 @@ TradedAmounts ExchangePrivate::trade(MonetaryAmount from, CurrencyCode toCurrenc
   const int nbTrades = static_cast<int>(conversionPath.size());
   const bool isMultiTradeAllowed = options.isMultiTradeAllowed(exchangeInfo().multiTradeAllowedByDefault());
   log::info("{}rade {} -> {} on {}_{} requested", isMultiTradeAllowed && nbTrades > 1 ? "Multi t" : "T", from.str(),
-            toCurrency.str(), _exchangePublic.name(), keyName());
+            toCurrency, _exchangePublic.name(), keyName());
   TradedAmounts tradedAmounts(from.currencyCode(), toCurrency);
   if (conversionPath.empty()) {
-    log::warn("Cannot trade {} into {} on {}", from.str(), toCurrency.str(), _exchangePublic.name());
+    log::warn("Cannot trade {} into {} on {}", from.str(), toCurrency, _exchangePublic.name());
     return tradedAmounts;
   }
   if (nbTrades > 1 && !isMultiTradeAllowed) {
     log::error("Can only convert {} to {} in {} steps, but multi trade is not allowed, aborting", from.str(),
-               toCurrency.str(), nbTrades);
+               toCurrency, nbTrades);
     return tradedAmounts;
   }
   MonetaryAmount avAmount = from;
   for (int tradePos = 0; tradePos < nbTrades; ++tradePos) {
     Market m = conversionPath[tradePos];
     log::info("Step {}/{} - trade {} into {}", tradePos + 1, nbTrades, avAmount.str(),
-              m.opposite(avAmount.currencyCode()).str());
+              m.opposite(avAmount.currencyCode()));
     TradedAmounts stepTradedAmounts = marketTrade(avAmount, options, m);
     avAmount = stepTradedAmounts.tradedTo;
     if (avAmount.isZero()) {

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -99,7 +99,7 @@ MarketsPath ExchangePublic::findMarketsPath(CurrencyCode fromCurrency, CurrencyC
                                             const Fiats &fiats, bool considerStableCoinsAsFiats) {
   MarketsPath ret;
   if (fromCurrency == toCurrency) {
-    log::warn("Cannot convert {} to itself", fromCurrency.str());
+    log::warn("Cannot convert {} to itself", fromCurrency);
     return ret;
   }
 
@@ -239,7 +239,7 @@ std::optional<Market> ExchangePublic::determineMarketFromMarketStr(std::string_v
 
   if (!filterCur.isNeutral()) {
     std::size_t firstCurLen;
-    std::string_view curStr = filterCur.str();
+    auto curStr = filterCur.str();
     std::size_t curPos = marketStr.find(curStr);
     if (curPos == 0) {
       firstCurLen = curStr.size();
@@ -317,7 +317,7 @@ Market ExchangePublic::determineMarketFromFilterCurrencies(MarketSet &markets, C
     if (tryAppendBaseCurrency(filterCur2)) {
       tryAppendQuoteCurrency(filterCur2, filterCur1);
     } else {
-      log::debug("Cannot find {} among {} markets", filterCur1.str(), name());
+      log::debug("Cannot find {} among {} markets", filterCur1, name());
     }
   }
   return ret;

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -95,7 +95,7 @@ CurrencyExchangeFlatSet BinancePublic::queryTradableCurrencies(const json& data)
   const ExchangeInfo::CurrencySet& excludedCurrencies = _commonInfo._exchangeInfo.excludedCurrenciesAll();
   for (const json& el : data) {
     std::string_view coin = el["coin"].get<std::string_view>();
-    if (coin.size() > CurrencyCode::kAcronymMaxLen) {
+    if (coin.size() > CurrencyCode::kMaxLen) {
       continue;
     }
     CurrencyCode cur(coin);
@@ -165,7 +165,7 @@ BinancePublic::ExchangeInfoFunc::ExchangeInfoDataByMarket BinancePublic::Exchang
       log::trace("Discard {}-{} as coincenter does not support leveraged markets", baseAsset, quoteAsset);
       continue;
     }
-    if (baseAsset.size() > CurrencyCode::kAcronymMaxLen || quoteAsset.size() > CurrencyCode::kAcronymMaxLen) {
+    if (baseAsset.size() > CurrencyCode::kMaxLen || quoteAsset.size() > CurrencyCode::kMaxLen) {
       log::trace("Discard {}-{} as one asset is too long", baseAsset, quoteAsset);
       continue;
     }
@@ -227,7 +227,7 @@ WithdrawalFeeMap BinancePublic::queryWithdrawalFees() {
   WithdrawalFeeMap ret;
   for (const json& el : _globalInfosCache.get()) {
     std::string_view coinStr = el["coin"].get<std::string_view>();
-    if (coinStr.size() > CurrencyCode::kAcronymMaxLen) {
+    if (coinStr.size() > CurrencyCode::kMaxLen) {
       continue;
     }
     CurrencyCode cur(coinStr);
@@ -249,7 +249,7 @@ MonetaryAmount BinancePublic::queryWithdrawalFee(CurrencyCode currencyCode) {
     }
   }
   string ex("Unable to find withdrawal fee for ");
-  ex.append(currencyCode.str());
+  currencyCode.appendStr(ex);
   throw exception(std::move(ex));
 }
 

--- a/src/api/exchanges/src/bithumbpublicapi.cpp
+++ b/src/api/exchanges/src/bithumbpublicapi.cpp
@@ -22,10 +22,10 @@ json PublicQuery(CurlHandle& curlHandle, std::string_view endpoint, CurrencyCode
                  CurrencyCode quote = CurrencyCode(), std::string_view urlOpts = "") {
   string methodUrl(endpoint);
   methodUrl.push_back('/');
-  methodUrl.append(base.str());
+  base.appendStr(methodUrl);
   if (!quote.isNeutral()) {
     methodUrl.push_back('_');
-    methodUrl.append(quote.str());
+    quote.appendStr(methodUrl);
   }
   if (!urlOpts.empty()) {
     methodUrl.push_back('?');
@@ -216,7 +216,7 @@ MarketOrderBookMap GetOrderbooks(CurlHandle& curlHandle, const CoincenterInfo& c
         baseCurrencyCode = CurrencyCode(config.standardizeCurrencyCode(baseOrSpecial));
         if (excludedCurrencies.contains(baseCurrencyCode)) {
           // Forbidden currency, do not consider its market
-          log::trace("Discard {} excluded by config", baseCurrencyCode.str());
+          log::trace("Discard {} excluded by config", baseCurrencyCode);
           continue;
         }
         asksBids[0] = std::addressof(asksAndBids["asks"]);

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -261,7 +261,7 @@ PlaceOrderInfo HuobiPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volu
   MonetaryAmount sanitizedVol = huobiPublic.sanitizeVolume(m, fromCurrencyCode, volume, price, isTakerStrategy);
   const bool isSimulationWithRealOrder = tradeInfo.options.isSimulation() && placeSimulatedRealOrder;
   if (volume < sanitizedVol && !isSimulationWithRealOrder) {
-    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode.str(),
+    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode,
               sanitizedVol.str());
     placeOrderInfo.setClosed();
     return placeOrderInfo;
@@ -367,16 +367,16 @@ InitiatedWithdrawInfo HuobiPrivate::launchWithdraw(MonetaryAmount grossAmount, W
   MonetaryAmount netEmittedAmount = grossAmount - fee;
   if (!withdrawParams.minWithdrawAmt.isDefault() && netEmittedAmount < withdrawParams.minWithdrawAmt) {
     string err("Minimum withdraw amount for ");
-    err.append(currencyCode.str())
-        .append(" on Huobi is ")
+    currencyCode.appendStr(err);
+    err.append(" on Huobi is ")
         .append(withdrawParams.minWithdrawAmt.amountStr())
         .append(", cannot withdraw ")
         .append(netEmittedAmount.str());
     throw exception(std::move(err));
   } else if (!withdrawParams.maxWithdrawAmt.isDefault() && netEmittedAmount > withdrawParams.maxWithdrawAmt) {
     string err("Maximum withdraw amount for ");
-    err.append(currencyCode.str())
-        .append(" on Huobi is ")
+    currencyCode.appendStr(err);
+    err.append(" on Huobi is ")
         .append(withdrawParams.maxWithdrawAmt.amountStr())
         .append(", cannot withdraw ")
         .append(netEmittedAmount.str());

--- a/src/api/exchanges/src/huobipublicapi.cpp
+++ b/src/api/exchanges/src/huobipublicapi.cpp
@@ -115,7 +115,7 @@ CurrencyExchangeFlatSet HuobiPublic::queryTradableCurrencies() {
       break;
     }
     if (!foundChainWithSameName) {
-      log::debug("Cannot find {} main chain in Huobi, discarding currency", cur.str());
+      log::debug("Cannot find {} main chain in Huobi, discarding currency", cur);
     }
   }
   CurrencyExchangeFlatSet ret(std::move(currencies));
@@ -150,7 +150,7 @@ std::pair<MarketSet, HuobiPublic::MarketsFunc::MarketInfoMap> HuobiPublic::Marke
       log::trace("Trading is {} for market {}-{}", stateStr, baseAsset, quoteAsset);
       continue;
     }
-    if (baseAsset.size() > CurrencyCode::kAcronymMaxLen || quoteAsset.size() > CurrencyCode::kAcronymMaxLen) {
+    if (baseAsset.size() > CurrencyCode::kMaxLen || quoteAsset.size() > CurrencyCode::kMaxLen) {
       log::trace("Discard {}-{} as one asset is too long", baseAsset, quoteAsset);
       continue;
     }
@@ -247,7 +247,9 @@ MonetaryAmount HuobiPublic::queryWithdrawalFee(CurrencyCode currencyCode) {
       }
     }
   }
-  throw exception("Unable to find withdrawal fee for " + string(currencyCode.str()));
+  string msg("Unable to find withdrawal fee for ");
+  currencyCode.appendStr(msg);
+  throw exception(std::move(msg));
 }
 
 MarketOrderBookMap HuobiPublic::AllOrderBooksFunc::operator()(int depth) {

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -142,7 +142,7 @@ Wallet KucoinPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
   json result = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/api/v2/deposit-addresses",
                              {{"currency", currencyCode.str()}});
   if (result.empty()) {
-    log::info("No deposit address for {} in {}, creating one", currencyCode.str(), _kucoinPublic.name());
+    log::info("No deposit address for {} in {}, creating one", currencyCode, _kucoinPublic.name());
     result = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kPost, "/api/v1/deposit-addresses",
                           {{"currency", currencyCode.str()}});
   } else {
@@ -258,7 +258,7 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
 
   MonetaryAmount sanitizedVol = kucoinPublic.sanitizeVolume(m, volume);
   if (volume < sanitizedVol) {
-    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode.str(),
+    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode,
               sanitizedVol.str());
     placeOrderInfo.setClosed();
     return placeOrderInfo;

--- a/src/api/exchanges/src/kucoinpublicapi.cpp
+++ b/src/api/exchanges/src/kucoinpublicapi.cpp
@@ -112,7 +112,7 @@ std::pair<MarketSet, KucoinPublic::MarketsFunc::MarketInfoMap> KucoinPublic::Mar
       log::trace("Discard {}-{} excluded by config", baseAsset, quoteAsset);
       continue;
     }
-    if (baseAsset.size() > CurrencyCode::kAcronymMaxLen || quoteAsset.size() > CurrencyCode::kAcronymMaxLen) {
+    if (baseAsset.size() > CurrencyCode::kMaxLen || quoteAsset.size() > CurrencyCode::kMaxLen) {
       log::trace("Discard {}-{} as one asset is too long", baseAsset, quoteAsset);
       continue;
     }
@@ -152,7 +152,9 @@ MonetaryAmount KucoinPublic::queryWithdrawalFee(CurrencyCode currencyCode) {
   const auto& currencyInfoSet = _tradableCurrenciesCache.get();
   auto it = currencyInfoSet.find(TradableCurrenciesFunc::CurrencyInfo(currencyCode));
   if (it == currencyInfoSet.end()) {
-    throw exception("Unable to find withdrawal fee for " + string(currencyCode.str()));
+    string msg("Unable to find withdrawal fee for ");
+    currencyCode.appendStr(msg);
+    throw exception(std::move(msg));
   }
   return MonetaryAmount(it->withdrawalMinFee, it->currencyExchange.standardCode());
 }

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -102,10 +102,10 @@ CurrencyExchangeFlatSet UpbitPrivate::TradableCurrenciesFunc::operator()() {
         depositStatus = CurrencyExchange::Deposit::kAvailable;
       }
       if (withdrawStatus == CurrencyExchange::Withdraw::kUnavailable) {
-        log::debug("{} cannot be withdrawn from Upbit", cur.str());
+        log::debug("{} cannot be withdrawn from Upbit", cur);
       }
       if (depositStatus == CurrencyExchange::Deposit::kUnavailable) {
-        log::debug("{} cannot be deposited to Upbit", cur.str());
+        log::debug("{} cannot be deposited to Upbit", cur);
       }
       currencies.emplace_back(cur, cur, cur, depositStatus, withdrawStatus,
                               _cryptowatchApi.queryIsCurrencyCodeFiat(cur) ? CurrencyExchange::Type::kFiat
@@ -136,7 +136,7 @@ Wallet UpbitPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
     std::string_view name = (*errorIt)["name"].get<std::string_view>();
     std::string_view msg = (*errorIt)["message"].get<std::string_view>();
     if (name == "coin_address_not_found") {
-      log::warn("No deposit address found for {}, generating a new one", currencyCode.str());
+      log::warn("No deposit address found for {}, generating a new one", currencyCode);
       generateDepositAddressNeeded = true;
     } else {
       string err("error: ");
@@ -167,7 +167,8 @@ Wallet UpbitPrivate::DepositWalletFunc::operator()(CurrencyCode currencyCode) {
   auto addressIt = result.find("deposit_address");
   if (addressIt == result.end() || addressIt->is_null()) {
     string err("Deposit address for ");
-    err.append(currencyCode.str()).append(" is undefined");
+    currencyCode.appendStr(err);
+    err.append(" is undefined");
     throw exception(std::move(err));
   }
   std::string_view tag;
@@ -325,7 +326,7 @@ PlaceOrderInfo UpbitPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volu
   MonetaryAmount sanitizedVol = UpbitPublic::SanitizeVolume(volume, price);
   const bool isSimulationWithRealOrder = tradeInfo.options.isSimulation() && placeSimulatedRealOrder;
   if (volume < sanitizedVol && !isSimulationWithRealOrder) {
-    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode.str(),
+    log::warn("No trade of {} into {} because min vol order is {} for this market", volume.str(), toCurrencyCode,
               sanitizedVol.str());
     placeOrderInfo.setClosed();
     return placeOrderInfo;
@@ -419,7 +420,7 @@ SentWithdrawInfo UpbitPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
   // 'canceled'}
   const bool isCanceled = stateUpperStr == "CANCELED";
   if (isCanceled) {
-    log::error("{} withdraw of {} has been cancelled", _exchangePublic.name(), currencyCode.str());
+    log::error("{} withdraw of {} has been cancelled", _exchangePublic.name(), currencyCode);
   }
   const bool isDone = stateUpperStr == "DONE";
   return SentWithdrawInfo(netEmittedAmount, isDone || isCanceled);

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -84,7 +84,7 @@ CurrencyExchangeFlatSet UpbitPublic::TradableCurrenciesFunc::operator()() {
 bool UpbitPublic::CheckCurrencyCode(CurrencyCode standardCode, const ExchangeInfo::CurrencySet& excludedCurrencies) {
   if (excludedCurrencies.contains(standardCode)) {
     // Forbidden currency, do not consider its market
-    log::trace("Discard {} excluded by config", standardCode.str());
+    log::trace("Discard {} excluded by config", standardCode);
     return false;
   }
   return true;

--- a/src/api/exchanges/test/commonapi_test.hpp
+++ b/src/api/exchanges/test/commonapi_test.hpp
@@ -115,14 +115,14 @@ class TestAPI {
 
       for (const CurrencyExchange &curExchange : sample) {
         CurrencyCode cur(curExchange.standardCode());
-        log::info("Choosing {} as random currency code for Withdrawal fee test", cur.str());
+        log::info("Choosing {} as random currency code for Withdrawal fee test", cur);
         auto withdrawalFeeIt = withdrawalFees.find(cur);
         if (exchangePublic.isWithdrawalFeesSourceReliable() || withdrawalFeeIt != withdrawalFees.end()) {
           ASSERT_NE(withdrawalFeeIt, withdrawalFees.end());
           EXPECT_GE(withdrawalFeeIt->second, MonetaryAmount(0, withdrawalFeeIt->second.currencyCode()));
           break;
         } else {
-          log::warn("{} withdrawal fee is not known (unreliable source), trying another one", cur.str());
+          log::warn("{} withdrawal fee is not known (unreliable source), trying another one", cur);
         }
       }
     }
@@ -155,7 +155,7 @@ class TestAPI {
 
         for (const CurrencyExchange &curExchange : sample) {
           CurrencyCode cur(curExchange.standardCode());
-          log::info("Choosing {} as random currency code for Deposit wallet test", cur.str());
+          log::info("Choosing {} as random currency code for Deposit wallet test", cur);
           try {
             Wallet w = exchangePrivatePtr.get()->queryDepositWallet(cur);
             EXPECT_FALSE(w.address().empty());
@@ -164,7 +164,7 @@ class TestAPI {
             if (exchangePrivatePtr.get()->canGenerateDepositAddress()) {
               throw;
             } else {
-              log::info("Wallet for {} is not generated, taking next one", cur.str());
+              log::info("Wallet for {} is not generated, taking next one", cur);
             }
           }
         }

--- a/src/api/interface/src/exchange.cpp
+++ b/src/api/interface/src/exchange.cpp
@@ -21,7 +21,7 @@ bool Exchange::canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlat
   }
   auto lb = currencyExchangeSet.find(currencyCode);
   if (lb == currencyExchangeSet.end()) {
-    log::trace("{} cannot be withdrawed from {}", currencyCode.str(), name());
+    log::trace("{} cannot be withdrawed from {}", currencyCode, name());
     return false;
   }
   return lb->canWithdraw();
@@ -30,7 +30,7 @@ bool Exchange::canWithdraw(CurrencyCode currencyCode, const CurrencyExchangeFlat
 bool Exchange::canDeposit(CurrencyCode currencyCode, const CurrencyExchangeFlatSet &currencyExchangeSet) const {
   auto lb = currencyExchangeSet.find(currencyCode);
   if (lb == currencyExchangeSet.end()) {
-    log::trace("{} cannot be deposited on {}", currencyCode.str(), name());
+    log::trace("{} cannot be deposited on {}", currencyCode, name());
     return false;
   }
   return lb->canDeposit();

--- a/src/engine/src/balanceperexchangeportfolio.cpp
+++ b/src/engine/src/balanceperexchangeportfolio.cpp
@@ -27,7 +27,8 @@ void BalancePerExchangePortfolio::printTable(std::ostream &os, bool wide) const 
     total.sortByDecreasingEquivalentAmount();
 
     string balanceEqCur("Total ");
-    balanceEqCur.append(balanceCurrencyCode.str()).append(" eq");
+    balanceCurrencyCode.appendStr(balanceEqCur);
+    balanceEqCur.append(" eq");
     header.emplace_back(std::move(balanceEqCur));
   }
 

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -167,7 +167,7 @@ BalancePerExchange Coincenter::getBalance(std::span<const ExchangeName> privateE
                                           CurrencyCode equiCurrency) {
   std::optional<CurrencyCode> optEquiCur = _coincenterInfo.fiatCurrencyIfStableCoin(equiCurrency);
   if (optEquiCur) {
-    log::warn("Consider {} instead of stable coin {} as equivalent currency", optEquiCur->str(), equiCurrency.str());
+    log::warn("Consider {} instead of stable coin {} as equivalent currency", *optEquiCur, equiCurrency);
     equiCurrency = *optEquiCur;
   }
 

--- a/src/engine/src/queryresultprinter.cpp
+++ b/src/engine/src/queryresultprinter.cpp
@@ -33,10 +33,10 @@ void QueryResultPrinter::printMarkets(CurrencyCode cur1, CurrencyCode cur2,
   switch (_apiOutputType) {
     case ApiOutputType::kFormattedTable: {
       string marketsCol("Markets with ");
-      marketsCol.append(cur1.str());
+      cur1.appendStr(marketsCol);
       if (!cur2.isNeutral()) {
         marketsCol.push_back('-');
-        marketsCol.append(cur2.str());
+        cur2.appendStr(marketsCol);
       }
       SimpleTable t("Exchange", std::move(marketsCol));
       for (const auto &[e, markets] : marketsPerExchange) {
@@ -587,12 +587,12 @@ void QueryResultPrinter::printLastTrades(Market m, int nbLastTrades,
   switch (_apiOutputType) {
     case ApiOutputType::kFormattedTable: {
       for (const auto &[exchangePtr, lastTrades] : lastTradesPerExchange) {
-        string buyTitle(m.baseStr());
+        string buyTitle = m.base().str();
+        string sellTitle = buyTitle;
         buyTitle.append(" buys");
-        string sellTitle(m.baseStr());
         sellTitle.append(" sells");
         string priceTitle("Price in ");
-        priceTitle.append(m.quoteStr());
+        m.quote().appendStr(priceTitle);
 
         string title(exchangePtr->name());
         title.append(" trades - UTC");

--- a/src/engine/src/stringoptionparser.cpp
+++ b/src/engine/src/stringoptionparser.cpp
@@ -5,6 +5,7 @@
 #include "cct_cctype.hpp"
 #include "cct_const.hpp"
 #include "cct_invalid_argument_exception.hpp"
+#include "toupperlower.hpp"
 
 namespace cct {
 namespace {
@@ -76,7 +77,6 @@ auto GetNextPercentageAmount(std::string_view opt, std::string_view sepWithPerce
   }
   return std::make_pair(std::move(startAmount), isPercentage);
 }
-
 }  // namespace
 
 ExchangeNames StringOptionParser::getExchanges() const { return GetExchanges(_opt); }
@@ -131,11 +131,11 @@ StringOptionParser::CurrenciesPrivateExchanges StringOptionParser::getCurrencies
     std::string_view token1 = GetNextStr(_opt, ',', pos);
     if (!IsExchangeName(token1)) {
       startExchangesPos = pos;
-      fromTradeCurrency = token1;
+      fromTradeCurrency = CurrencyCode(token1);
       std::string_view token2 = GetNextStr(_opt, ',', pos);
       if (!IsExchangeName(token2)) {
         startExchangesPos = pos;
-        toTradeCurrency = token2;
+        toTradeCurrency = CurrencyCode(token2);
       }
     }
   } else {

--- a/src/engine/test/stringoptionparser_test.cpp
+++ b/src/engine/test/stringoptionparser_test.cpp
@@ -31,6 +31,8 @@ TEST(StringOptionParserTest, GetCurrencyPrivateExchanges) {
           .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
       std::make_pair(CurrencyCode("KRW"), ExchangeNames({ExchangeName("bithumb"), ExchangeName("binance", "user1")})));
 
+  EXPECT_THROW(StringOptionParser("toolongcurrency,Bithumb,binance_user1").getCurrencyPrivateExchanges(optionalCur),
+               invalid_argument);
   EXPECT_THROW(StringOptionParser("binance_user1,bithumb")
                    .getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kMandatory),
                invalid_argument);
@@ -42,6 +44,8 @@ TEST(StringOptionParserTest, GetMarketExchanges) {
   EXPECT_EQ(StringOptionParser("dash-krw,bithumb,upbit").getMarketExchanges(),
             StringOptionParser::MarketExchanges(Market("DASH", "KRW"),
                                                 ExchangeNames({ExchangeName("bithumb"), ExchangeName("upbit")})));
+
+  EXPECT_THROW(StringOptionParser("dash-toolongcurrency,bithumb,upbit").getMarketExchanges(), invalid_argument);
 }
 
 TEST(StringOptionParserTest, GetMonetaryAmountPrivateExchanges) {

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <algorithm>
-#include <array>
+#include <spdlog/fmt/bundled/format.h>
+
 #include <compare>
 #include <cstdint>
 #include <ostream>
@@ -9,79 +9,267 @@
 #include <type_traits>
 
 #include "cct_hash.hpp"
-#include "cct_log.hpp"
-#include "toupperlower.hpp"
+#include "cct_invalid_argument_exception.hpp"
 
 namespace cct {
 
+struct CurrencyCodeConstants {
+  static constexpr int kMaxLen = 10;
+
+  static constexpr uint64_t kNbBitsChar = 6;
+  static constexpr uint64_t kNbBitsNbDecimals = 4;
+
+  static constexpr uint64_t kNbDecimals4Mask = (1ULL << kNbBitsNbDecimals) - 1ULL;
+
+  static constexpr uint64_t kFirstCharMask = ~((1ULL << (kNbBitsNbDecimals + (kMaxLen - 1) * kNbBitsChar)) - 1ULL);
+
+  static constexpr uint64_t kBeforeLastCharMask = kFirstCharMask >> (kNbBitsChar * (kMaxLen - 2));
+
+  static constexpr int64_t kMaxNbDecimalsLongCurrencyCode = 15;  // 2^4 - 1
+
+  static constexpr char kFirstAuthorizedLetter = 33;  // '!'
+  static constexpr char kLastAuthorizedLetter = 95;   // '_'
+};
+
+class CurrencyCodeIterator {
+ public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = char;
+  using pointer = const char *;
+  using reference = const char &;
+
+  constexpr auto operator<=>(const CurrencyCodeIterator &) const noexcept = default;
+  bool operator==(const CurrencyCodeIterator &) const noexcept = default;
+
+  CurrencyCodeIterator &operator++() noexcept {  // Prefix increment
+    ++_pos;
+    return *this;
+  }
+
+  CurrencyCodeIterator &operator--() noexcept {  // Prefix decrement
+    --_pos;
+    return *this;
+  }
+
+  CurrencyCodeIterator operator++(int) noexcept {  // Postfix increment
+    CurrencyCodeIterator oldSelf = *this;
+    ++*this;
+    return oldSelf;
+  }
+
+  CurrencyCodeIterator operator--(int) noexcept {  // Postfix decrement
+    CurrencyCodeIterator oldSelf = *this;
+    --*this;
+    return oldSelf;
+  }
+
+  char operator*() const noexcept {
+    return static_cast<char>((_data >> (CurrencyCodeConstants::kNbBitsNbDecimals +
+                                        CurrencyCodeConstants::kNbBitsChar *
+                                            (CurrencyCodeConstants::kMaxLen - static_cast<int>(_pos) - 1))) &
+                             ((1ULL << CurrencyCodeConstants::kNbBitsChar) - 1ULL)) +
+           CurrencyCodeConstants::kFirstAuthorizedLetter - 1;
+  }
+
+ private:
+  friend class CurrencyCode;
+
+  // Default constructor needed for an iterator in C++20
+  CurrencyCodeIterator() noexcept : _data(0), _pos(0) {}
+
+  explicit CurrencyCodeIterator(uint64_t data, uint64_t pos = 0) : _data(data), _pos(pos) {}
+
+  uint64_t _data;
+  uint64_t _pos;
+};
+
 /// Lightweight object representing a currency code with its acronym. Can be used as a key.
-/// Can be used to represent a fiat currency or a coin (for the latter, acronym is expected to be 7 chars long maximum)
+/// Can be used to represent a fiat currency or a coin (for the latter, acronym is expected to be 10 chars long maximum)
 class CurrencyCode {
  public:
-  static constexpr int kAcronymMaxLen = 7;
+  using iterator = CurrencyCodeIterator;
+  using const_iterator = CurrencyCodeIterator;
 
-  using AcronymType = std::array<char, kAcronymMaxLen>;  // warning: not null terminated
+  static constexpr auto kMaxLen = CurrencyCodeConstants::kMaxLen;
 
   /// Constructs a neutral currency code.
-  constexpr CurrencyCode() noexcept : _data() {}
+  constexpr CurrencyCode() noexcept : _data(0) {}
 
-  /// Constructs a currency code from a static char array.
-  /// Note: spaces are not skipped. If any, there will be captured as part of the code, which is probably unexpected.
-  template <unsigned N, std::enable_if_t<N <= kAcronymMaxLen + 1, bool> = true>
-  constexpr CurrencyCode(const char (&acronym)[N]) noexcept {
-    set(acronym);
-  }
+  /// Constructs a currency code from a char array.
+  template <unsigned N, std::enable_if_t<N <= kMaxLen + 1, bool> = true>
+  constexpr CurrencyCode(const char (&acronym)[N]) : _data(ComputeData(acronym)) {}
 
   /// Constructs a currency code from given string.
-  /// Note: spaces are not skipped. If any, there will be captured as part of the code, which is probably unexpected.
+  /// If number of chars in 'acronym' is higher than 'kMaxLen', exception will be raised.
+  /// Note: spaces are not skipped. If any, they will be captured as part of the code, which is probably unexpected.
   constexpr CurrencyCode(std::string_view acronym) {
-    if (_data.size() < acronym.size()) {
-      if (!std::is_constant_evaluated()) {
-        log::debug("Acronym {} is too long, truncating to {} chars", acronym, kAcronymMaxLen);
-      }
-      acronym.remove_suffix(acronym.size() - _data.size());
+    if (acronym.length() > kMaxLen) {
+      throw invalid_argument("Acronym is too long to fit in a CurrencyCode");
     }
-    set(acronym);
+    _data = ComputeData(acronym);
   }
 
-  constexpr uint64_t size() const { return std::ranges::find(_data, '\0') - _data.begin(); }
+  CurrencyCodeIterator begin() const { return CurrencyCodeIterator(_data); }
+  CurrencyCodeIterator end() const { return CurrencyCodeIterator(_data, size()); }
 
-  /// Get a string view of this CurrencyCode, trimmed.
-  constexpr std::string_view str() const { return std::string_view(_data.begin(), std::ranges::find(_data, '\0')); }
+  constexpr uint64_t size() const {
+    uint64_t s = 0;
+    while (static_cast<int>(s) < kMaxLen &&
+           (_data & (CurrencyCodeConstants::kFirstCharMask >> (CurrencyCodeConstants::kNbBitsChar * s)))) {
+      ++s;
+    }
+    return s;
+  }
+
+  constexpr uint64_t length() const { return size(); }
+
+  /// Get a string of this CurrencyCode, trimmed.
+  string str() const {
+    string s;
+    appendStr(s);
+    return s;
+  }
+
+  /// Append currency string reprensentation to given string.
+  void appendStr(string &s) const {
+    for (uint32_t charPos = 0; charPos < kMaxLen; ++charPos) {
+      char c = (*this)[charPos];
+      if (c == CurrencyCodeConstants::kFirstAuthorizedLetter - 1) {
+        break;
+      }
+      s.push_back(c);
+    }
+  }
 
   /// Returns a 64 bits code
-  constexpr uint64_t code() const noexcept {
-    uint64_t ret = _data[6];
-    ret |= static_cast<uint64_t>(_data[5]) << 8;
-    ret |= static_cast<uint64_t>(_data[4]) << 16;
-    ret |= static_cast<uint64_t>(_data[3]) << 24;
-    ret |= static_cast<uint64_t>(_data[2]) << 32;
-    ret |= static_cast<uint64_t>(_data[1]) << 40;
-    ret |= static_cast<uint64_t>(_data[0]) << 48;
-    return ret;
-  }
+  constexpr uint64_t code() const noexcept { return _data; }
 
-  constexpr bool isNeutral() const noexcept { return _data.front() == '\0'; }
+  constexpr bool isNeutral() const noexcept { return !(_data & CurrencyCodeConstants::kFirstCharMask); }
+
+  constexpr char operator[](uint32_t pos) const {
+    return static_cast<char>((_data >> (CurrencyCodeConstants::kNbBitsNbDecimals +
+                                        CurrencyCodeConstants::kNbBitsChar * (kMaxLen - static_cast<int>(pos) - 1))) &
+                             ((1ULL << CurrencyCodeConstants::kNbBitsChar) - 1ULL)) +
+           CurrencyCodeConstants::kFirstAuthorizedLetter - 1;
+  }
 
   constexpr auto operator<=>(const CurrencyCode &) const = default;
 
   constexpr bool operator==(const CurrencyCode &) const = default;
 
-  friend std::ostream &operator<<(std::ostream &os, const CurrencyCode &c) {
-    os << c.str();
+  friend std::ostream &operator<<(std::ostream &os, const CurrencyCode &cur) {
+    for (uint32_t charPos = 0; charPos < kMaxLen; ++charPos) {
+      char c = cur[charPos];
+      if (c == CurrencyCodeConstants::kFirstAuthorizedLetter - 1) {
+        break;
+      }
+      os << c;
+    }
     return os;
   }
 
  private:
-  AcronymType _data;
+  friend class MonetaryAmount;
 
-  constexpr inline void set(std::string_view acronym) {
-    // Fill extra chars to 0 is important as we always read them for code generation
-    std::fill(std::transform(acronym.begin(), acronym.end(), _data.begin(), toupper), _data.end(), '\0');
+  // bitmap with 10 words of 6 bits (from ascii [33, 95]) + 4 extra bits that will be used by
+  // MonetaryAmount to hold number of decimals (max 15)
+  uint64_t _data;
+
+  explicit constexpr CurrencyCode(uint64_t data) : _data(data) {}
+
+  constexpr bool isLongCurrencyCode() const { return _data & CurrencyCodeConstants::kBeforeLastCharMask; }
+
+  constexpr void setNbDecimals(int8_t nbDecimals) {
+    if (isLongCurrencyCode()) {
+      if (!std::is_constant_evaluated() && nbDecimals > CurrencyCodeConstants::kMaxNbDecimalsLongCurrencyCode) {
+        throw invalid_argument("Too many decimals for long currency code");
+      }
+      // For currency codes whose length is > 8, only 15 digits are supported
+      _data = static_cast<uint64_t>(nbDecimals) + (_data & (~CurrencyCodeConstants::kNbDecimals4Mask));
+    } else {
+      // max 64 decimals for currency codes whose length is maximum 8 (most cases)
+      _data =
+          (static_cast<uint64_t>(nbDecimals) << CurrencyCodeConstants::kNbBitsNbDecimals) +
+          (_data & ~((1ULL << (CurrencyCodeConstants::kNbBitsChar + CurrencyCodeConstants::kNbBitsNbDecimals)) - 1ULL));
+    }
+  }
+
+  constexpr int8_t nbDecimals() const {
+    if (isLongCurrencyCode()) {
+      // For currency codes whose length is > 8, only 15 digits are supported
+      return static_cast<int8_t>(_data & CurrencyCodeConstants::kNbDecimals4Mask);
+    }
+    // max 64 decimals for currency codes whose length is maximum 8 (most cases)
+    return static_cast<int8_t>((_data >> CurrencyCodeConstants::kNbBitsNbDecimals) &
+                               ((1ULL << CurrencyCodeConstants::kNbBitsChar) - 1ULL));
+  }
+
+  constexpr CurrencyCode toNeutral() const {
+    // keep number of decimals
+    return CurrencyCode(
+        _data &
+        (isLongCurrencyCode()
+             ? CurrencyCodeConstants::kNbDecimals4Mask
+             : (1ULL << (CurrencyCodeConstants::kNbBitsChar + CurrencyCodeConstants::kNbBitsNbDecimals)) - 1ULL));
+  }
+
+  constexpr CurrencyCode withNoDecimalsPart() const {
+    // Keep currency, not decimals
+    return CurrencyCode(
+        _data &
+        ~(isLongCurrencyCode()
+              ? CurrencyCodeConstants::kNbDecimals4Mask
+              : (1ULL << (CurrencyCodeConstants::kNbBitsChar + CurrencyCodeConstants::kNbBitsNbDecimals)) - 1ULL));
+  }
+
+  static constexpr uint64_t ComputeData(std::string_view acronym) {
+    uint64_t ret = 0;
+    int charPos = 0;
+    for (char c : acronym) {
+      if (c >= 'a') {
+        if (c > 'z') {
+          throw invalid_argument("Unexpected char in acronym");
+        }
+        c -= 'a' - 'A';
+      }
+      if (c < CurrencyCodeConstants::kFirstAuthorizedLetter || c > CurrencyCodeConstants::kLastAuthorizedLetter) {
+        throw invalid_argument("Unexpected char in acronym");
+      }
+
+      ret |= static_cast<uint64_t>(c - CurrencyCodeConstants::kFirstAuthorizedLetter + 1)
+             << (CurrencyCodeConstants::kNbBitsNbDecimals +
+                 CurrencyCodeConstants::kNbBitsChar * static_cast<uint64_t>(kMaxLen - charPos - 1));
+
+      ++charPos;
+    }
+    return ret;
   }
 };
 
 }  // namespace cct
+
+template <>
+struct fmt::formatter<cct::CurrencyCode> {
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
+    auto it = ctx.begin(), end = ctx.end();
+    if (it != end && *it != '}') {
+      throw format_error("invalid format");
+    }
+    return it;
+  }
+
+  // Formats the point p using the parsed format specification (presentation)
+  // stored in this formatter.
+  template <typename FormatContext>
+  auto format(const cct::CurrencyCode &cur, FormatContext &ctx) const -> decltype(ctx.out()) {
+    // ctx.out() is an output iterator to write to.
+    for (char c : cur) {
+      *ctx.out() = c;
+      ++ctx.out();
+    }
+    return ctx.out();
+  }
+};
 
 // Specialize std::hash<CurrencyCode> for easy usage of CurrencyCode as unordered_map key
 namespace std {

--- a/src/objects/include/currencyexchange.hpp
+++ b/src/objects/include/currencyexchange.hpp
@@ -34,9 +34,9 @@ class CurrencyExchange {
   CurrencyExchange(CurrencyCode standardCode, CurrencyCode exchangeCode, CurrencyCode altCode, Deposit deposit,
                    Withdraw withdraw, Type type);
 
-  std::string_view standardStr() const { return _standardCode.str(); }
-  std::string_view exchangeStr() const { return _exchangeCode.str(); }
-  std::string_view altStr() const { return _altCode.str(); }
+  string standardStr() const { return _standardCode.str(); }
+  string exchangeStr() const { return _exchangeCode.str(); }
+  string altStr() const { return _altCode.str(); }
 
   string str() const;
 

--- a/src/objects/include/currencyexchangeflatset.hpp
+++ b/src/objects/include/currencyexchangeflatset.hpp
@@ -63,7 +63,7 @@ class CurrencyExchangeFlatSet {
     const_iterator it = find(standardCode);
     if (it == _set.end()) {
       string ex("Unknown ");
-      ex.append(standardCode.str());
+      standardCode.appendStr(ex);
       throw exception(std::move(ex));
     }
     return *it;

--- a/src/objects/include/market.hpp
+++ b/src/objects/include/market.hpp
@@ -33,24 +33,14 @@ class Market {
   Market reverse() const { return Market(_assets[1], _assets[0]); }
 
   /// Get the base CurrencyCode of this Market.
-  /// Beware: do not use this method to get a string view of the Currency, prefer 'baseStr' instead as it returns a
-  /// CurrencyCode by copy.
   CurrencyCode base() const { return _assets[0]; }
 
   /// Get the quote CurrencyCode of this Market.
-  /// Beware: do not use this method to get a string view of the Currency, prefer 'quoteStr' instead as it returns a
-  /// CurrencyCode by copy.
   CurrencyCode quote() const { return _assets[1]; }
 
   /// Given 'c' a currency traded in this Market, return the other currency it is paired with.
   /// If 'c' is not traded by this market, return the second currency.
   CurrencyCode opposite(CurrencyCode c) const { return _assets[1] == c ? _assets[0] : _assets[1]; }
-
-  /// Returns a string_view on the base currency of this market.
-  std::string_view baseStr() const { return _assets[0].str(); }
-
-  /// Returns a string_view on the quote currency of this market.
-  std::string_view quoteStr() const { return _assets[1].str(); }
 
   bool canTrade(MonetaryAmount a) const { return canTrade(a.currencyCode()); }
   bool canTrade(CurrencyCode c) const { return base() == c || quote() == c; }

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -15,13 +15,21 @@
 
 namespace cct {
 
-/// Represents a fixed-precision decimal amount with a currency (fiat or coin).
-///
-/// This object aims to provide high performance operations as well as predictive and precise basic arithmetic (as
-/// opposed to double).
-/// In addition, it is light (only 16 bytes) and can be passed by copy instead of reference.
+/// Represents a fixed-precision decimal amount with a CurrencyCode (fiat or coin).
+/// It is designed to be
+///  - fast
+///  - small (16 bytes only). Thus can be passed by copy instead of reference
+///  - precise (amount is stored in a int64_t)
+///  - optimized, predictive and exact for additions and subtractions (if no overflow during the operation)
 ///
 /// It is easy and straightforward to use with string_view constructor and partial constexpr support.
+///
+/// A MonetaryAmount is only 16 bytes:
+/// - One integral amount stored on 64 bits
+/// - A CurrencyCode holding up to 10 chars + the number of decimals
+///
+/// It can support up to 17 decimals for currency codes whose length is less than 9,
+/// and up to 15 decimals for currencies whose length is 9 or 10.
 ///
 /// Examples: $50, -2.045 BTC.
 /// The integral value stored in the MonetaryAmount is multiplied by 10^'_nbDecimals'
@@ -29,19 +37,18 @@ namespace cct {
 class MonetaryAmount {
  public:
   using AmountType = int64_t;
-  enum class RoundType { kDown, kUp, kNearest };
+
+  enum class RoundType : int8_t { kDown, kUp, kNearest };
 
   /// Constructs a MonetaryAmount with a value of 0 of neutral currency.
-  constexpr MonetaryAmount() noexcept : _amount(0), _nbDecimals(0) {}
+  constexpr MonetaryAmount() noexcept : _amount(0) {}
 
   /// Constructs a MonetaryAmount representing the integer 'amount' with a neutral currency
-  constexpr explicit MonetaryAmount(std::integral auto amount) noexcept : _amount(amount), _nbDecimals(0) {
-    sanitizeIntegralPart();
-  }
+  constexpr explicit MonetaryAmount(std::integral auto amount) noexcept : _amount(amount) { sanitizeIntegralPart(); }
 
   /// Constructs a MonetaryAmount representing the integer 'amount' with a currency
   constexpr explicit MonetaryAmount(std::integral auto amount, CurrencyCode currencyCode) noexcept
-      : _amount(amount), _nbDecimals(0), _currencyCode(currencyCode) {
+      : _amount(amount), _curWithDecimals(currencyCode) {
     sanitizeIntegralPart();
   }
 
@@ -55,17 +62,25 @@ class MonetaryAmount {
   /// Constructs a new MonetaryAmount from an integral representation which is already multiplied by given
   /// number of decimals
   constexpr MonetaryAmount(AmountType amount, CurrencyCode currencyCode, int8_t nbDecimals) noexcept
-      : _amount(amount), _nbDecimals(nbDecimals), _currencyCode(currencyCode) {
-    sanitizeDecimals();
+      : _amount(amount), _curWithDecimals(currencyCode) {
+    sanitizeDecimals(nbDecimals, maxNbDecimals());
     sanitizeIntegralPart();
   }
 
   /// Constructs a new MonetaryAmount from a string, containing an optional CurrencyCode.
-  /// If it's not present, assume default CurrencyCode.
-  /// If given string is empty, it is equivalent to a default constructor.
+  /// - If a currency is not present, assume default CurrencyCode
+  /// - If the currency is too long to fit in a CurrencyCode, exception will be raised
+  /// - If given string is empty, it is equivalent to a default constructor
+  ///
+  /// A space can be present or not between the amount and the currency code.
+  /// Beware however that if there is no space and the currency starts with a digit, parsing will consider
+  /// the digit as part of the amount, which results in a wrong MonetaryAmount. Use a space to avoid
+  /// ambiguity in this case.
   /// Examples: "10.5EUR" -> 10.5 units of currency EUR
   ///           "45 KRW" -> 45 units of currency KRW
   ///           "-345.8909" -> -345.8909 units of no currency
+  ///           "36.61INCH" -> 36.63 units of currency INCH
+  ///           "36.6 1INCH" -> 36.6 units of currency 1INCH
   explicit MonetaryAmount(std::string_view amountCurrencyStr);
 
   /// Constructs a new MonetaryAmount from a string representing the amount only and a currency code.
@@ -75,7 +90,9 @@ class MonetaryAmount {
   /// Constructs a new MonetaryAmount from another MonetaryAmount and a new CurrencyCode.
   /// Use this constructor to change currency of an existing MonetaryAmount.
   constexpr MonetaryAmount(MonetaryAmount o, CurrencyCode newCurrencyCode)
-      : _amount(o._amount), _nbDecimals(o._nbDecimals), _currencyCode(newCurrencyCode) {}
+      : _amount(o._amount), _curWithDecimals(newCurrencyCode) {
+    setNbDecimals(o.nbDecimals());
+  }
 
   /// Get an integral representation of this MonetaryAmount multiplied by given number of decimals.
   /// If an overflow would occur for the resulting amount, return std::nullopt
@@ -83,24 +100,40 @@ class MonetaryAmount {
   std::optional<AmountType> amount(int8_t nbDecimals) const;
 
   /// Get the integer part of the amount of this MonetaryAmount.
-  constexpr AmountType integerPart() const { return _amount / ipow(10, _nbDecimals); }
+  constexpr AmountType integerPart() const { return _amount / ipow(10, static_cast<uint8_t>(nbDecimals())); }
 
   /// Get the decimal part of the amount of this MonetaryAmount.
   /// Warning: starting zeros will not be part of the returned value. Use nbDecimals to retrieve the number of decimals
   /// of this MonetaryAmount.
   /// Example: "45.046" decimalPart() = 46
-  constexpr AmountType decimalPart() const { return _amount - integerPart() * ipow(10, _nbDecimals); }
+  constexpr AmountType decimalPart() const {
+    return _amount - integerPart() * ipow(10, static_cast<uint8_t>(nbDecimals()));
+  }
 
   /// Get the amount of this MonetaryAmount in double format.
-  constexpr double toDouble() const { return static_cast<double>(_amount) / ipow(10, _nbDecimals); }
+  constexpr double toDouble() const {
+    return static_cast<double>(_amount) / ipow(10, static_cast<uint8_t>(nbDecimals()));
+  }
 
-  constexpr CurrencyCode currencyCode() const { return _currencyCode; }
+  constexpr CurrencyCode currencyCode() const {
+    // We do not want to expose private nb decimals bits to outside world
+    return _curWithDecimals.withNoDecimalsPart();
+  }
 
-  constexpr int8_t nbDecimals() const { return _nbDecimals; }
+  constexpr int8_t nbDecimals() const { return _curWithDecimals.nbDecimals(); }
+
+  constexpr int8_t maxNbDecimals() const {
+    return _curWithDecimals.isLongCurrencyCode()
+               ? CurrencyCodeConstants::kMaxNbDecimalsLongCurrencyCode
+               : std::numeric_limits<AmountType>::digits10 - 1;  // -1 as minimal nb digits of integral part
+  }
 
   /// Returns the maximum number of decimals that this amount could hold, given its integral part.
-  constexpr int8_t maxNbDecimals() const {
-    return _nbDecimals + static_cast<int8_t>(std::numeric_limits<AmountType>::digits10 - ndigits(_amount));
+  /// Examples:
+  ///  0.00426622338114037 EUR -> 17
+  ///  45.546675 EUR           -> 16
+  constexpr int8_t currentMaxNbDecimals() const {
+    return static_cast<int8_t>(maxNbDecimals() - ndigits(integerPart()) + 1);
   }
 
   /// Converts current amount at given price.
@@ -132,10 +165,10 @@ class MonetaryAmount {
   constexpr bool isStrictlyNegative() const noexcept { return _amount < 0; }
 
   constexpr MonetaryAmount abs() const noexcept {
-    return MonetaryAmount(_amount < 0 ? -_amount : _amount, _currencyCode, _nbDecimals);
+    return MonetaryAmount(true, _amount < 0 ? -_amount : _amount, _curWithDecimals);
   }
 
-  constexpr MonetaryAmount operator-() const noexcept { return MonetaryAmount(-_amount, _currencyCode, _nbDecimals); }
+  constexpr MonetaryAmount operator-() const noexcept { return MonetaryAmount(true, -_amount, _curWithDecimals); }
 
   MonetaryAmount operator+(MonetaryAmount o) const;
 
@@ -182,19 +215,22 @@ class MonetaryAmount {
     return *this;
   }
 
-  constexpr MonetaryAmount toNeutral() const noexcept { return MonetaryAmount(_amount, _nbDecimals); }
+  constexpr MonetaryAmount toNeutral() const noexcept {
+    return MonetaryAmount(true, _amount, _curWithDecimals.toNeutral());
+  }
 
   constexpr bool isDefault() const noexcept { return _amount == 0 && hasNeutralCurrency(); }
 
-  constexpr bool hasNeutralCurrency() const noexcept { return _currencyCode.isNeutral(); }
+  constexpr bool hasNeutralCurrency() const noexcept { return _curWithDecimals.isNeutral(); }
 
-  constexpr bool isAmountInteger() const noexcept { return _nbDecimals == 0; }
+  constexpr bool isAmountInteger() const noexcept { return nbDecimals() == 0; }
 
-  /// Truncate the MonetaryAmount such that it will contain at most maxNbDecimals
-  constexpr void truncate(int8_t maxNbDecimals) noexcept { sanitizeDecimals(maxNbDecimals); }
+  /// Truncate the MonetaryAmount such that it will contain at most maxNbDecimals.
+  /// Does nothing if maxNbDecimals is larger than current number of decimals
+  constexpr void truncate(int8_t maxNbDecimals) noexcept { sanitizeDecimals(nbDecimals(), maxNbDecimals); }
 
-  /// Get a std::string_view on the currency of this amount
-  constexpr std::string_view currencyStr() const { return _currencyCode.str(); }
+  /// Get a string on the currency of this amount
+  string currencyStr() const { return _curWithDecimals.str(); }
 
   /// Get a string representation of the amount hold by this MonetaryAmount (without currency).
   string amountStr() const;
@@ -208,49 +244,48 @@ class MonetaryAmount {
 
   static constexpr AmountType kMaxAmountFullNDigits = ipow(10, std::numeric_limits<AmountType>::digits10);
 
-  /// Private constructor used only to transform one MonetaryAmount in neutral currency
-  constexpr MonetaryAmount(AmountType amount, int8_t nbDecimals) noexcept : _amount(amount), _nbDecimals(nbDecimals) {}
+  /// Private constructor to set fields directly without checks.
+  /// We add a dummy bool parameter to differentiate it from the public constructor
+  constexpr MonetaryAmount(bool, AmountType amount, CurrencyCode curWithDecimals) noexcept
+      : _amount(amount), _curWithDecimals(curWithDecimals) {}
 
-  constexpr void simplifyDecimals() noexcept {
+  constexpr void sanitizeDecimals(int8_t nowNbDecimals, int8_t maxNbDecimals) noexcept {
+    const int8_t nbDecimalsToTruncate = nowNbDecimals - maxNbDecimals;
+    if (nbDecimalsToTruncate > 0) {
+      _amount /= ipow(10, static_cast<uint8_t>(nbDecimalsToTruncate));
+      nowNbDecimals -= nbDecimalsToTruncate;
+    }
+    simplifyDecimals(nowNbDecimals);
+  }
+
+  constexpr void simplifyDecimals(int8_t nbDecs) noexcept {
     if (_amount == 0) {
-      _nbDecimals = 0;
+      nbDecs = 0;
     } else {
-      for (; _nbDecimals > 0 && _amount % 10 == 0; --_nbDecimals) {
+      for (; nbDecs > 0 && _amount % 10 == 0; --nbDecs) {
         _amount /= 10;
       }
     }
-  }
-
-  constexpr void sanitizeDecimals(int8_t maxNbDecimals = std::numeric_limits<AmountType>::digits10 - 1) noexcept {
-    const int8_t nbDecimalsToTruncate = _nbDecimals - maxNbDecimals;
-    if (nbDecimalsToTruncate > 0) {
-      _amount /= ipow(10, static_cast<uint8_t>(nbDecimalsToTruncate));
-      _nbDecimals -= nbDecimalsToTruncate;
-    }
-    simplifyDecimals();
+    setNbDecimals(nbDecs);
   }
 
   constexpr void sanitizeIntegralPart() {
     if (_amount >= kMaxAmountFullNDigits) {
       if (!std::is_constant_evaluated()) {
-        log::debug("Truncating last digit of integral part which is too big");
+        log::warn("Truncating last digit of integral part {} which is too big", _amount);
       }
       _amount /= 10;
     }
   }
 
-  constexpr bool isSane() const noexcept {
-    return _nbDecimals < std::numeric_limits<AmountType>::digits10 &&
-           ndigits(_amount) <= std::numeric_limits<AmountType>::digits10;
-  }
+  constexpr inline void setNbDecimals(int8_t nbDecs) { _curWithDecimals.setNbDecimals(nbDecs); }
 
   AmountType _amount;
-  int8_t _nbDecimals;
-  CurrencyCode _currencyCode;
+  CurrencyCode _curWithDecimals;
 };
 
 static_assert(sizeof(MonetaryAmount) <= 16, "MonetaryAmount size should stay small");
-static_assert(std::is_trivially_copyable_v<MonetaryAmount>, "MonetaryAmount should be fast to copy");
+static_assert(std::is_trivially_copyable_v<MonetaryAmount>, "MonetaryAmount should be trivially copyable");
 
 inline MonetaryAmount operator*(MonetaryAmount::AmountType mult, MonetaryAmount rhs) { return rhs * mult; }
 

--- a/src/objects/src/currencyexchange.cpp
+++ b/src/objects/src/currencyexchange.cpp
@@ -30,13 +30,13 @@ string CurrencyExchange::str() const {
   if (_exchangeCode != _standardCode || _altCode != _standardCode) {
     ret.push_back('(');
     if (_exchangeCode != _standardCode) {
-      ret.append(_exchangeCode.str());
+      _exchangeCode.appendStr(ret);
     }
     if (_altCode != _standardCode) {
       if (_exchangeCode != _standardCode) {
         ret.push_back(',');
       }
-      ret.append(_altCode.str());
+      _altCode.appendStr(ret);
     }
     ret.push_back(')');
   }

--- a/src/objects/src/exchangeinfo.cpp
+++ b/src/objects/src/exchangeinfo.cpp
@@ -15,7 +15,7 @@ string BuildCurrenciesString(std::span<const CurrencyCode> currencies) {
     if (ret.size() > 1) {
       ret.push_back(',');
     }
-    ret.append(c.str());
+    c.appendStr(ret);
   }
   ret.push_back(']');
   return ret;

--- a/src/objects/src/market.cpp
+++ b/src/objects/src/market.cpp
@@ -19,7 +19,7 @@ string Market::assetsPairStr(char sep, bool lowerCase) const {
   if (sep != 0) {
     ret.push_back(sep);
   }
-  ret.append(_assets.back().str());
+  _assets.back().appendStr(ret);
   if (lowerCase) {
     std::ranges::transform(ret, ret.begin(), tolower);
   }

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -20,8 +20,10 @@ MarketOrderBook::MarketOrderBook(Market market, OrderBookLineSpan orderLines, Vo
   _orders.reserve(nbPrices);
   if (_volAndPriNbDecimals == VolAndPriNbDecimals()) {
     for (const OrderBookLine& l : orderLines) {
-      _volAndPriNbDecimals.volNbDecimals = std::min(_volAndPriNbDecimals.volNbDecimals, l._amount.maxNbDecimals());
-      _volAndPriNbDecimals.priNbDecimals = std::min(_volAndPriNbDecimals.priNbDecimals, l._price.maxNbDecimals());
+      _volAndPriNbDecimals.volNbDecimals =
+          std::min(_volAndPriNbDecimals.volNbDecimals, l._amount.currentMaxNbDecimals());
+      _volAndPriNbDecimals.priNbDecimals =
+          std::min(_volAndPriNbDecimals.priNbDecimals, l._price.currentMaxNbDecimals());
     }
   }
   if (nbPrices == 0) {
@@ -568,15 +570,17 @@ std::optional<MonetaryAmount> MarketOrderBook::computeAvgPrice(MonetaryAmount fr
 void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName,
                             std::optional<MonetaryAmount> conversionPriceRate) const {
   string h1("Sellers of ");
-  h1.append(_market.baseStr()).append(" (asks)");
+  string baseStr = _market.base().str();
+  h1.append(baseStr).append(" (asks)");
   string h2(exchangeName);
-  h2.append(" ").append(_market.baseStr()).append(" price in ").append(_market.quoteStr());
+  h2.append(" ").append(baseStr).append(" price in ");
+  _market.quote().appendStr(h2);
   string h3(exchangeName);
   if (conversionPriceRate) {
-    h3.append(" ").append(_market.baseStr()).append(" price in ").append(conversionPriceRate->currencyStr());
+    h3.append(" ").append(baseStr).append(" price in ").append(conversionPriceRate->currencyStr());
   }
   string h4("Buyers of ");
-  h4.append(_market.baseStr()).append(" (bids)");
+  h4.append(baseStr).append(" (bids)");
 
   SimpleTable t;
   if (conversionPriceRate) {

--- a/src/objects/src/wallet.cpp
+++ b/src/objects/src/wallet.cpp
@@ -56,7 +56,7 @@ bool Wallet::ValidateWallet(WalletCheck walletCheck, const ExchangeName &exchang
     }
   }
 
-  log::error("Unknown currency {} for wallet", currency.str());
+  log::error("Unknown currency {} for wallet", currency);
   return false;
 }
 
@@ -94,7 +94,7 @@ Wallet::Wallet(ExchangeName &&exchangeName, CurrencyCode currency, string &&addr
 string Wallet::str() const {
   string ret(_exchangeName.str());
   ret.append(" wallet of ");
-  ret.append(_currency.str());
+  _currency.appendStr(ret);
   ret.append(" [");
   ret.append(address());
   ret.push_back(']');

--- a/src/objects/test/currencycode_test.cpp
+++ b/src/objects/test/currencycode_test.cpp
@@ -11,17 +11,58 @@ TEST(CurrencyCodeTest, Neutral) {
   EXPECT_EQ(0U, neutral.size());
 }
 
-TEST(CurrencyCodeTest, Instantiate) {
-  CurrencyCode eur = "EUR";
-  EXPECT_EQ("EUR", eur.str());
-  EXPECT_EQ(3U, eur.size());
-  EXPECT_EQ("KRW", CurrencyCode(std::string_view("KRW")).str());
+TEST(CurrencyCodeTest, BracketsOperator) {
+  EXPECT_EQ('G', CurrencyCode("gHYs5T")[0]);
+  EXPECT_EQ('H', CurrencyCode("gHYs5T")[1]);
+  EXPECT_EQ('Y', CurrencyCode("gHYs5T")[2]);
+  EXPECT_EQ('S', CurrencyCode("gHYs5T")[3]);
+  EXPECT_EQ('5', CurrencyCode("gHYs5T")[4]);
+  EXPECT_EQ('T', CurrencyCode("gHYs5T")[5]);
+}
+
+TEST(CurrencyCodeTest, String) {
+  EXPECT_EQ("", CurrencyCode("").str());
+  EXPECT_EQ("1", CurrencyCode("1").str());
+  EXPECT_EQ("GT", CurrencyCode("gT").str());
+  EXPECT_EQ("PAR", CurrencyCode("PAR").str());
+  EXPECT_EQ("LOKI", CurrencyCode("Loki").str());
+  EXPECT_EQ("KOREA", CurrencyCode("KorEA").str());
+  EXPECT_EQ("COUCOU", CurrencyCode("coucou").str());
+  EXPECT_EQ("ANTIBES", CurrencyCode("anTibEs").str());
+  EXPECT_EQ("LAVATORY", CurrencyCode("lavatoRY").str());
+  EXPECT_EQ("FIVEPLUS1", CurrencyCode("FivePLus1").str());
+  EXPECT_EQ("MAGIC4LIFE", CurrencyCode("Magic4Life").str());
+}
+
+TEST(CurrencyCodeTest, ExoticString) {
+  EXPECT_EQ("G%&$-0_", CurrencyCode("g%&$-0_").str());
+  EXPECT_EQ("()", CurrencyCode("()").str());
+}
+
+TEST(CurrencyCodeTest, InvalidString) {
+  EXPECT_THROW(CurrencyCode("toolongcurrency"), invalid_argument);
+  EXPECT_THROW(CurrencyCode("invchar~"), invalid_argument);
+}
+
+TEST(CurrencyCodeTest, Size) {
+  EXPECT_EQ(0U, CurrencyCode("").size());
+  EXPECT_EQ(1U, CurrencyCode("1").size());
+  EXPECT_EQ(2U, CurrencyCode("gT").size());
+  EXPECT_EQ(3U, CurrencyCode("PAR").size());
+  EXPECT_EQ(4U, CurrencyCode("Loki").size());
+  EXPECT_EQ(5U, CurrencyCode("KorEA").size());
+  EXPECT_EQ(6U, CurrencyCode("coucou").size());
+  EXPECT_EQ(7U, CurrencyCode("anTibEs").size());
+  EXPECT_EQ(8U, CurrencyCode("lavatoRY").size());
+  EXPECT_EQ(9U, CurrencyCode("FivePLus1").size());
+  EXPECT_EQ(10U, CurrencyCode("Magic4Life").size());
 }
 
 TEST(CurrencyCodeTest, Code) {
   CurrencyCode eur = "EUR";
   CurrencyCode krw = "KRW";
   EXPECT_NE(eur.code(), krw.code());
+  EXPECT_EQ(CurrencyCode("krw").code(), krw.code());
   EXPECT_EQ(eur.code(), CurrencyCode("EUR").code());
 }
 
@@ -60,12 +101,21 @@ TEST(CurrencyCodeTest, UpperConversion) {
   EXPECT_EQ(CurrencyCode("doge"), CurrencyCode("DOGE"));
   EXPECT_EQ(CurrencyCode("BtC"), CurrencyCode("BTC"));
   EXPECT_EQ(CurrencyCode("duRfVgh"), CurrencyCode("dUrfVGH"));
+  EXPECT_EQ(CurrencyCode("etc").str(), "ETC");
 }
 
 TEST(CurrencyCodeTest, Constexpr) {
   static_assert(CurrencyCode("doge") == CurrencyCode("DOGE"));
-  static_assert(CurrencyCode("etc").str() == "ETC");
   static_assert(CurrencyCode("XRP").code() != 0);
+}
+
+TEST(CurrencyCodeTest, Iterator) {
+  EXPECT_NE(CurrencyCode("doge").begin(), CurrencyCode("DOGE").end());
+  string s;
+  for (char c : CurrencyCode("test")) {
+    s.push_back(c);
+  }
+  EXPECT_EQ("TEST", s);
 }
 
 }  // namespace cct


### PR DESCRIPTION
- Increase maximum length of a currency code from 7 to 10
- Throw invalid argument if `MonetaryAmount` is built with a `CurrencyCode` too long, and in CLI as well