### PR TITLE
Activate deep merge for exchange info config from default

### DIFF
--- a/src/objects/src/exchangeinfoparser.cpp
+++ b/src/objects/src/exchangeinfoparser.cpp
@@ -29,7 +29,7 @@ json LoadExchangeConfigData(const LoadConfiguration& loadConfiguration) {
             return jsonData;
           }
         }
-        jsonData.update(exchangeConfigJsonData);
+        jsonData.update(exchangeConfigJsonData, true);
       }
       return jsonData;
     }


### PR DESCRIPTION
Otherwise new keys in top level options will not be recognized.