### PR TITLE
Allow addition / subtraction of default MonetaryAmount with any other (neutral element)

### DIFF
--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -117,7 +117,7 @@ class CurrencyCode {
   static constexpr auto kMaxLen = CurrencyCodeBase::kMaxLen;
 
   /// Constructs a neutral currency code.
-  constexpr CurrencyCode() noexcept : _data(0) {}
+  constexpr CurrencyCode() noexcept : _data() {}
 
   /// Constructs a currency code from a char array.
   template <unsigned N, std::enable_if_t<N <= kMaxLen + 1, bool> = true>

--- a/src/objects/include/monetaryamount.hpp
+++ b/src/objects/include/monetaryamount.hpp
@@ -174,6 +174,10 @@ class MonetaryAmount {
 
   constexpr MonetaryAmount operator-() const noexcept { return MonetaryAmount(true, -_amount, _curWithDecimals); }
 
+  /// @brief  Addition of two MonetaryAmounts.
+  ///         They should have same currency for addition to be possible.
+  ///         Exception: default MonetaryAmount (0 with neutral currency) is a neutral element for addition and
+  ///         subtraction
   MonetaryAmount operator+(MonetaryAmount o) const;
 
   MonetaryAmount operator-(MonetaryAmount o) const { return *this + (-o); }
@@ -183,7 +187,7 @@ class MonetaryAmount {
     return *this;
   }
   MonetaryAmount &operator-=(MonetaryAmount o) {
-    *this = *this - o;
+    *this = *this + (-o);
     return *this;
   }
 

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -308,6 +308,12 @@ std::strong_ordering MonetaryAmount::operator<=>(const MonetaryAmount &o) const 
 }
 
 MonetaryAmount MonetaryAmount::operator+(MonetaryAmount o) const {
+  if (_amount == 0 && _curWithDecimals.isNeutral()) {
+    return o;
+  }
+  if (o._amount == 0 && o._curWithDecimals.isNeutral()) {
+    return *this;
+  }
   if (currencyCode() != o.currencyCode()) {
     throw exception("Addition is only possible on amounts with same currency");
   }

--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -97,6 +97,9 @@ TEST(MonetaryAmountTest, Arithmetic) {
 
   EXPECT_EQ(MonetaryAmount("0.49999999999976", "KRW") + MonetaryAmount("14183417.9174094504", "KRW"),
             MonetaryAmount("14183418.4174094503", "KRW"));
+
+  EXPECT_EQ(MonetaryAmount() + MonetaryAmount("3.1415 EUR"), MonetaryAmount("3.1415 EUR"));
+  EXPECT_EQ(MonetaryAmount("3.1415 EUR") - MonetaryAmount(), MonetaryAmount("3.1415 EUR"));
 }
 
 TEST(MonetaryAmountTest, Comparison) {


### PR DESCRIPTION
This has one main benefit: containers of `MonetaryAmount` can be initialized with default `MonetaryAmounts` that will be involved in additions / subtraction later on.
Example:
```
vector<MonetaryAmount> v(10); // 10 default MonetaryAmount
v[0] += MonetaryAmount(10, "EUR");
v[1] += MonetaryAmount(2000, "KRW");
```