### PR TITLE
Extract URL picker logic from CurlHandle in a new class

### DIFF
--- a/src/api/common/include/cryptowatchapi.hpp
+++ b/src/api/common/include/cryptowatchapi.hpp
@@ -7,6 +7,7 @@
 
 #include "cachedresult.hpp"
 #include "cct_flatset.hpp"
+#include "cct_json.hpp"
 #include "curlhandle.hpp"
 #include "exchangebase.hpp"
 #include "market.hpp"

--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -7,6 +7,7 @@
 #include "cct_json.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "timedef.hpp"
 #include "toupperlower.hpp"
 

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -3,6 +3,7 @@
 #include "cachedresult.hpp"
 #include "cct_json.hpp"
 #include "curlhandle.hpp"
+#include "curloptions.hpp"
 #include "exchangeprivateapi.hpp"
 #include "exchangeprivateapitypes.hpp"
 #include "exchangepublicapitypes.hpp"

--- a/src/api/exchanges/include/kucoinpublicapi.hpp
+++ b/src/api/exchanges/include/kucoinpublicapi.hpp
@@ -9,6 +9,7 @@
 #include "cct_json.hpp"
 #include "cct_string.hpp"
 #include "curlhandle.hpp"
+#include "curloptions.hpp"
 #include "currencycode.hpp"
 #include "exchangepublicapi.hpp"
 #include "exchangepublicapitypes.hpp"

--- a/src/api/exchanges/src/binancepublicapi.cpp
+++ b/src/api/exchanges/src/binancepublicapi.cpp
@@ -14,6 +14,7 @@
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "fiatconverter.hpp"
 #include "monetaryamount.hpp"
 #include "ssl_sha.hpp"

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -14,6 +14,7 @@
 #include "cct_smallvector.hpp"
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "recentdeposit.hpp"
 #include "ssl_sha.hpp"
 #include "stringhelpers.hpp"

--- a/src/api/exchanges/src/bithumbpublicapi.cpp
+++ b/src/api/exchanges/src/bithumbpublicapi.cpp
@@ -11,6 +11,7 @@
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "fiatconverter.hpp"
 #include "monetaryamount.hpp"
 #include "stringhelpers.hpp"

--- a/src/api/exchanges/src/huobiprivateapi.cpp
+++ b/src/api/exchanges/src/huobiprivateapi.cpp
@@ -6,6 +6,7 @@
 #include "apikey.hpp"
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "huobipublicapi.hpp"
 #include "recentdeposit.hpp"
 #include "ssl_sha.hpp"

