### PR TITLE
New option balance in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,19 +292,22 @@ If you have only one key per exchange, suffixing with the name is not necessary 
 
 ### Balance
 
-Check your balance across supported exchanges at one glance!
+Check your available balance across supported exchanges at one glance!
 ```
 coincenter --balance
 ```
 prints a formatted table with sum of assets from all loaded private keys (for all exchanges).
 It is also possible to give a list of exchanges (comma separated) to print balance only on those ones.
 
-You can also specify a currency to which all assets will be converted (if possible) to have a nice estimation of your total balance.
+You can also specify a currency to which all assets will be converted (if possible) to have a nice estimation of your total balance in your currency.
 The currency acronym should be at the first position of the comma separated values, the next ones being the accounts.
-For instance, to print total balance on Kraken and Bithumb exchanges, with a summary currency of *Euro*, launch:
+For instance, to print total balance on Kraken and Bithumb exchanges, with a summary currency of *Euro*:
 ```
 coincenter --balance eur,kraken,bithumb
 ```
+
+By default, the balance displayed is the available one, with opened orders remaining unmatched amounts deduced. 
+To include balance in use as well, `--balance-in-use` should be added.
 
 ### Single Trade
 

--- a/src/api-objects/include/balanceoptions.hpp
+++ b/src/api-objects/include/balanceoptions.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+
+#include "currencycode.hpp"
+
+namespace cct {
+class BalanceOptions {
+ public:
+  enum class AmountIncludePolicy : int8_t {
+    kOnlyAvailable,
+    kWithBalanceInUse,
+  };
+
+  /// @brief Creates a default BalanceOptions.
+  /// It has no equivalent currency to convert amounts to,
+  /// and only available balance will be taken into account
+  BalanceOptions() noexcept = default;
+
+  /// @brief Constructs a BalanceOptions
+  /// @param amountIncludePolicy  kOnlyAvailable: only available amounts will be returned
+  ///                             kWithBalanceInUse: include balance in use by opened orders as well.
+  /// @param equiCurrency for each amount in a currency, attempt to convert each asset to given currency as an
+  ///                     additional value information. For instance: EUR, USD, BTC...
+  BalanceOptions(AmountIncludePolicy amountIncludePolicy, CurrencyCode equiCurrency)
+      : _equiCurrency(equiCurrency), _amountIncludePolicy(amountIncludePolicy) {}
+
+  CurrencyCode equiCurrency() const { return _equiCurrency; }
+  AmountIncludePolicy amountIncludePolicy() const { return _amountIncludePolicy; }
+
+  constexpr bool operator==(const BalanceOptions &) const noexcept = default;
+
+ private:
+  CurrencyCode _equiCurrency;
+  AmountIncludePolicy _amountIncludePolicy = AmountIncludePolicy::kOnlyAvailable;
+};
+}  // namespace cct

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "apikey.hpp"
+#include "balanceoptions.hpp"
 #include "balanceportfolio.hpp"
 #include "cachedresultvault.hpp"
 #include "curlhandle.hpp"
