### PR TITLE
Better protection against extreme response time in URL base picker

### DIFF
--- a/src/tools/include/besturlpicker.hpp
+++ b/src/tools/include/besturlpicker.hpp
@@ -57,6 +57,8 @@ class BestURLPicker {
     uint16_t avgResponseTime;  // approximation of moving average
     uint16_t avgDeviation;     // approximation of moving standard deviation
 
+    bool operator==(const ResponseTimeStats &) const noexcept = default;
+
     uint32_t score() const { return static_cast<uint32_t>(avgResponseTime) + avgDeviation; }
   };
 


### PR DESCRIPTION
When the `BestURLPicker` gives chance to 10 % of requests to use another base URL, taking the ones with the least number of requests done, make sure it's not the same as the one which has the min score, to force these 10 % to be on a different URL.