--- a/src/api/exchanges/src/huobipublicapi.cpp
+++ b/src/api/exchanges/src/huobipublicapi.cpp
@@ -10,6 +10,7 @@
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "fiatconverter.hpp"
 #include "monetaryamount.hpp"
 #include "toupperlower.hpp"

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -9,6 +9,7 @@
 #include "cct_log.hpp"
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "krakenpublicapi.hpp"
 #include "recentdeposit.hpp"
 #include "ssl_sha.hpp"

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -12,6 +12,7 @@
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "timedef.hpp"
 
 namespace cct::api {

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -5,6 +5,7 @@
 #include "apikey.hpp"
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "kucoinpublicapi.hpp"
 #include "recentdeposit.hpp"
 #include "ssl_sha.hpp"

--- a/src/api/exchanges/src/kucoinpublicapi.cpp
+++ b/src/api/exchanges/src/kucoinpublicapi.cpp
@@ -4,12 +4,12 @@
 #include <cassert>
 #include <execution>
 #include <thread>
-#include <unordered_map>
 
 #include "cct_exception.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "fiatconverter.hpp"
 #include "monetaryamount.hpp"
 #include "stringhelpers.hpp"

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -15,6 +15,7 @@
 #include "codec.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
+#include "curloptions.hpp"
 #include "monetaryamount.hpp"
 #include "recentdeposit.hpp"
 #include "ssl_sha.hpp"

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -8,6 +8,7 @@
 #include "cct_json.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
+#include "curloptions.hpp"
 #include "fiatconverter.hpp"
 #include "stringhelpers.hpp"
 

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -4,7 +4,7 @@
 #include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "coincenterinfo.hpp"
-#include "curlhandle.hpp"
+#include "curloptions.hpp"
 
 namespace cct {
 namespace {

--- a/src/objects/test/fiatconverter_test.cpp
+++ b/src/objects/test/fiatconverter_test.cpp
@@ -23,10 +23,12 @@ void AreDoubleEqual(double lhs, double rhs) {
 constexpr double kKRW = 1341.88;
 constexpr double kUSD = 1.21;
 constexpr double kGBP = 0.88;
+
+constexpr std::string_view kSomeFakeURL = "some/fake/url";
 }  // namespace
 
-CurlHandle::CurlHandle(const std::string_view *, int8_t, AbstractMetricGateway *, Duration, settings::RunMode)
-    : _handle(nullptr) {}
+CurlHandle::CurlHandle(const BestURLPicker &, AbstractMetricGateway *, Duration, settings::RunMode)
+    : _handle(nullptr), _bestUrlPicker(kSomeFakeURL) {}
 
 string CurlHandle::query(std::string_view url, const CurlOptions &) {
   json j;

--- a/src/tech/include/mathhelpers.hpp
+++ b/src/tech/include/mathhelpers.hpp
@@ -68,16 +68,10 @@ constexpr int64_t ipow(int64_t base, uint8_t exp) noexcept {
   }
 }
 
-template <class T>
-concept SignedIntegral = std::integral<T> && std::is_signed_v<T>;
-
-template <class T>
-concept UnsignedIntegral = std::integral<T> && !std::is_signed_v<T>;
-
 /// Return the number of digits of given integral.
 /// The minus sign is not counted.
 /// Uses dichotomy for highest performance as possible.
-constexpr int ndigits(SignedIntegral auto n) noexcept {
+constexpr int ndigits(std::signed_integral auto n) noexcept {
   using T = decltype(n);
   if constexpr (std::is_same_v<T, int8_t>) {
     return n < 0 ? (n > -100 ? (n > -10 ? 1 : 2) : 3) : (n < 100 ? (n < 10 ? 1 : 2) : 3);
@@ -113,11 +107,11 @@ constexpr int ndigits(SignedIntegral auto n) noexcept {
 }
 
 /// Count the number of digits including the possible minus sign for negative integrals.
-constexpr int nchars(SignedIntegral auto n) noexcept { return ndigits(n) + static_cast<int>(n < 0); }
+constexpr int nchars(std::signed_integral auto n) noexcept { return ndigits(n) + static_cast<int>(n < 0); }
 
 /// Return the number of digits of given integral.
 /// Uses dichotomy for highest performance as possible.
-constexpr int ndigits(UnsignedIntegral auto n) noexcept {
+constexpr int ndigits(std::unsigned_integral auto n) noexcept {
   using T = decltype(n);
   if constexpr (std::is_same_v<T, uint8_t>) {
     return n < 100U ? (n < 10U ? 1 : 2) : 3;
@@ -141,6 +135,6 @@ constexpr int ndigits(UnsignedIntegral auto n) noexcept {
 }
 
 /// Synonym of ndigits for unsigned types.
-constexpr int nchars(UnsignedIntegral auto n) noexcept { return ndigits(n); }
+constexpr int nchars(std::unsigned_integral auto n) noexcept { return ndigits(n); }
 
 }  // namespace cct

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -17,6 +17,13 @@ target_link_libraries(coincenter_tools PRIVATE CURL::libcurl)
 target_include_directories(coincenter_tools PUBLIC include)
 
 add_unit_test(
+    besturlpicker_test
+    test/besturlpicker_test.cpp
+    LIBRARIES
+    coincenter_tools
+)
+
+add_unit_test(
     curlhandle_test
     test/curlhandle_test.cpp
     LIBRARIES

--- a/src/tools/include/besturlpicker.hpp
+++ b/src/tools/include/besturlpicker.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+
+#include "cct_fixedcapacityvector.hpp"
+#include "cct_string.hpp"
+
+namespace cct {
+/// Utility class that holds the logic to pick the most interesting URL for each query based on response time
+/// statistics (average and standard deviation) stored over requests.
+/// The maximum number of base URLs it can work with is known at compile time, and should stay small as data is stored
+/// inline.
+/// BestURLPicker basically favors the base URLs with the lowest average response time and deviation (scored as a sum,
+/// so the average naturally counts 'more' than the deviation).
+/// We approximate storage of a moving average of response time and standard deviation instead of holding stats for the
+/// 'n' last requests.
+class BestURLPicker {
+ private:
+  static constexpr int kNbMaxBaseUrl = 4;
+
+ public:
+  /// Builds a BestURLPicker that will work with several base URLs.
+  /// Warning: given base URL should come from static storage
+  template <unsigned N, std::enable_if_t<(N > 0) && N <= kNbMaxBaseUrl, bool> = true>
+  BestURLPicker(const std::string_view (&aBaseUrl)[N]) : BestURLPicker(std::span<const std::string_view>(aBaseUrl)) {}
+
+  BestURLPicker(const string[]) = delete;
+  BestURLPicker(const char *[]) = delete;
+
+  /// Builds a BestURLPicker with a single base URL.
+  /// The chosen base URL is thus trivial and will always be the same.
+  /// Warning: given base URL should come from static storage
+  BestURLPicker(const std::string_view &singleBaseUrl)
+      : BestURLPicker(std::span<const std::string_view>(std::addressof(singleBaseUrl), 1)) {}
+
+  BestURLPicker(const string &) = delete;
+  BestURLPicker(const char *) = delete;
+
+  // Return the best URL that will be used by the next query.
+  // A "good" URL is some URL that has lower average response time (all queries mixed) according to the others.
+  std::string_view getNextBaseURL() const { return _pBaseUrls[nextBaseURLPos()]; }
+  std::string_view getBaseURL(int8_t pos) const { return _pBaseUrls[pos]; }
+
+  int8_t nextBaseURLPos() const;
+  void storeResponseTimePerBaseURL(int8_t baseUrlPos, uint32_t responseTimeInMs);
+
+  int8_t nbBaseURL() const { return static_cast<int8_t>(_responseTimeStatsPerBaseUrl.size()); }
+
+ private:
+  explicit BestURLPicker(std::span<const std::string_view> baseUrls)
+      : _pBaseUrls(baseUrls.data()), _responseTimeStatsPerBaseUrl(baseUrls.size()) {}
+
+  struct ResponseTimeStats {
+    uint16_t nbRequestsDone;   // when reaching max, all stats are reset to give equal chances to all base URLs
+    uint16_t avgResponseTime;  // approximation of moving average
+    uint16_t avgDeviation;     // approximation of moving standard deviation
+
+    uint32_t score() const { return static_cast<uint32_t>(avgResponseTime) + avgDeviation; }
+  };
+
+  using ResponseTimeStatsPerBaseUrl = FixedCapacityVector<ResponseTimeStats, kNbMaxBaseUrl>;
+
+  // Non-owning pointer, should come from static storage (default special operations are fine)
+  const std::string_view *_pBaseUrls;
+  ResponseTimeStatsPerBaseUrl _responseTimeStatsPerBaseUrl;
+};
+}  // namespace cct

--- a/src/tools/src/besturlpicker.cpp
+++ b/src/tools/src/besturlpicker.cpp
@@ -1,0 +1,91 @@
+#include "besturlpicker.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+#include "cct_log.hpp"
+#include "mathhelpers.hpp"
+
+namespace cct {
+int8_t BestURLPicker::nextBaseURLPos() const {
+  // First, pick the base url which has less than 'kNbRequestMinBeforeCompare' if any
+  auto minNbIt = std::ranges::find_if(_responseTimeStatsPerBaseUrl, [](ResponseTimeStats lhs) {
+    static constexpr decltype(lhs.nbRequestsDone) kNbRequestMinBeforeCompare = 10;
+    return lhs.nbRequestsDone < kNbRequestMinBeforeCompare;
+  });
+  if (minNbIt != _responseTimeStatsPerBaseUrl.end()) {
+    return static_cast<int8_t>(minNbIt - _responseTimeStatsPerBaseUrl.begin());
+  }
+
+  // We favor the URL that has the least score for 90 % of the requests, and give a chance to the one with the least
+  // number of requests 10 % of the time
+  int totalNbRequestsDone =
+      std::accumulate(_responseTimeStatsPerBaseUrl.begin(), _responseTimeStatsPerBaseUrl.end(), 0,
+                      [](int sum, ResponseTimeStats stats) { return sum + stats.nbRequestsDone; });
+
+  if ((totalNbRequestsDone % 10) == 9) {
+    auto minNbOfRequestsURLPosIt = std::ranges::min_element(
+        _responseTimeStatsPerBaseUrl,
+        [](ResponseTimeStats lhs, ResponseTimeStats rhs) { return lhs.nbRequestsDone < rhs.nbRequestsDone; });
+    return static_cast<int8_t>(minNbOfRequestsURLPosIt - _responseTimeStatsPerBaseUrl.begin());
+  }
+
+  // Then, let's compute a 'score' based on the average deviation and the avg response time and pick best url
+  // The lowest score will correspond to the best URL
+  auto minScoreByURLIt =
+      std::ranges::min_element(_responseTimeStatsPerBaseUrl,
+                               [](ResponseTimeStats lhs, ResponseTimeStats rhs) { return lhs.score() < rhs.score(); });
+  return static_cast<int8_t>(minScoreByURLIt - _responseTimeStatsPerBaseUrl.begin());
+}
+
+void BestURLPicker::storeResponseTimePerBaseURL(int8_t baseUrlPos, uint32_t responseTimeInMs) {
+  ResponseTimeStats &stats = _responseTimeStatsPerBaseUrl[baseUrlPos];
+
+  // How many requests we consider to compute stats?
+  using NbRequestType = decltype(stats.nbRequestsDone);
+  static constexpr NbRequestType kMaxLastNbRequestsToConsider = 20;
+
+  if (stats.nbRequestsDone == std::numeric_limits<NbRequestType>::max()) {
+    // If one URL has reached the max number of requests done, we reset all stats and give an equal chance for all Base
+    // URLs once again
+    log::debug("Reset time stats for '{}'", _pBaseUrls[baseUrlPos]);
+    std::ranges::fill(_responseTimeStatsPerBaseUrl, ResponseTimeStats{});
+    return;
+  }
+
+  ++stats.nbRequestsDone;
+
+  NbRequestType nbRequestsToConsider = std::min(stats.nbRequestsDone, kMaxLastNbRequestsToConsider);
+
+  // Update moving average
+  uint64_t sumResponseTime = static_cast<uint64_t>(stats.avgResponseTime) * (nbRequestsToConsider - 1);
+  sumResponseTime += responseTimeInMs;
+  uint64_t newAverageResponseTime = sumResponseTime / nbRequestsToConsider;
+  using RTType = decltype(stats.avgResponseTime);
+  if (newAverageResponseTime > static_cast<uint64_t>(std::numeric_limits<RTType>::max())) {
+    log::warn("Cannot update accurately the new average response time {} because of overflow", newAverageResponseTime);
+    stats.avgResponseTime = std::numeric_limits<RTType>::max();
+  } else {
+    stats.avgResponseTime = static_cast<RTType>(newAverageResponseTime);
+  }
+
+  // Update moving deviation
+  uint64_t sumDeviation = static_cast<uint64_t>(ipow(stats.avgDeviation, 2)) * (nbRequestsToConsider - 1);
+  sumDeviation += static_cast<uint64_t>(
+      ipow(static_cast<int64_t>(stats.avgResponseTime) - static_cast<int64_t>(responseTimeInMs), 2));
+  uint64_t newDeviationResponseTime = static_cast<uint64_t>(std::sqrt(sumDeviation / nbRequestsToConsider));
+  using DevType = decltype(stats.avgDeviation);
+  if (newDeviationResponseTime > static_cast<uint64_t>(std::numeric_limits<DevType>::max())) {
+    log::warn("Cannot update accurately the new deviation response time {} because of overflow",
+              newDeviationResponseTime);
+    stats.avgDeviation = std::numeric_limits<DevType>::max();
+  } else {
+    stats.avgDeviation = static_cast<DevType>(newDeviationResponseTime);
+  }
+
+  log::debug("Response time stats for '{}': Avg: {} ms, Dev: {} ms, Nb: {} (last: {} ms)", _pBaseUrls[baseUrlPos],
+             stats.avgResponseTime, stats.avgDeviation, stats.nbRequestsDone, responseTimeInMs);
+}
+}  // namespace cct

--- a/src/tools/test/besturlpicker_test.cpp
+++ b/src/tools/test/besturlpicker_test.cpp
@@ -1,0 +1,102 @@
+#include "besturlpicker.hpp"
+
+#include <gtest/gtest.h>
+
+namespace cct {
+namespace {
+constexpr std::string_view kSingleURL = "singleurl";
+constexpr std::string_view kSeveralURL[] = {"url1", "url2", "url3"};
+}  // namespace
+
+TEST(BestURLPicker, SingleURL) {
+  BestURLPicker bestURLPicker(kSingleURL);
+
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSingleURL);
+  EXPECT_EQ(bestURLPicker.nbBaseURL(), 1);
+
+  for (int requestPos = 0; requestPos < 20; ++requestPos) {
+    // Whatever the response time stats are, we should always return the unique URL that we stored.
+    EXPECT_EQ(bestURLPicker.nextBaseURLPos(), 0);
+    bestURLPicker.storeResponseTimePerBaseURL(0, requestPos * 10);
+  }
+}
+
+TEST(BestURLPicker, SeveralURL) {
+  BestURLPicker bestURLPicker(kSeveralURL);
+
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  EXPECT_EQ(bestURLPicker.nbBaseURL(), std::end(kSeveralURL) - std::begin(kSeveralURL));
+
+  // Store some response times
+
+  // For url 0, avg = 29, dev = 27.386127875
+  bestURLPicker.storeResponseTimePerBaseURL(0, 30);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 24);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 37);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 36);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 32);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 15);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 22);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 19);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 45);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 30);
+
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[1]);
+
+  // For url 1, avg = 41, dev = 23.452078799
+  bestURLPicker.storeResponseTimePerBaseURL(1, 35);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 35);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 37);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 62);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 41);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[1]);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 39);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 39);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 38);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 41);
+  bestURLPicker.storeResponseTimePerBaseURL(1, 43);
+
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+
+  // For url 2, avg = 32, dev = 14.662878299
+  bestURLPicker.storeResponseTimePerBaseURL(2, 27);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 27);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 29);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 44);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 33);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 31);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 31);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 30);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 33);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 35);
+
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  bestURLPicker.storeResponseTimePerBaseURL(2, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[2]);
+
+  // First URL should now be the best as we had good response times for the last queries
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+
+  // we should give 10 % of requests the chance to the least used URLs
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[1]);
+  bestURLPicker.storeResponseTimePerBaseURL(0, 28);
+  EXPECT_EQ(bestURLPicker.getNextBaseURL(), kSeveralURL[0]);
+}
+}  // namespace cct

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "cct_proxy.hpp"
+#include "curloptions.hpp"
 
 /* URL available to test HTTPS, cf
  * https://support.nmi.com/hc/en-gb/articles/360021544791-How-to-Check-If-the-Correct-Certificates-Are-Installed-on-Linux


### PR DESCRIPTION
Also refreshed the logic by calling least used base URL 10 % of the time to keep stats up-to date over time if `coincenter` is long running.