@@ -42,10 +43,8 @@ class ExchangePrivate : public ExchangeBase {
   /// Information should be fully set with private key.
   virtual CurrencyExchangeFlatSet queryTradableCurrencies() = 0;
 
-  /// Get a fast overview of the available assets on this exchange.
-  /// @param equiCurrency (optional) if provided, attempt to convert each asset to given currency as an
-  ///                     additional value information
-  BalancePortfolio getAccountBalance(CurrencyCode equiCurrency = CurrencyCode());
+  /// Get a fast overview of the account balance on this exchange.
+  BalancePortfolio getAccountBalance(const BalanceOptions &balanceOptions = BalanceOptions());
 
   /// Get the deposit wallet of given currency associated to this exchange.
   virtual Wallet queryDepositWallet(CurrencyCode currencyCode) = 0;
@@ -112,7 +111,7 @@ class ExchangePrivate : public ExchangeBase {
  protected:
   ExchangePrivate(const CoincenterInfo &coincenterInfo, ExchangePublic &exchangePublic, const APIKey &apiKey);
 
-  virtual BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) = 0;
+  virtual BalancePortfolio queryAccountBalance(const BalanceOptions &balanceOptions = BalanceOptions()) = 0;
 
   /// Adds an amount to given BalancePortfolio.
   /// @param equiCurrency Asks conversion of given amount into this currency as well

--- a/src/api/common/include/exchangeprivateapi_mock.hpp
+++ b/src/api/common/include/exchangeprivateapi_mock.hpp
@@ -13,7 +13,7 @@ class MockExchangePrivate : public ExchangePrivate {
       : ExchangePrivate(config, exchangePublic, apiKey) {}
 
   MOCK_METHOD(CurrencyExchangeFlatSet, queryTradableCurrencies, (), (override));
-  MOCK_METHOD(BalancePortfolio, queryAccountBalance, (CurrencyCode), (override));
+  MOCK_METHOD(BalancePortfolio, queryAccountBalance, (const BalanceOptions &), (override));
   MOCK_METHOD(Wallet, queryDepositWallet, (CurrencyCode), (override));
   MOCK_METHOD(bool, canGenerateDepositAddress, (), (const override));
   MOCK_METHOD(Orders, queryOpenedOrders, (const OrdersConstraints &), (override));

--- a/src/api/common/src/exchangeprivateapi.cpp
+++ b/src/api/common/src/exchangeprivateapi.cpp
@@ -13,9 +13,9 @@ ExchangePrivate::ExchangePrivate(const CoincenterInfo &coincenterInfo, ExchangeP
                                  const APIKey &apiKey)
     : ExchangeBase(), _exchangePublic(exchangePublic), _coincenterInfo(coincenterInfo), _apiKey(apiKey) {}
 
-BalancePortfolio ExchangePrivate::getAccountBalance(CurrencyCode equiCurrency) {
+BalancePortfolio ExchangePrivate::getAccountBalance(const BalanceOptions &balanceOptions) {
   UniqueQueryHandle uniqueQueryHandle(_cachedResultVault);
-  BalancePortfolio balancePortfolio = queryAccountBalance(equiCurrency);
+  BalancePortfolio balancePortfolio = queryAccountBalance(balanceOptions);
   log::info("Retrieved {} balance for {} assets", _exchangePublic.name(), balancePortfolio.size());
   return balancePortfolio;
 }

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -99,7 +99,6 @@ MarketsPath ExchangePublic::findMarketsPath(CurrencyCode fromCurrency, CurrencyC
                                             const Fiats &fiats, bool considerStableCoinsAsFiats) {
   MarketsPath ret;
   if (fromCurrency == toCurrency) {
-    log::warn("Cannot convert {} to itself", fromCurrency);
     return ret;
   }
 

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -23,7 +23,7 @@ class BinancePrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/api/exchanges/include/bithumbprivateapi.hpp
+++ b/src/api/exchanges/include/bithumbprivateapi.hpp
@@ -23,7 +23,7 @@ class BithumbPrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _exchangePublic.queryTradableCurrencies(); }
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/api/exchanges/include/huobiprivateapi.hpp
+++ b/src/api/exchanges/include/huobiprivateapi.hpp
@@ -22,7 +22,7 @@ class HuobiPrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _exchangePublic.queryTradableCurrencies(); }
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/api/exchanges/include/krakenprivateapi.hpp
+++ b/src/api/exchanges/include/krakenprivateapi.hpp
@@ -23,7 +23,7 @@ class KrakenPrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override;
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/api/exchanges/include/kucoinprivateapi.hpp
+++ b/src/api/exchanges/include/kucoinprivateapi.hpp
@@ -22,7 +22,7 @@ class KucoinPrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _exchangePublic.queryTradableCurrencies(); }
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -23,7 +23,7 @@ class UpbitPrivate : public ExchangePrivate {
 
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
-  BalancePortfolio queryAccountBalance(CurrencyCode equiCurrency = CurrencyCode()) override;
+  BalancePortfolio queryAccountBalance(const BalanceOptions& balanceOptions = BalanceOptions()) override;
 
   Wallet queryDepositWallet(CurrencyCode currencyCode) override { return _depositWalletsCache.get(currencyCode); }
 

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -68,7 +68,7 @@ class Coincenter {
 
   /// Query the private balance
   BalancePerExchange getBalance(std::span<const ExchangeName> privateExchangeNames,
-                                CurrencyCode equiCurrency = CurrencyCode());
+                                const BalanceOptions &balanceOptions);
 
   WalletPerExchange getDepositInfo(std::span<const ExchangeName> privateExchangeNames, CurrencyCode depositCurrency);
 

--- a/src/engine/include/coincentercommand.hpp
+++ b/src/engine/include/coincentercommand.hpp
@@ -35,6 +35,7 @@ class CoincenterCommand {
   CoincenterCommand& setCur2(CurrencyCode cur2);
 
   CoincenterCommand& setPercentageAmount(bool value = true);
+  CoincenterCommand& withBalanceInUse(bool value = true);
 
   bool isPublic() const;
   bool isPrivate() const { return !isPublic(); }
@@ -61,6 +62,7 @@ class CoincenterCommand {
   CoincenterCommandType type() const { return _type; }
 
   bool isPercentageAmount() const { return _isPercentageAmount; }
+  bool withBalanceInUse() const { return _withBalanceInUse; }
 
   using trivially_relocatable = std::integral_constant<bool, is_trivially_relocatable_v<ExchangeNames> &&
                                                                  is_trivially_relocatable_v<OrdersConstraints>>::type;
@@ -76,6 +78,7 @@ class CoincenterCommand {
   CurrencyCode _cur1, _cur2;
   CoincenterCommandType _type;
   bool _isPercentageAmount = false;
+  bool _withBalanceInUse = false;
 };
 
 }  // namespace cct

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -121,22 +121,16 @@ struct CoincenterCmdLineOptions {
   std::string_view apiOutputType;
   std::string_view logConsole;
   std::string_view logFile;
-  bool help = false;
-  bool version = false;
   std::optional<std::string_view> nosecrets;
-  CommandLineOptionalInt repeats;
   Duration repeatTime = kDefaultRepeatTime;
 
   std::string_view monitoringAddress = kDefaultMonitoringIPAddress;
   std::string_view monitoringUsername;
   std::string_view monitoringPassword;
-  int monitoringPort = kDefaultMonitoringPort;
-  bool useMonitoring = false;
 
   std::string_view markets;
 
   std::string_view orderbook;
-  int orderbookDepth = 0;
   std::string_view orderbookCur;
 
   std::optional<std::string_view> ticker;
@@ -151,11 +145,6 @@ struct CoincenterCmdLineOptions {
   std::string_view tradeStrategy;
   Duration tradeTimeout{TradeOptions().maxTradeTime()};
   Duration tradeUpdatePrice{TradeOptions().minTimeBetweenPriceUpdates()};
-
-  bool forceMultiTrade = false;
-  bool forceSingleTrade = false;
-  bool tradeTimeoutMatch = false;
-  bool tradeSim{TradeOptions().isSimulation()};
 
   std::string_view buy;
   std::string_view sell;
@@ -179,7 +168,20 @@ struct CoincenterCmdLineOptions {
   std::string_view lastPrice;
 
   std::string_view lastTrades;
+
+  CommandLineOptionalInt repeats;
   int nbLastTrades = api::ExchangePublic::kNbLastTradesDefault;
+  int monitoringPort = kDefaultMonitoringPort;
+  int orderbookDepth = 0;
+
+  bool forceMultiTrade = false;
+  bool forceSingleTrade = false;
+  bool tradeTimeoutMatch = false;
+  bool tradeSim{TradeOptions().isSimulation()};
+  bool help = false;
+  bool version = false;
+  bool useMonitoring = false;
+  bool withBalanceInUse = false;
 };
 
 template <class OptValueType>
@@ -289,6 +291,8 @@ struct CoincenterAllowedOptions {
         "in this case a total amount will be printed in this currency "
         "if conversion is possible."},
        &OptValueType::balance},
+      {{{"Private queries", 30}, "--balance-in-use", "", "Include balance in use as well from opened orders"},
+       &OptValueType::withBalanceInUse},
       {{{"Private queries", 31},
         "--orders-opened",
         "<cur1-cur2[,exch1,...]>",

--- a/src/engine/include/exchangesorchestrator.hpp
+++ b/src/engine/include/exchangesorchestrator.hpp
@@ -21,7 +21,7 @@ class ExchangesOrchestrator {
                                                      CurrencyCode equiCurrencyCode, std::optional<int> depth);
 
   BalancePerExchange getBalance(std::span<const ExchangeName> privateExchangeNames,
-                                CurrencyCode equiCurrency = CurrencyCode());
+                                const BalanceOptions &balanceOptions = BalanceOptions());
 
   WalletPerExchange getDepositInfo(std::span<const ExchangeName> privateExchangeNames, CurrencyCode depositCurrency);
 

--- a/src/engine/src/coincentercommand.cpp
+++ b/src/engine/src/coincentercommand.cpp
@@ -121,4 +121,12 @@ CoincenterCommand& CoincenterCommand::setPercentageAmount(bool value) {
   _isPercentageAmount = value;
   return *this;
 }
+
+CoincenterCommand& CoincenterCommand::withBalanceInUse(bool value) {
+  if (_type != CoincenterCommandType::kBalance) {
+    throw exception("With balance in use can only be set for Balance command");
+  }
+  _withBalanceInUse = value;
+  return *this;
+}
 }  // namespace cct

--- a/src/engine/src/coincentercommands.cpp
+++ b/src/engine/src/coincentercommands.cpp
@@ -109,6 +109,7 @@ bool CoincenterCommands::setFromOptions(const CoincenterCmdLineOptions &cmdLineO
         anyParser.getCurrencyPrivateExchanges(StringOptionParser::CurrencyIs::kOptional);
     _commands.emplace_back(CoincenterCommandType::kBalance)
         .setCur1(balanceCurrencyCode)
+        .withBalanceInUse(cmdLineOptions.withBalanceInUse)
         .setExchangeNames(std::move(exchanges));
   }
 

--- a/src/engine/test/exchangesorchestrator_private_test.cpp
+++ b/src/engine/test/exchangesorchestrator_private_test.cpp
@@ -13,31 +13,28 @@ using Type = CurrencyExchange::Type;
 class ExchangeOrchestratorTest : public ExchangesBaseTest {
  protected:
   ExchangesOrchestrator exchangesOrchestrator{std::span<Exchange>(&this->exchange1, 8)};
+  BalanceOptions balanceOptions;
 };
 
 TEST_F(ExchangeOrchestratorTest, BalanceNoEquivalentCurrencyUniqueExchange) {
-  CurrencyCode equiCurrency;
-
-  EXPECT_CALL(exchangePrivate1, queryAccountBalance(equiCurrency)).WillOnce(testing::Return(balancePortfolio1));
+  EXPECT_CALL(exchangePrivate1, queryAccountBalance(balanceOptions)).WillOnce(testing::Return(balancePortfolio1));
 
   const ExchangeName privateExchangeNames[1] = {ExchangeName(exchange1.name(), exchange1.keyName())};
   BalancePerExchange ret{{&exchange1, balancePortfolio1}};
-  EXPECT_EQ(exchangesOrchestrator.getBalance(privateExchangeNames, equiCurrency), ret);
+  EXPECT_EQ(exchangesOrchestrator.getBalance(privateExchangeNames, balanceOptions), ret);
 }
 
 TEST_F(ExchangeOrchestratorTest, BalanceNoEquivalentCurrencySeveralExchanges) {
-  CurrencyCode equiCurrency;
-
-  EXPECT_CALL(exchangePrivate1, queryAccountBalance(equiCurrency)).WillOnce(testing::Return(balancePortfolio1));
-  EXPECT_CALL(exchangePrivate3, queryAccountBalance(equiCurrency)).WillOnce(testing::Return(balancePortfolio2));
-  EXPECT_CALL(exchangePrivate4, queryAccountBalance(equiCurrency)).WillOnce(testing::Return(balancePortfolio3));
+  EXPECT_CALL(exchangePrivate1, queryAccountBalance(balanceOptions)).WillOnce(testing::Return(balancePortfolio1));
+  EXPECT_CALL(exchangePrivate3, queryAccountBalance(balanceOptions)).WillOnce(testing::Return(balancePortfolio2));
+  EXPECT_CALL(exchangePrivate4, queryAccountBalance(balanceOptions)).WillOnce(testing::Return(balancePortfolio3));
 
   const ExchangeName privateExchangeNames[] = {ExchangeName(exchange3.name(), exchange3.keyName()),
                                                ExchangeName(exchange1.name(), exchange1.keyName()),
                                                ExchangeName(exchange4.name(), exchange4.keyName())};
   BalancePerExchange ret{
       {&exchange1, balancePortfolio1}, {&exchange3, balancePortfolio2}, {&exchange4, balancePortfolio3}};
-  EXPECT_EQ(exchangesOrchestrator.getBalance(privateExchangeNames, equiCurrency), ret);
+  EXPECT_EQ(exchangesOrchestrator.getBalance(privateExchangeNames, balanceOptions), ret);
 }
 
 TEST_F(ExchangeOrchestratorTest, DepositInfoUniqueExchanges) {
@@ -191,7 +188,7 @@ class ExchangeOrchestratorWithdrawTest : public ExchangeOrchestratorTest {
 
   WithdrawInfo createWithdrawInfo(MonetaryAmount grossAmount, bool isPercentageWithdraw) {
     if (isPercentageWithdraw) {
-      EXPECT_CALL(exchangePrivate1, queryAccountBalance(CurrencyCode())).WillOnce(testing::Return(balancePortfolio1));
+      EXPECT_CALL(exchangePrivate1, queryAccountBalance(balanceOptions)).WillOnce(testing::Return(balancePortfolio1));
       grossAmount = (grossAmount.toNeutral() * balancePortfolio1.get(cur)) / 100;
     } else {
       EXPECT_CALL(exchangePrivate1, queryAccountBalance(testing::_)).Times(0);


### PR DESCRIPTION
Fix Kraken balance which was including balance in use
Now balance by default always retrieves the available balance.
New option `--balance-in-use` allows `coincenter` to include balance in use as well (with opened orders).