### PR TITLE
Health check implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Main features:
     - [Format](#format)
     - [Logging](#logging)
   - [Public requests](#public-requests)
+    - [Health check](#health-check)
     - [Markets](#markets)
       - [Examples](#examples)
     - [Ticker information](#ticker-information)
@@ -149,6 +150,11 @@ For this, you can configure statically the default level for each in the [config
 It is also overridable on the command line, with options `--log <log-level>` and `--log-file <log-level>`.
 
 ## Public requests
+
+### Health check
+
+`--health-check` pings the exchanges and checks if it is up and running.
+It is the first thing that is checked in exchanges unit tests, hence if the health check fails for an exchange, the tests are skipped for the exchange.
 
 ### Markets
 

--- a/src/api/common/include/exchangepublicapi.hpp
+++ b/src/api/common/include/exchangepublicapi.hpp
@@ -32,6 +32,10 @@ class ExchangePublic : public ExchangeBase {
 
   virtual ~ExchangePublic() {}
 
+  /// Check if public exchange is responding to basic health check, return true in this case.
+  /// Exchange that implements the HealthCheck do not need to add a retry mechanism.
+  virtual bool healthCheck() = 0;
+
   /// Retrieve the possible currencies known by current exchange.
   /// If some information is not known without any private key, information can be returned partially.
   virtual CurrencyExchangeFlatSet queryTradableCurrencies() = 0;

--- a/src/api/common/include/exchangepublicapi_mock.hpp
+++ b/src/api/common/include/exchangepublicapi_mock.hpp
@@ -14,6 +14,7 @@ class MockExchangePublic : public ExchangePublic {
                      const CoincenterInfo &config)
       : ExchangePublic(name, fiatConverter, cryptowatchApi, config) {}
 
+  MOCK_METHOD(bool, healthCheck, (), (override));
   MOCK_METHOD(CurrencyExchangeFlatSet, queryTradableCurrencies, (), (override));
   MOCK_METHOD(CurrencyExchange, convertStdCurrencyToCurrencyExchange, (CurrencyCode currencyCode), (override));
   MOCK_METHOD(MarketSet, queryTradableMarkets, (), (override));

--- a/src/api/exchanges/include/binancepublicapi.hpp
+++ b/src/api/exchanges/include/binancepublicapi.hpp
@@ -31,6 +31,8 @@ class BinancePublic : public ExchangePublic {
   BinancePublic(const CoincenterInfo& coincenterInfo, FiatConverter& fiatConverter,
                 api::CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override {
     return queryTradableCurrencies(_globalInfosCache.get());
   }

--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -19,6 +19,8 @@ class BithumbPublic : public ExchangePublic {
  public:
   BithumbPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) override {

--- a/src/api/exchanges/include/huobipublicapi.hpp
+++ b/src/api/exchanges/include/huobipublicapi.hpp
@@ -32,6 +32,8 @@ class HuobiPublic : public ExchangePublic {
 
   HuobiPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, api::CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override;
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode standardCode) override {
@@ -166,6 +168,7 @@ class HuobiPublic : public ExchangePublic {
 
   const ExchangeInfo& _exchangeInfo;
   CurlHandle _curlHandle;
+  CurlHandle _healthCheckCurlHandle;
   CachedResult<TradableCurrenciesFunc> _tradableCurrenciesCache;
   CachedResult<MarketsFunc> _marketsCache;
   CachedResult<AllOrderBooksFunc, int> _allOrderBooksCache;

--- a/src/api/exchanges/include/krakenpublicapi.hpp
+++ b/src/api/exchanges/include/krakenpublicapi.hpp
@@ -20,6 +20,8 @@ class KrakenPublic : public ExchangePublic {
  public:
   KrakenPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) override {

--- a/src/api/exchanges/include/kucoinpublicapi.hpp
+++ b/src/api/exchanges/include/kucoinpublicapi.hpp
@@ -33,6 +33,8 @@ class KucoinPublic : public ExchangePublic {
 
   KucoinPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, api::CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override;
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode standardCode) override {

--- a/src/api/exchanges/include/upbitpublicapi.hpp
+++ b/src/api/exchanges/include/upbitpublicapi.hpp
@@ -21,6 +21,8 @@ class UpbitPublic : public ExchangePublic {
  public:
   UpbitPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, CryptowatchAPI& cryptowatchAPI);
 
+  bool healthCheck() override;
+
   CurrencyExchangeFlatSet queryTradableCurrencies() override { return _tradableCurrenciesCache.get(); }
 
   CurrencyExchange convertStdCurrencyToCurrencyExchange(CurrencyCode currencyCode) override {

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -79,6 +79,15 @@ BinancePublic::BinancePublic(const CoincenterInfo& coincenterInfo, FiatConverter
       _tickerCache(CachedResultOptions(exchangeInfo().getAPICallUpdateFrequency(kLastPrice), _cachedResultVault),
                    _commonInfo) {}
 
+bool BinancePublic::healthCheck() {
+  json result = json::parse(
+      _commonInfo._curlHandle.query("/api/v3/ping", CurlOptions(HttpRequestType::kGet, BinancePublic::kUserAgent)));
+  if (!result.empty()) {
+    log::error("{} health check is not empty: {}", _name, result.dump());
+  }
+  return result.empty();
+}
+
 BinancePublic::CommonInfo::CommonInfo(const CoincenterInfo& coincenterInfo, const ExchangeInfo& exchangeInfo,
                                       settings::RunMode runMode)
     : _exchangeInfo(exchangeInfo),

--- a/src/api/interface/include/exchange.hpp
+++ b/src/api/interface/include/exchange.hpp
@@ -44,6 +44,8 @@ class Exchange {
 
   bool hasPrivateAPI() const { return _pExchangePrivate; }
 
+  bool healthCheck() { return _exchangePublic.healthCheck(); }
+
   CurrencyExchangeFlatSet queryTradableCurrencies() {
     return hasPrivateAPI() ? _pExchangePrivate->queryTradableCurrencies() : _exchangePublic.queryTradableCurrencies();
   }

--- a/src/engine/include/coincenter.hpp
+++ b/src/engine/include/coincenter.hpp
@@ -33,6 +33,8 @@ class Coincenter {
 
   void process(const CoincenterCommands &opts);
 
+  ExchangeHealthCheckStatus healthCheck(ExchangeNameSpan exchangeNames);
+
   /// Retrieve the markets for given selected public exchanges, or all if empty.
   MarketsPerExchange getMarketsPerExchange(CurrencyCode cur1, CurrencyCode cur2, ExchangeNameSpan exchangeNames);
 

--- a/src/engine/include/coincentercommandtype.hpp
+++ b/src/engine/include/coincentercommandtype.hpp
@@ -5,6 +5,7 @@
 
 namespace cct {
 enum class CoincenterCommandType : int8_t {
+  kHealthCheck,
   kMarkets,
   kConversionPath,
   kLastPrice,

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -135,6 +135,8 @@ struct CoincenterCmdLineOptions {
   std::string_view orderbook;
   std::string_view orderbookCur;
 
+  std::optional<std::string_view> healthCheck;
+
   std::optional<std::string_view> ticker;
 
   std::string_view conversionPath;
@@ -231,6 +233,11 @@ struct CoincenterAllowedOptions {
        &OptValueType::repeats},
       {{{"General", 9}, "--repeat-time", "<time>", CoincenterCmdLineOptions::kRepeat}, &OptValueType::repeatTime},
       {{{"General", 10}, "--version", "", "Display program version"}, &OptValueType::version},
+      {{{"Public queries", 20},
+        "--health-check",
+        "<[exch1,...]>",
+        "Simple health check for all exchanges or specified ones"},
+       &OptValueType::healthCheck},
       {{{"Public queries", 20},
         "--markets",
         'm',

--- a/src/engine/include/exchangesorchestrator.hpp
+++ b/src/engine/include/exchangesorchestrator.hpp
@@ -15,6 +15,8 @@ class ExchangesOrchestrator {
 
   explicit ExchangesOrchestrator(std::span<Exchange> exchangesSpan) : _exchangeRetriever(exchangesSpan) {}
 
+  ExchangeHealthCheckStatus healthCheck(ExchangeNameSpan exchangeNames);
+
   ExchangeTickerMaps getTickerInformation(ExchangeNameSpan exchangeNames);
 
   MarketOrderBookConversionRates getMarketOrderBooks(Market m, ExchangeNameSpan exchangeNames,

--- a/src/engine/include/metricsexporter.hpp
+++ b/src/engine/include/metricsexporter.hpp
@@ -12,6 +12,8 @@ class MetricsExporter {
  public:
   explicit MetricsExporter(AbstractMetricGateway *pMetricsGateway);
 
+  void exportHealthCheckMetrics(const ExchangeHealthCheckStatus &healthCheckPerExchange);
+
   void exportBalanceMetrics(const BalancePerExchange &balancePerExchange, CurrencyCode equiCurrency);
 
   void exportTickerMetrics(const ExchangeTickerMaps &marketOrderBookMaps);

--- a/src/engine/include/queryresultprinter.hpp
+++ b/src/engine/include/queryresultprinter.hpp
@@ -27,6 +27,8 @@ class QueryResultPrinter {
   /// @brief  Creates a QueryResultPrinter that will output result in given ostream
   QueryResultPrinter(std::ostream &os, ApiOutputType apiOutputType);
 
+  void printHealthCheck(const ExchangeHealthCheckStatus &healthCheckPerExchange) const;
+
   void printMarkets(CurrencyCode cur1, CurrencyCode cur2, const MarketsPerExchange &marketsPerExchange) const;
 
   void printMarketOrderBooks(Market m, CurrencyCode equiCurrencyCode, std::optional<int> depth,

--- a/src/engine/include/queryresulttypes.hpp
+++ b/src/engine/include/queryresulttypes.hpp
@@ -35,6 +35,8 @@ using TradedAmountsPerExchange = SmallVector<std::pair<const Exchange *, TradedA
 using TradedAmountsVectorWithFinalAmountPerExchange =
     SmallVector<std::pair<const Exchange *, TradedAmountsVectorWithFinalAmount>, kTypicalNbPrivateAccounts>;
 
+using ExchangeHealthCheckStatus = FixedCapacityVector<std::pair<const Exchange *, bool>, kNbSupportedExchanges>;
+
 using ExchangeTickerMaps = FixedCapacityVector<std::pair<const Exchange *, MarketOrderBookMap>, kNbSupportedExchanges>;
 
 using BalancePerExchange = SmallVector<std::pair<Exchange *, BalancePortfolio>, kTypicalNbPrivateAccounts>;

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -46,6 +46,11 @@ void Coincenter::process(const CoincenterCommands &coincenterCommands) {
 
 void Coincenter::processCommand(const CoincenterCommand &cmd) {
   switch (cmd.type()) {
+    case CoincenterCommandType::kHealthCheck: {
+      ExchangeHealthCheckStatus healthCheckStatus = healthCheck(cmd.exchangeNames());
+      _queryResultPrinter.printHealthCheck(healthCheckStatus);
+      break;
+    }
     case CoincenterCommandType::kMarkets: {
       MarketsPerExchange marketsPerExchange = getMarketsPerExchange(cmd.cur1(), cmd.cur2(), cmd.exchangeNames());
       _queryResultPrinter.printMarkets(cmd.cur1(), cmd.cur2(), marketsPerExchange);
@@ -154,6 +159,14 @@ void Coincenter::processCommand(const CoincenterCommand &cmd) {
     default:
       throw exception("Unknown command type");
   }
+}
+
+ExchangeHealthCheckStatus Coincenter::healthCheck(ExchangeNameSpan exchangeNames) {
+  ExchangeHealthCheckStatus ret = _exchangesOrchestrator.healthCheck(exchangeNames);
+
+  _metricsExporter.exportHealthCheckMetrics(ret);
+
+  return ret;
 }
 
 ExchangeTickerMaps Coincenter::getTickerInformation(ExchangeNameSpan exchangeNames) {

--- a/src/engine/src/coincentercommand.cpp
+++ b/src/engine/src/coincentercommand.cpp
@@ -5,6 +5,8 @@
 namespace cct {
 bool CoincenterCommand::isPublic() const {
   switch (_type) {
+    case CoincenterCommandType::kHealthCheck:
+      [[fallthrough]];
     case CoincenterCommandType::kMarkets:
       [[fallthrough]];
     case CoincenterCommandType::kConversionPath:

--- a/src/engine/src/coincentercommands.cpp
+++ b/src/engine/src/coincentercommands.cpp
@@ -71,6 +71,11 @@ bool CoincenterCommands::setFromOptions(const CoincenterCmdLineOptions &cmdLineO
 
   _repeatTime = cmdLineOptions.repeatTime;
 
+  if (cmdLineOptions.healthCheck) {
+    StringOptionParser anyParser(*cmdLineOptions.healthCheck);
+    _commands.emplace_back(CoincenterCommandType::kHealthCheck).setExchangeNames(anyParser.getExchanges());
+  }
+
   if (!cmdLineOptions.markets.empty()) {
     StringOptionParser anyParser(cmdLineOptions.markets);
     auto [cur1, cur2, exchanges] = anyParser.getCurrenciesPublicExchanges();

--- a/src/engine/src/coincentercommandtype.cpp
+++ b/src/engine/src/coincentercommandtype.cpp
@@ -5,6 +5,8 @@
 namespace cct {
 std::string_view CoincenterCommandTypeToString(CoincenterCommandType type) {
   switch (type) {
+    case CoincenterCommandType::kHealthCheck:
+      return "HealthCheck";
     case CoincenterCommandType::kMarkets:
       return "Markets";
     case CoincenterCommandType::kConversionPath:

--- a/src/engine/src/exchangesorchestrator.cpp
+++ b/src/engine/src/exchangesorchestrator.cpp
@@ -50,6 +50,17 @@ ExchangeRetriever::PublicExchangesVec SelectUniquePublicExchanges(ExchangeRetrie
 
 }  // namespace
 
+ExchangeHealthCheckStatus ExchangesOrchestrator::healthCheck(ExchangeNameSpan exchangeNames) {
+  log::info("Health check for {}", ConstructAccumulatedExchangeNames(exchangeNames));
+  UniquePublicSelectedExchanges selectedExchanges = _exchangeRetriever.selectOneAccount(exchangeNames);
+
+  ExchangeHealthCheckStatus ret(selectedExchanges.size());
+  std::transform(std::execution::par, selectedExchanges.begin(), selectedExchanges.end(), ret.begin(),
+                 [](Exchange *e) { return std::make_pair(e, e->healthCheck()); });
+
+  return ret;
+}
+
 ExchangeTickerMaps ExchangesOrchestrator::getTickerInformation(ExchangeNameSpan exchangeNames) {
   log::info("Ticker information for {}", ConstructAccumulatedExchangeNames(exchangeNames));
 

--- a/src/engine/src/metricsexporter.cpp
+++ b/src/engine/src/metricsexporter.cpp
@@ -17,6 +17,16 @@ MetricsExporter::MetricsExporter(AbstractMetricGateway *pMetricsGateway) : _pMet
   }
 }
 
+void MetricsExporter::exportHealthCheckMetrics(const ExchangeHealthCheckStatus &healthCheckPerExchange) {
+  RETURN_IF_NO_MONITORING;
+  MetricKey key = CreateMetricKey("health_check", "Is exchange status OK?");
+  for (const auto &[exchangePtr, healthCheckResult] : healthCheckPerExchange) {
+    const Exchange &exchange = *exchangePtr;
+    key.set("exchange", exchange.name());
+    _pMetricsGateway->add(MetricType::kGauge, MetricOperation::kSet, key, static_cast<double>(healthCheckResult));
+  }
+}
+
 void MetricsExporter::exportBalanceMetrics(const BalancePerExchange &balancePerExchange, CurrencyCode equiCurrency) {
   RETURN_IF_NO_MONITORING;
   MetricKey key = CreateMetricKey("available_balance", "Available balance in the exchange account");

--- a/src/engine/test/exchangesorchestrator_public_test.cpp
+++ b/src/engine/test/exchangesorchestrator_public_test.cpp
@@ -14,6 +14,17 @@ class ExchangeOrchestratorTest : public ExchangesBaseTest {
   ExchangesOrchestrator exchangesOrchestrator{std::span<Exchange>(&this->exchange1, 8)};
 };
 
+TEST_F(ExchangeOrchestratorTest, HealthCheck) {
+  EXPECT_CALL(exchangePublic1, healthCheck()).WillOnce(testing::Return(true));
+  EXPECT_CALL(exchangePublic2, healthCheck()).WillOnce(testing::Return(false));
+
+  const ExchangeName kTestedExchanges12[] = {ExchangeName(kSupportedExchanges[0]),
+                                             ExchangeName(kSupportedExchanges[1])};
+
+  ExchangeHealthCheckStatus expectedHealthCheck = {{&exchange1, true}, {&exchange2, false}};
+  EXPECT_EQ(exchangesOrchestrator.healthCheck(kTestedExchanges12), expectedHealthCheck);
+}
+
 TEST_F(ExchangeOrchestratorTest, TickerInformation) {
   const MarketOrderBookMap marketOrderbookMap1 = {{m1, marketOrderBook10}, {m2, marketOrderBook20}};
   EXPECT_CALL(exchangePublic1, queryAllApproximatedOrderBooks(1)).WillOnce(testing::Return(marketOrderbookMap1));


### PR DESCRIPTION
New option `--health-check`.
Also reorganize exchange unit tests to avoid having to query everything at the construction of the test object.