### PR TITLE
Make output print of tables and json as logger, to be synchronized with console logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,9 @@
 *-ut
 cscope*
 **/*secret.json
-data/secret
 data/cache
+data/log
+data/secret
 data/static/exchangeconfig.json
 data/static/generalconfig.json
 monitoring/data/grafana/*

--- a/src/api/exchanges/test/commonapi_test.hpp
+++ b/src/api/exchanges/test/commonapi_test.hpp
@@ -35,9 +35,7 @@ class TestAPI {
 
   LoadConfiguration loadConfig{kDefaultDataDir, LoadConfiguration::ExchangeConfigFileType::kTest};
   CoincenterInfo coincenterInfo{settings::RunMode::kProd, loadConfig};
-  CoincenterInfo coincenterTestInfo{settings::RunMode::kTest, loadConfig};
   APIKeysProvider apiKeysProvider{coincenterInfo.dataDir(), coincenterInfo.getRunMode()};
-  APIKeysProvider apiTestKeysProvider{coincenterTestInfo.dataDir(), coincenterTestInfo.getRunMode()};
   FiatConverter fiatConverter{coincenterInfo, Duration::max()};  // max to avoid real Fiat converter queries
   CryptowatchAPI cryptowatchAPI{coincenterInfo};
   PublicExchangeT exchangePublic{coincenterInfo, fiatConverter, cryptowatchAPI};

--- a/src/engine/include/balanceperexchangeportfolio.hpp
+++ b/src/engine/include/balanceperexchangeportfolio.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <ostream>
-
 #include "cct_const.hpp"
 #include "cct_json.hpp"
 #include "queryresulttypes.hpp"
+#include "simpletable.hpp"
 
 namespace cct {
 class BalancePerExchangePortfolio {
@@ -14,7 +13,7 @@ class BalancePerExchangePortfolio {
 
   /// Pretty print table of balance.
   /// @param wide if true, all exchange amount will be printed as well
-  void printTable(std::ostream &os, bool wide) const;
+  SimpleTable getTable(bool wide) const;
 
   /// Print in json format.
   json printJson(CurrencyCode equiCurrency) const;

--- a/src/engine/include/queryresultprinter.hpp
+++ b/src/engine/include/queryresultprinter.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <ostream>
 
 #include "apioutputtype.hpp"
+#include "cct_json.hpp"
+#include "cct_log.hpp"
 #include "coincentercommandtype.hpp"
 #include "currencycode.hpp"
 #include "market.hpp"
@@ -11,10 +14,16 @@
 #include "queryresulttypes.hpp"
 
 namespace cct {
+class SimpleTable;
 class TradeOptions;
 class WithdrawInfo;
+
 class QueryResultPrinter {
  public:
+  /// @brief  Creates a QueryResultPrinter that will output result in the output logger.
+  explicit QueryResultPrinter(ApiOutputType apiOutputType);
+
+  /// @brief  Creates a QueryResultPrinter that will output result in given ostream
   QueryResultPrinter(std::ostream &os, ApiOutputType apiOutputType);
 
   void printMarkets(CurrencyCode cur1, CurrencyCode cur2, const MarketsPerExchange &marketsPerExchange) const;
@@ -73,7 +82,12 @@ class QueryResultPrinter {
                    bool isPercentageTrade, CurrencyCode toCurrency, const TradeOptions &tradeOptions,
                    CoincenterCommandType commandType) const;
 
-  std::ostream &_os;
+  void printTable(const SimpleTable &t) const;
+
+  void printJson(json &&in, json &&out) const;
+
+  std::ostream *_pOs = nullptr;
+  std::shared_ptr<log::logger> _outputLogger;
   ApiOutputType _apiOutputType;
 };
 

--- a/src/engine/src/balanceperexchangeportfolio.cpp
+++ b/src/engine/src/balanceperexchangeportfolio.cpp
@@ -17,7 +17,7 @@ MonetaryAmount ComputeTotalSum(const BalancePortfolio &total) {
 }
 }  // namespace
 
-void BalancePerExchangePortfolio::printTable(std::ostream &os, bool wide) const {
+SimpleTable BalancePerExchangePortfolio::getTable(bool wide) const {
   BalancePortfolio total = computeTotal();
   CurrencyCode balanceCurrencyCode = total.empty() ? CurrencyCode() : total.front().equi.currencyCode();
   const bool countEqui = !balanceCurrencyCode.isNeutral();
@@ -66,7 +66,7 @@ void BalancePerExchangePortfolio::printTable(std::ostream &os, bool wide) const 
     }
     balanceTable.push_back(std::move(r));
   }
-  balanceTable.print(os);
+  return balanceTable;
 }
 
 namespace {

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -17,13 +17,13 @@ using UniquePublicSelectedExchanges = ExchangeRetriever::UniquePublicSelectedExc
 
 Coincenter::Coincenter(const CoincenterInfo &coincenterInfo, const ExchangeSecretsInfo &exchangeSecretsInfo)
     : _coincenterInfo(coincenterInfo),
-      _cryptowatchAPI(_coincenterInfo, coincenterInfo.getRunMode()),
-      _fiatConverter(_coincenterInfo, _coincenterInfo.fiatConversionQueryRate()),
+      _cryptowatchAPI(coincenterInfo, coincenterInfo.getRunMode()),
+      _fiatConverter(coincenterInfo, coincenterInfo.fiatConversionQueryRate()),
       _apiKeyProvider(coincenterInfo.dataDir(), exchangeSecretsInfo, coincenterInfo.getRunMode()),
-      _metricsExporter(_coincenterInfo.metricGatewayPtr()),
-      _exchangePool(_coincenterInfo, _fiatConverter, _cryptowatchAPI, _apiKeyProvider),
+      _metricsExporter(coincenterInfo.metricGatewayPtr()),
+      _exchangePool(coincenterInfo, _fiatConverter, _cryptowatchAPI, _apiKeyProvider),
       _exchangesOrchestrator(_exchangePool.exchanges()),
-      _queryResultPrinter(std::cout, _coincenterInfo.apiOutputType()) {}
+      _queryResultPrinter(coincenterInfo.apiOutputType()) {}
 
 void Coincenter::process(const CoincenterCommands &coincenterCommands) {
   const int nbRepeats = coincenterCommands.repeats();

--- a/src/engine/test/queryresultprinter_test.cpp
+++ b/src/engine/test/queryresultprinter_test.cpp
@@ -45,7 +45,7 @@ class QueryResultPrinterTest : public ExchangesBaseTest {
 #endif
   }
 
-  std::stringstream ss;
+  std::ostringstream ss;
 };
 
 class QueryResultPrinterMarketsTest : public QueryResultPrinterTest {
@@ -82,8 +82,7 @@ TEST_F(QueryResultPrinterMarketsTest, EmptyJson) {
     "req": "Markets"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -106,8 +105,7 @@ TEST_F(QueryResultPrinterMarketsTest, Json) {
       "XRP-EUR"
     ]
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -146,8 +144,7 @@ TEST_F(QueryResultPrinterTickerTest, EmptyJson) {
     "req": "Ticker"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -197,8 +194,7 @@ TEST_F(QueryResultPrinterTickerTest, Json) {
       }
     ]
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -256,8 +252,7 @@ TEST_F(QueryResultPrinterMarketOrderBookTest, EmptyJson) {
     "req": "Orderbook"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -335,8 +330,7 @@ TEST_F(QueryResultPrinterMarketOrderBookTest, Json) {
       ]
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -377,8 +371,7 @@ TEST_F(QueryResultPrinterEmptyBalanceNoEquiCurTest, EmptyJson) {
       "cur": {}
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -403,8 +396,7 @@ TEST_F(QueryResultPrinterEmptyBalanceNoEquiCurTest, Json) {
       "cur": {}
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -455,8 +447,7 @@ TEST_F(QueryResultPrinterBalanceNoEquiCurTest, EmptyJson) {
       "cur": {}
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -544,8 +535,7 @@ TEST_F(QueryResultPrinterBalanceNoEquiCurTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -601,8 +591,7 @@ TEST_F(QueryResultPrinterBalanceEquiCurTest, EmptyJson) {
       "eq": "0"
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -677,8 +666,7 @@ TEST_F(QueryResultPrinterBalanceEquiCurTest, Json) {
       "eq": "44180.28"
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -721,8 +709,7 @@ TEST_F(QueryResultPrinterDepositInfoWithoutTagTest, EmptyJson) {
     "req": "DepositInfo"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -748,8 +735,7 @@ TEST_F(QueryResultPrinterDepositInfoWithoutTagTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -791,8 +777,7 @@ TEST_F(QueryResultPrinterDepositInfoWithTagTest, EmptyJson) {
     "req": "DepositInfo"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -818,8 +803,7 @@ TEST_F(QueryResultPrinterDepositInfoWithTagTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -884,8 +868,7 @@ TEST_F(QueryResultPrinterTradesAmountTest, EmptyJson) {
     "req": "Trade"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -934,8 +917,7 @@ TEST_F(QueryResultPrinterTradesAmountTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -996,8 +978,7 @@ TEST_F(QueryResultPrinterTradesPercentageTest, EmptyJson) {
     "req": "Trade"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1036,8 +1017,7 @@ TEST_F(QueryResultPrinterTradesPercentageTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1092,8 +1072,7 @@ TEST_F(QueryResultPrinterSmartBuyTest, EmptyJson) {
     "req": "Buy"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1128,8 +1107,7 @@ TEST_F(QueryResultPrinterSmartBuyTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1190,8 +1168,7 @@ TEST_F(QueryResultPrinterSmartSellTest, EmptyJson) {
     "req": "Sell"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1237,8 +1214,7 @@ TEST_F(QueryResultPrinterSmartSellTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1299,8 +1275,7 @@ TEST_F(QueryResultPrinterOpenedOrdersNoConstraintsTest, EmptyJson) {
     "req": "OrdersOpened"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1371,8 +1346,7 @@ TEST_F(QueryResultPrinterOpenedOrdersNoConstraintsTest, Json) {
       ]
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1412,8 +1386,7 @@ TEST_F(QueryResultPrinterCancelOrdersTest, EmptyJson) {
     "req": "OrdersCancel"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1444,8 +1417,7 @@ TEST_F(QueryResultPrinterCancelOrdersTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1487,8 +1459,7 @@ TEST_F(QueryResultPrinterConversionPathTest, EmptyJson) {
     "req": "ConversionPath"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1512,8 +1483,7 @@ TEST_F(QueryResultPrinterConversionPathTest, Json) {
       "BBB-XRP"
     ]
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1553,8 +1523,7 @@ TEST_F(QueryResultPrinterWithdrawFeeTest, EmptyJson) {
     "req": "WithdrawFee"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1572,8 +1541,7 @@ TEST_F(QueryResultPrinterWithdrawFeeTest, Json) {
     "bithumb": "0.15",
     "huobi": "0.05"
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1615,8 +1583,7 @@ TEST_F(QueryResultPrinterLast24HoursTradedVolumeTest, EmptyJson) {
     "req": "Last24hTradedVolume"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1635,8 +1602,7 @@ TEST_F(QueryResultPrinterLast24HoursTradedVolumeTest, Json) {
     "binance": "37.8",
     "huobi": "14"
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1713,8 +1679,7 @@ TEST_F(QueryResultPrinterLastTradesVolumeTest, EmptyJson) {
     "req": "LastTrades"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1785,8 +1750,7 @@ TEST_F(QueryResultPrinterLastTradesVolumeTest, Json) {
       }
     ]
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1829,8 +1793,7 @@ TEST_F(QueryResultPrinterLastPriceTest, EmptyJson) {
     "req": "LastPrice"
   },
   "out": {}
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1849,8 +1812,7 @@ TEST_F(QueryResultPrinterLastPriceTest, Json) {
     "bithumb": "590",
     "huobi": "444"
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1921,8 +1883,7 @@ TEST_F(QueryResultPrinterWithdrawAmountTest, Json) {
       "tag": "xrptag2"
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -1978,8 +1939,7 @@ TEST_F(QueryResultPrinterWithdrawPercentageTest, Json) {
       "tag": "xrptag2"
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 
@@ -2062,8 +2022,7 @@ TEST_F(QueryResultPrinterDustSweeperTest, Json) {
       }
     }
   }
-}
-)";
+})";
   expectJson(kExpected);
 }
 

--- a/src/objects/include/generalconfig.hpp
+++ b/src/objects/include/generalconfig.hpp
@@ -17,8 +17,6 @@ class GeneralConfig {
 
   GeneralConfig() = default;
 
-  GeneralConfig(const LoggingInfo &loggingInfo, Duration fiatConversionQueryRate, ApiOutputType apiOutputType);
-
   GeneralConfig(LoggingInfo &&loggingInfo, Duration fiatConversionQueryRate, ApiOutputType apiOutputType);
 
   const LoggingInfo &loggingInfo() const { return _loggingInfo; }

--- a/src/objects/include/logginginfo.hpp
+++ b/src/objects/include/logginginfo.hpp
@@ -8,16 +8,25 @@
 
 namespace cct {
 
+/// @brief Singleton encapsulating loggers lifetime and set-up.
 class LoggingInfo {
  public:
   static constexpr int kDefaultNbMaxFiles = 10;
   static constexpr int64_t kDefaultFileSizeInBytes = 5 * 1024 * 1024;
+  static constexpr char const *const kOutputLoggerName = "output";
 
   /// Creates a default logging info, with level 'info' on standard output.
-  constexpr LoggingInfo() noexcept = default;
+  LoggingInfo() { createLoggers(); }
 
   /// Creates a logging info from general config json file.
   explicit LoggingInfo(const json &generalConfigJsonLogPart);
+
+  LoggingInfo(const LoggingInfo &) = delete;
+  LoggingInfo(LoggingInfo &&) noexcept;
+  LoggingInfo &operator=(const LoggingInfo &) = delete;
+  LoggingInfo &operator=(LoggingInfo &&) noexcept;
+
+  ~LoggingInfo();
 
   int64_t maxFileSizeInBytes() const { return _maxFileSizeInBytes; }
 
@@ -27,7 +36,9 @@ class LoggingInfo {
   log::level::level_enum logFile() const { return LevelFromPos(_logLevelFilePos); }
 
  private:
-  void activateLogOptions() const;
+  void createLoggers() const;
+
+  void createOutputLogger() const;
 
   static constexpr int8_t PosFromLevel(log::level::level_enum level) {
     return static_cast<int8_t>(log::level::off) - static_cast<int8_t>(level);
@@ -40,6 +51,7 @@ class LoggingInfo {
   int _maxNbFiles = kDefaultNbMaxFiles;
   int8_t _logLevelConsolePos = PosFromLevel(log::level::info);
   int8_t _logLevelFilePos = PosFromLevel(log::level::off);
+  bool _destroyLoggers = true;
 };
 
 }  // namespace cct

--- a/src/objects/include/marketorderbook.hpp
+++ b/src/objects/include/marketorderbook.hpp
@@ -2,13 +2,13 @@
 
 #include <limits>
 #include <optional>
-#include <ostream>
 #include <span>
 #include <string_view>
 
 #include "cct_smallvector.hpp"
 #include "market.hpp"
 #include "monetaryamount.hpp"
+#include "simpletable.hpp"
 #include "volumeandpricenbdecimals.hpp"
 
 namespace cct {
@@ -143,10 +143,10 @@ class MarketOrderBook {
 
   std::optional<MonetaryAmount> computeAvgPrice(MonetaryAmount from, const PriceOptions& priceOptions) const;
 
-  /// Print the market order book to given stream.
+  /// Print the market order book in a SimpleTable and returns it.
   /// @param conversionPriceRate prices will be multiplied to given amount to display an additional column of equivalent
   ///                            currency
-  void print(std::ostream& os, std::string_view exchangeName, std::optional<MonetaryAmount> conversionPriceRate) const;
+  SimpleTable getTable(std::string_view exchangeName, std::optional<MonetaryAmount> conversionPriceRate) const;
 
  private:
   using AmountType = MonetaryAmount::AmountType;

--- a/src/objects/src/generalconfig.cpp
+++ b/src/objects/src/generalconfig.cpp
@@ -4,10 +4,6 @@
 
 namespace cct {
 
-GeneralConfig::GeneralConfig(const LoggingInfo &loggingInfo, Duration fiatConversionQueryRate,
-                             ApiOutputType apiOutputType)
-    : _loggingInfo(loggingInfo), _fiatConversionQueryRate(fiatConversionQueryRate), _apiOutputType(apiOutputType) {}
-
 GeneralConfig::GeneralConfig(LoggingInfo &&loggingInfo, Duration fiatConversionQueryRate, ApiOutputType apiOutputType)
     : _loggingInfo(std::move(loggingInfo)),
       _fiatConversionQueryRate(fiatConversionQueryRate),

--- a/src/objects/src/marketorderbook.cpp
+++ b/src/objects/src/marketorderbook.cpp
@@ -8,7 +8,6 @@
 #include "cct_fixedcapacityvector.hpp"
 #include "cct_log.hpp"
 #include "priceoptions.hpp"
-#include "simpletable.hpp"
 #include "stringhelpers.hpp"
 #include "unreachable.hpp"
 
@@ -534,8 +533,8 @@ std::optional<MonetaryAmount> MarketOrderBook::computeAvgPrice(MonetaryAmount fr
   }
 }
 
-void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName,
-                            std::optional<MonetaryAmount> conversionPriceRate) const {
+SimpleTable MarketOrderBook::getTable(std::string_view exchangeName,
+                                      std::optional<MonetaryAmount> conversionPriceRate) const {
   string h1("Sellers of ");
   string baseStr = _market.base().str();
   h1.append(baseStr).append(" (asks)");
@@ -573,7 +572,7 @@ void MarketOrderBook::print(std::ostream& os, std::string_view exchangeName,
     }
     t.push_back(std::move(r));
   }
-  t.print(os);
+  return t;
 }
 
 }  // namespace cct

--- a/src/tech/src/simpletable.cpp
+++ b/src/tech/src/simpletable.cpp
@@ -110,6 +110,6 @@ void SimpleTable::print(std::ostream &os) const {
     }
   }
 
-  os << lineSep << std::endl;
+  os << lineSep;
 }
 }  // namespace cct


### PR DESCRIPTION
Currently it's possible that print of output tables and json data is interleaved with asynchronous logger.
This PR transforms the output prints to use a logger instead of std::cout so that it is synchronized with the asynchronous logger.