### PR TITLE
Chore/invalid argument format

### DIFF
--- a/src/engine/include/commandlineoptionsparser.hpp
+++ b/src/engine/include/commandlineoptionsparser.hpp
@@ -22,8 +22,7 @@
 namespace cct {
 
 inline void ThrowExpectingValueException(const CommandLineOption& commandLineOption) {
-  static const string ex = "Expecting a value for option: " + string(commandLineOption.fullName());
-  throw invalid_argument(ex.c_str());
+  throw invalid_argument("Expecting a value for option {}", commandLineOption.fullName());
 }
 
 // helper type for the visitor #4
@@ -64,9 +63,7 @@ class CommandLineOptionsParser : private OptValueType {
       const bool knownOption =
           std::ranges::any_of(_opts, [argStr](const auto& opt) { return opt.first.matches(argStr); });
       if (!knownOption) {
-        string ex("Unrecognized command-line option: ");
-        ex.append(argStr);
-        throw invalid_argument(std::move(ex));
+        throw invalid_argument("Unrecognized command-line option {}", argStr);
       }
 
       for (auto& cbk : _callbacks) {

--- a/src/objects/src/apioutputtype.cpp
+++ b/src/objects/src/apioutputtype.cpp
@@ -16,8 +16,6 @@ ApiOutputType ApiOutputTypeFromString(std::string_view str) {
   if (lowerStr == kApiOutputTypeJsonStr) {
     return ApiOutputType::kJson;
   }
-  string err("Unrecognized api output type ");
-  err.append(str);
-  throw invalid_argument(std::move(err));
+  throw invalid_argument("Unrecognized api output type {}", str);
 }
 }  // namespace cct

--- a/src/tech/include/cct_invalid_argument_exception.hpp
+++ b/src/tech/include/cct_invalid_argument_exception.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cct_exception.hpp"
+#include "cct_format.hpp"
 
 namespace cct {
 class invalid_argument : public exception {
@@ -9,5 +10,16 @@ class invalid_argument : public exception {
   explicit invalid_argument(const char (&str)[N]) noexcept : exception(str) {}
 
   explicit invalid_argument(string&& str) noexcept : exception(std::move(str)) {}
+
+#ifdef CCT_MSVC
+  // MSVC bug: https://developercommunity.visualstudio.com/t/using-fmtlib-on-a-custom-exceptions-constructor-pa/1673659
+  // do not use fmt for building an exception waiting for the bug to be fixed...
+  // Exception message will be incorrect.
+  template <typename... Args>
+  explicit invalid_argument(std::string_view fmt, Args&&... args) : exception(fmt, std::forward<Args>(args)...) {}
+#else
+  template <typename... Args>
+  explicit invalid_argument(format_string<Args...> fmt, Args&&... args) : exception(fmt, std::forward<Args>(args)...) {}
+#endif
 };
 }  // namespace cct

--- a/src/tech/src/codec.cpp
+++ b/src/tech/src/codec.cpp
@@ -12,7 +12,6 @@ string BinToHex(std::span<const unsigned char> bindata) {
   static constexpr char kHexits[] = "0123456789abcdef";
   const int s = static_cast<int>(bindata.size());
   string ret(2 * s, '\0');
-  ret.reserve(2 * s);
   for (int i = 0; i < s; ++i) {
     ret[i * 2] = kHexits[bindata[i] >> 4];
     ret[(i * 2) + 1] = kHexits[bindata[i] & 0x0F];

--- a/src/tech/src/durationstring.cpp
+++ b/src/tech/src/durationstring.cpp
@@ -40,9 +40,6 @@ Duration ParseDuration(std::string_view durationStr) {
     while (p < s && islower(durationStr[p])) {
       ++p;
     }
-    if (unitFirst == p) {
-      throw invalid_argument(kInvalidTimeDurationUnitMsg);
-    }
     std::string_view timeUnitStr(durationStr.begin() + unitFirst, durationStr.begin() + p);
     if (timeUnitStr == "y") {
       ret += std::chrono::years(timeAmount);


### PR DESCRIPTION
Support format for invalid_argument exception
Clean-up code in currencycode, addition of more comments to explain the technical parts