### PR TITLE
Fix withdraw logs in Kraken. Also clean up returned objects from withdraw APIs

### DIFF
--- a/src/api-objects/include/recentdeposit.hpp
+++ b/src/api-objects/include/recentdeposit.hpp
@@ -17,6 +17,7 @@ class RecentDeposit {
 
   /// Select the RecentDeposit among given ones which is the closest to 'this' object.
   /// It may reorder the given vector but will not modify objects themselves.
+  /// Returns nullptr if no matching deposit has been found
   const RecentDeposit *selectClosestRecentDeposit(RecentDepositVector &recentDeposits) const;
 
   string str() const;

--- a/src/api-objects/src/withdrawinfo.cpp
+++ b/src/api-objects/src/withdrawinfo.cpp
@@ -4,7 +4,7 @@
 
 namespace cct {
 namespace api {
-InitiatedWithdrawInfo::InitiatedWithdrawInfo(Wallet receivingWallet, WithdrawIdView withdrawId,
+InitiatedWithdrawInfo::InitiatedWithdrawInfo(Wallet receivingWallet, std::string_view withdrawId,
                                              MonetaryAmount grossEmittedAmount, TimePoint initiatedTime)
     : _receivingWallet(std::move(receivingWallet)),
       _withdrawIdOrMsgIfNotInitiated(withdrawId),
@@ -12,20 +12,21 @@ InitiatedWithdrawInfo::InitiatedWithdrawInfo(Wallet receivingWallet, WithdrawIdV
       _grossEmittedAmount(grossEmittedAmount) {}
 }  // namespace api
 
-WithdrawInfo::WithdrawInfo(const api::InitiatedWithdrawInfo &initiatedWithdrawInfo,
-                           const api::SentWithdrawInfo &sentWithdrawInfo, TimePoint receivedTime)
-    : _receivingWallet(initiatedWithdrawInfo.receivingWallet()),
-      _withdrawIdOrMsgIfNotInitiated(initiatedWithdrawInfo.withdrawId()),
-      _initiatedTime(initiatedWithdrawInfo.initiatedTime()),
-      _receivedTime(receivedTime),
-      _grossAmount(initiatedWithdrawInfo.grossEmittedAmount()),
-      _netEmittedAmount(sentWithdrawInfo.netEmittedAmount()) {}
+WithdrawInfo::WithdrawInfo(const api::InitiatedWithdrawInfo &initiatedWithdrawInfo, MonetaryAmount receivedAmount,
+                           TimePoint receivedTime)
+    : _initiatedWithdrawInfo(initiatedWithdrawInfo), _receivedTime(receivedTime), _receivedAmount(receivedAmount) {}
 
-const WithdrawId &WithdrawInfo::withdrawId() const {
+WithdrawInfo::WithdrawInfo(api::InitiatedWithdrawInfo &&initiatedWithdrawInfo, MonetaryAmount receivedAmount,
+                           TimePoint receivedTime)
+    : _initiatedWithdrawInfo(std::move(initiatedWithdrawInfo)),
+      _receivedTime(receivedTime),
+      _receivedAmount(receivedAmount) {}
+
+std::string_view WithdrawInfo::withdrawId() const {
   if (!hasBeenInitiated()) {
     throw exception("Cannot retrieve withdraw id of an empty withdraw");
   }
-  return _withdrawIdOrMsgIfNotInitiated;
+  return _initiatedWithdrawInfo.withdrawId();
 }
 
 }  // namespace cct

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -109,6 +109,7 @@ class ExchangePrivate : public ExchangeBase {
   /// Returns the amounts actually traded with the final amount balance on this currency
   TradedAmountsVectorWithFinalAmount queryDustSweeper(CurrencyCode currencyCode);
 
+  /// Builds en ExchangeName wrapping the exchange and the key name
   ExchangeName exchangeName() const { return ExchangeName(_exchangePublic.name(), _apiKey.name()); }
 
   const ExchangeInfo &exchangeInfo() const { return _exchangePublic.exchangeInfo(); }
@@ -152,8 +153,8 @@ class ExchangePrivate : public ExchangeBase {
 
   /// Check if withdraw has been received by 'this' exchange.
   /// Default implementation is provided. It can be overriden if necessary.
-  virtual bool isWithdrawReceived(const InitiatedWithdrawInfo &initiatedWithdrawInfo,
-                                  const SentWithdrawInfo &sentWithdrawInfo);
+  virtual ReceivedWithdrawInfo isWithdrawReceived(const InitiatedWithdrawInfo &initiatedWithdrawInfo,
+                                                  const SentWithdrawInfo &sentWithdrawInfo);
 
   TradedAmounts marketTrade(MonetaryAmount from, const TradeOptions &options, Market m);
 

--- a/src/api/common/include/exchangeprivateapi_mock.hpp
+++ b/src/api/common/include/exchangeprivateapi_mock.hpp
@@ -29,7 +29,8 @@ class MockExchangePrivate : public ExchangePrivate {
   MOCK_METHOD(OrderInfo, queryOrderInfo, (const OrderRef &), (override));
   MOCK_METHOD(InitiatedWithdrawInfo, launchWithdraw, (MonetaryAmount, Wallet &&), (override));
   MOCK_METHOD(SentWithdrawInfo, isWithdrawSuccessfullySent, (const InitiatedWithdrawInfo &), (override));
-  MOCK_METHOD(bool, isWithdrawReceived, (const InitiatedWithdrawInfo &, const SentWithdrawInfo &), (override));
+  MOCK_METHOD(ReceivedWithdrawInfo, isWithdrawReceived, (const InitiatedWithdrawInfo &, const SentWithdrawInfo &),
+              (override));
 };
 
 }  // namespace cct::api

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -54,8 +54,8 @@ class BinancePrivate : public ExchangePrivate {
 
   SentWithdrawInfo isWithdrawSuccessfullySent(const InitiatedWithdrawInfo& initiatedWithdrawInfo) override;
 
-  bool isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWithdrawInfo,
-                          const SentWithdrawInfo& sentWithdrawInfo) override;
+  ReceivedWithdrawInfo isWithdrawReceived(const InitiatedWithdrawInfo& initiatedWithdrawInfo,
+                                          const SentWithdrawInfo& sentWithdrawInfo) override;
 
  private:
   OrderInfo queryOrder(const OrderRef& orderRef, bool isCancel);

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -707,7 +707,7 @@ SentWithdrawInfo BithumbPrivate::isWithdrawSuccessfullySent(const InitiatedWithd
       MonetaryAmount consumedAmt(std::string_view(unitsStr.begin() + first, unitsStr.end()), currencyCode);
       if (consumedAmt == initiatedWithdrawInfo.grossEmittedAmount()) {
         bool isWithdrawSuccess = searchGb == 5;
-        return SentWithdrawInfo(initiatedWithdrawInfo.grossEmittedAmount() - realFee, isWithdrawSuccess);
+        return SentWithdrawInfo(initiatedWithdrawInfo.grossEmittedAmount() - realFee, realFee, isWithdrawSuccess);
       }
       // TODO: Could we have rounding issues in case Bithumb returns to us a string representation of an amount coming
       // from a double? In this case, we should offer a security interval, for instance, accepting +- 1 % error.

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -153,7 +153,7 @@ MonetaryAmount KrakenPublic::queryWithdrawalFee(CurrencyCode currencyCode) {
   const WithdrawalFeeMap& withdrawalFeeMaps = _withdrawalFeesCache.get().first;
   auto foundIt = withdrawalFeeMaps.find(currencyCode);
   if (foundIt == withdrawalFeeMaps.end()) {
-    log::error("Unable to find {} withdrawal fee for {}", name(), currencyCode);
+    log::warn("Unable to find {} withdrawal fee for {}, consider 0 instead", name(), currencyCode);
     return MonetaryAmount(0, currencyCode);
   }
   return foundIt->second;

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -450,9 +450,9 @@ SentWithdrawInfo UpbitPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
   json result = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, "/v1/withdraw",
                              {{"currency", currencyCode.str()}, {"uuid", initiatedWithdrawInfo.withdrawId()}});
   MonetaryAmount withdrawFee = _exchangePublic.queryWithdrawalFee(currencyCode);
-  MonetaryAmount realFee(result["fee"].get<std::string_view>(), currencyCode);
-  if (realFee != withdrawFee) {
-    log::error("{} withdraw fee is {} instead of {}", _exchangePublic.name(), realFee, withdrawFee);
+  MonetaryAmount fee(result["fee"].get<std::string_view>(), currencyCode);
+  if (fee != withdrawFee) {
+    log::warn("{} withdraw fee is {} instead of {}", _exchangePublic.name(), fee, withdrawFee);
   }
   MonetaryAmount netEmittedAmount(result["amount"].get<std::string_view>(), currencyCode);
 
@@ -466,7 +466,7 @@ SentWithdrawInfo UpbitPrivate::isWithdrawSuccessfullySent(const InitiatedWithdra
     log::error("{} withdraw of {} has been cancelled", _exchangePublic.name(), currencyCode);
   }
   const bool isDone = stateUpperStr == "DONE";
-  return SentWithdrawInfo(netEmittedAmount, isDone || isCanceled);
+  return SentWithdrawInfo(netEmittedAmount, fee, isDone || isCanceled);
 }
 
 }  // namespace cct::api

--- a/src/engine/src/queryresultprinter.cpp
+++ b/src/engine/src/queryresultprinter.cpp
@@ -795,7 +795,7 @@ void QueryResultPrinter::printWithdraw(const WithdrawInfo &withdrawInfo, Monetar
                     "Net received amount");
       t.emplace_back(fromPrivateExchangeName.name(), toPrivateExchangeName.name(), grossAmount.str(),
                      ToString(withdrawInfo.initiatedTime()), ToString(withdrawInfo.receivedTime()),
-                     withdrawInfo.netEmittedAmount().str());
+                     withdrawInfo.receivedAmount().str());
       printTable(t);
       break;
     }
@@ -825,7 +825,7 @@ void QueryResultPrinter::printWithdraw(const WithdrawInfo &withdrawInfo, Monetar
       out.emplace("to", std::move(to));
       out.emplace("initiatedTime", ToString(withdrawInfo.initiatedTime()));
       out.emplace("receivedTime", ToString(withdrawInfo.receivedTime()));
-      out.emplace("netReceivedAmount", withdrawInfo.netEmittedAmount().amountStr());
+      out.emplace("netReceivedAmount", withdrawInfo.receivedAmount().amountStr());
 
       printJson(std::move(in), std::move(out));
       break;

--- a/src/engine/test/exchangesorchestrator_private_test.cpp
+++ b/src/engine/test/exchangesorchestrator_private_test.cpp
@@ -218,12 +218,12 @@ class ExchangeOrchestratorWithdrawTest : public ExchangeOrchestratorTest {
     api::InitiatedWithdrawInfo initiatedWithdrawInfo{receivingWallet, withdrawIdView, grossAmount};
     EXPECT_CALL(exchangePrivate1, launchWithdraw(grossAmount, std::move(receivingWallet)))
         .WillOnce(testing::Return(initiatedWithdrawInfo));
-    api::SentWithdrawInfo sentWithdrawInfo{netEmittedAmount, true};
+    api::SentWithdrawInfo sentWithdrawInfo{netEmittedAmount, fee, true};
     EXPECT_CALL(exchangePrivate1, isWithdrawSuccessfullySent(initiatedWithdrawInfo))
         .WillOnce(testing::Return(sentWithdrawInfo));
     EXPECT_CALL(exchangePrivate2, isWithdrawReceived(initiatedWithdrawInfo, sentWithdrawInfo))
-        .WillOnce(testing::Return(true));
-    return WithdrawInfo(initiatedWithdrawInfo, sentWithdrawInfo);
+        .WillOnce(testing::Return(api::ReceivedWithdrawInfo{netEmittedAmount, true}));
+    return WithdrawInfo(initiatedWithdrawInfo, netEmittedAmount);
   }
 
   CurrencyCode cur{"XRP"};
@@ -233,7 +233,7 @@ class ExchangeOrchestratorWithdrawTest : public ExchangeOrchestratorTest {
   std::string_view address{"TestAddress"};
   std::string_view tag{"TestTag"};
 
-  WithdrawIdView withdrawIdView{"WithdrawId"};
+  std::string_view withdrawIdView{"WithdrawId"};
 
   MonetaryAmount fee{"0.02", cur};
 };

--- a/src/engine/test/queryresultprinter_test.cpp
+++ b/src/engine/test/queryresultprinter_test.cpp
@@ -1983,16 +1983,17 @@ class QueryResultPrinterWithdrawTest : public QueryResultPrinterTest {
  protected:
   MonetaryAmount grossAmount{"76.55 XRP"};
   MonetaryAmount netEmittedAmount{"75.55 XRP"};
+  MonetaryAmount fee = grossAmount - netEmittedAmount;
   bool isWithdrawSent = true;
   ExchangeName fromExchange{exchange1.apiPrivate().exchangeName()};
   ExchangeName toExchange{exchange4.apiPrivate().exchangeName()};
 
   Wallet receivingWallet{toExchange, grossAmount.currencyCode(), "xrpaddress666", "xrptag2", WalletCheck{}};
-  WithdrawIdView withdrawId = "WithdrawTest01";
+  std::string_view withdrawId = "WithdrawTest01";
   MonetaryAmount grossEmittedAmount;
   api::InitiatedWithdrawInfo initiatedWithdrawInfo{receivingWallet, withdrawId, grossAmount, tp1};
-  api::SentWithdrawInfo sentWithdrawInfo{netEmittedAmount, isWithdrawSent};
-  WithdrawInfo withdrawInfo{initiatedWithdrawInfo, sentWithdrawInfo, tp2};
+  api::SentWithdrawInfo sentWithdrawInfo{netEmittedAmount, fee, isWithdrawSent};
+  WithdrawInfo withdrawInfo{initiatedWithdrawInfo, netEmittedAmount, tp2};
 };
 
 class QueryResultPrinterWithdrawAmountTest : public QueryResultPrinterWithdrawTest {

--- a/src/objects/test/exchangename_test.cpp
+++ b/src/objects/test/exchangename_test.cpp
@@ -53,12 +53,22 @@ TEST(ExchangeName, Equality) {
   EXPECT_NE(ExchangeName("upbit", "_user13"), ExchangeName("binance", "_user13"));
 }
 
-TEST(ExchangeName, Format) {
-  EXPECT_EQ(fmt::format("{}", ExchangeName("binance_key")), "binance");
-  EXPECT_EQ(fmt::format("{:e}", ExchangeName("binance_key")), "binance");
-  EXPECT_EQ(fmt::format("{:n}", ExchangeName("binance_key")), "binance");
-  EXPECT_EQ(fmt::format("{:k}", ExchangeName("binance_key")), "key");
-  EXPECT_EQ(fmt::format("{:ek}", ExchangeName("binance_key")), "binance_key");
+TEST(ExchangeName, FormatWithoutKey) {
+  ExchangeName en("kraken");
+  EXPECT_EQ(fmt::format("{}", en), "kraken");
+  EXPECT_EQ(fmt::format("{:e}", en), "kraken");
+  EXPECT_EQ(fmt::format("{:n}", en), "kraken");
+  EXPECT_EQ(fmt::format("{:k}", en), "");
+  EXPECT_EQ(fmt::format("{:ek}", en), "kraken");
+}
+
+TEST(ExchangeName, FormatWithKey) {
+  ExchangeName en("binance_key");
+  EXPECT_EQ(fmt::format("{}", en), "binance_key");
+  EXPECT_EQ(fmt::format("{:e}", en), "binance");
+  EXPECT_EQ(fmt::format("{:n}", en), "binance");
+  EXPECT_EQ(fmt::format("{:k}", en), "key");
+  EXPECT_EQ(fmt::format("{:ek}", en), "binance_key");
 }
 
 }  // namespace cct


### PR DESCRIPTION
Avoid spamming scaring logs when withdrawing from Kraken with a coin that has no withdrawal fee data (it is retrieved from best effort mode from a scraped web page as Kraken does not provide a stable API to retrieve withdrawal fees):
```
[2023-01-19 21:40:49.602] [warning] Kraken withdraw fee is 0.02 XRP instead of parsed 0 XRP
[2023-01-19 21:40:54.602] [error] Unable to find kraken withdrawal fee for XRP
[2023-01-19 21:40:54.602] [info] POST https://api.kraken.com/0/private/WithdrawStatus?asset=XRP&nonce=1674160854602
[2023-01-19 21:40:54.824] [warning] Kraken withdraw fee is 0.02 XRP instead of parsed 0 XRP
[2023-01-19 21:40:59.824] [error] Unable to find kraken withdrawal fee for XRP
[2023-01-19 21:40:59.824] [info] POST https://api.kraken.com/0/private/WithdrawStatus?asset=XRP&nonce=1674160859824
[2023-01-19 21:41:00.149] [warning] Kraken withdraw fee is 0.02 XRP instead of parsed 0 XRP
[2023-01-19 21:41:05.149] [error] Unable to find kraken withdrawal fee for XRP
[2023-01-19 21:41:05.149] [info] POST https://api.kraken.com/0/private/WithdrawStatus?asset=XRP&nonce=1674160865149
```

In fact it's harmless for the withdraw as Kraken withdraw POST query relies on gross amount so the fee is not used in the API, only for traces.

Also clean-up and simplify withdraw sub API queries returned objects and definitions.