### PR TITLE
TradeInfo objects refactoring

### DIFF
--- a/src/api-objects/include/tradeinfo.hpp
+++ b/src/api-objects/include/tradeinfo.hpp
@@ -9,35 +9,25 @@
 
 namespace cct::api {
 
-struct OrderRef {
-#ifndef CCT_AGGR_INIT_CXX20
-  OrderRef(const OrderId &orderId, int64_t nbSecondsSinceEpoch, Market market, TradeSide s)
-      : id(orderId), userRef(nbSecondsSinceEpoch), m(market), side(s) {}
-#endif
+using UserRefInt = int32_t;
+
+struct TradeContext {
+  TradeContext(Market market, TradeSide s, UserRefInt userRef = 0) : m(market), side(s), userRef(userRef) {}
 
   CurrencyCode fromCur() const { return side == TradeSide::kSell ? m.base() : m.quote(); }
   CurrencyCode toCur() const { return side == TradeSide::kBuy ? m.base() : m.quote(); }
 
-  const OrderId &id;
-  int64_t userRef;  // Used by Kraken for instance, used to group orders queries context
   Market m;
   TradeSide side;
+  UserRefInt userRef;  // Used by Kraken for instance, used to group orders queries context
 };
 
 struct TradeInfo {
 #ifndef CCT_AGGR_INIT_CXX20
-  TradeInfo(int64_t nbSecondsSinceEpoch, Market market, TradeSide s, const TradeOptions &opts)
-      : userRef(nbSecondsSinceEpoch), m(market), side(s), options(opts) {}
+  TradeInfo(const TradeContext &tradeContext, const TradeOptions &opts) : tradeContext(tradeContext), options(opts) {}
 #endif
 
-  CurrencyCode fromCur() const { return side == TradeSide::kSell ? m.base() : m.quote(); }
-  CurrencyCode toCur() const { return side == TradeSide::kBuy ? m.base() : m.quote(); }
-
-  OrderRef createOrderRef(const OrderId &orderId) const { return OrderRef(orderId, userRef, m, side); }
-
-  int64_t userRef;  // Used by Kraken for instance, used to group orders queries context
-  Market m;
-  TradeSide side;
+  TradeContext tradeContext;
   TradeOptions options;
 };
 

--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -139,11 +139,11 @@ class ExchangePrivate : public ExchangeBase {
   /// Cancel given order id and return its possible matched amounts.
   /// When this methods ends, order should be successfully cancelled and its matched parts returned definitely (trade
   /// automaton will not come back on this order later on)
-  virtual OrderInfo cancelOrder(const OrderRef &orderRef) = 0;
+  virtual OrderInfo cancelOrder(OrderIdView orderId, const TradeContext &tradeContext) = 0;
 
   /// Query an order and return and 'OrderInfo' with its matched parts and if it is closed or not (closed means that its
   /// status and matched parts will not evolve in the future).
-  virtual OrderInfo queryOrderInfo(const OrderRef &orderRef) = 0;
+  virtual OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext &tradeContext) = 0;
 
   /// Orders a withdraw in mode fire and forget.
   virtual InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet &&wallet) = 0;

--- a/src/api/common/include/exchangeprivateapi_mock.hpp
+++ b/src/api/common/include/exchangeprivateapi_mock.hpp
@@ -25,8 +25,8 @@ class MockExchangePrivate : public ExchangePrivate {
 
   MOCK_METHOD(PlaceOrderInfo, placeOrder, (MonetaryAmount, MonetaryAmount, MonetaryAmount, const TradeInfo &),
               (override));
-  MOCK_METHOD(OrderInfo, cancelOrder, (const OrderRef &), (override));
-  MOCK_METHOD(OrderInfo, queryOrderInfo, (const OrderRef &), (override));
+  MOCK_METHOD(OrderInfo, cancelOrder, (OrderIdView, const TradeContext &), (override));
+  MOCK_METHOD(OrderInfo, queryOrderInfo, (OrderIdView, const TradeContext &), (override));
   MOCK_METHOD(InitiatedWithdrawInfo, launchWithdraw, (MonetaryAmount, Wallet &&), (override));
   MOCK_METHOD(SentWithdrawInfo, isWithdrawSuccessfullySent, (const InitiatedWithdrawInfo &), (override));
   MOCK_METHOD(ReceivedWithdrawInfo, isWithdrawReceived, (const InitiatedWithdrawInfo &, const SentWithdrawInfo &),

--- a/src/api/exchanges/include/binanceprivateapi.hpp
+++ b/src/api/exchanges/include/binanceprivateapi.hpp
@@ -46,9 +46,13 @@ class BinancePrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override { return queryOrder(orderRef, HttpRequestType::kDelete); }
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override {
+    return queryOrder(orderId, tradeContext, HttpRequestType::kDelete);
+  }
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override { return queryOrder(orderRef, HttpRequestType::kGet); }
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override {
+    return queryOrder(orderId, tradeContext, HttpRequestType::kGet);
+  }
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
 
@@ -58,7 +62,7 @@ class BinancePrivate : public ExchangePrivate {
                                           const SentWithdrawInfo& sentWithdrawInfo) override;
 
  private:
-  OrderInfo queryOrder(const OrderRef& orderRef, HttpRequestType requestType);
+  OrderInfo queryOrder(OrderIdView orderId, const TradeContext& tradeContext, HttpRequestType requestType);
 
   bool checkMarketAppendSymbol(Market m, CurlPostData& params);
 

--- a/src/api/exchanges/include/bithumbprivateapi.hpp
+++ b/src/api/exchanges/include/bithumbprivateapi.hpp
@@ -43,9 +43,9 @@ class BithumbPrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override;
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override;
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override;
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override;
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
 
@@ -65,7 +65,7 @@ class BithumbPrivate : public ExchangePrivate {
     BithumbPublic& _exchangePublic;
   };
 
-  void cancelOrderProcess(const OrderRef& orderRef);
+  void cancelOrderProcess(OrderIdView orderId, const TradeContext& tradeContext);
 
   struct CurrencyOrderInfo {
     int8_t nbDecimals{};

--- a/src/api/exchanges/include/huobiprivateapi.hpp
+++ b/src/api/exchanges/include/huobiprivateapi.hpp
@@ -40,18 +40,18 @@ class HuobiPrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override;
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override;
 
   int batchCancel(const OrdersConstraints::OrderIdSet& orderIdSet);
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override;
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override;
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
 
   SentWithdrawInfo isWithdrawSuccessfullySent(const InitiatedWithdrawInfo& initiatedWithdrawInfo) override;
 
  private:
-  void cancelOrderProcess(const OrderId& id);
+  void cancelOrderProcess(OrderIdView orderId);
 
   struct AccountIdFunc {
 #ifndef CCT_AGGR_INIT_CXX20

--- a/src/api/exchanges/include/krakenprivateapi.hpp
+++ b/src/api/exchanges/include/krakenprivateapi.hpp
@@ -43,10 +43,10 @@ class KrakenPrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override;
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override;
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override {
-    return queryOrderInfo(orderRef, QueryOrder::kOpenedThenClosed);
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override {
+    return queryOrderInfo(orderId, tradeContext, QueryOrder::kOpenedThenClosed);
   }
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
@@ -67,11 +67,11 @@ class KrakenPrivate : public ExchangePrivate {
     KrakenPublic& _exchangePublic;
   };
 
-  json queryOrdersData(int64_t userRef, const OrderId& orderId, QueryOrder queryOrder);
+  json queryOrdersData(int64_t userRef, OrderIdView orderId, QueryOrder queryOrder);
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef, QueryOrder queryOrder);
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext, QueryOrder queryOrder);
 
-  void cancelOrderProcess(const OrderId& id);
+  void cancelOrderProcess(OrderIdView orderId);
 
   CurlHandle _curlHandle;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;

--- a/src/api/exchanges/include/kucoinprivateapi.hpp
+++ b/src/api/exchanges/include/kucoinprivateapi.hpp
@@ -40,9 +40,9 @@ class KucoinPrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override;
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override;
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override;
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override;
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
 
@@ -62,7 +62,7 @@ class KucoinPrivate : public ExchangePrivate {
     const KucoinPublic& _kucoinPublic;
   };
 
-  void cancelOrderProcess(const OrderId& id);
+  void cancelOrderProcess(OrderIdView orderId);
 
   CurlHandle _curlHandle;
   CachedResult<DepositWalletFunc, CurrencyCode> _depositWalletsCache;

--- a/src/api/exchanges/include/upbitprivateapi.hpp
+++ b/src/api/exchanges/include/upbitprivateapi.hpp
@@ -45,9 +45,9 @@ class UpbitPrivate : public ExchangePrivate {
   PlaceOrderInfo placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                             const TradeInfo& tradeInfo) override;
 
-  OrderInfo cancelOrder(const OrderRef& orderRef) override;
+  OrderInfo cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) override;
 
-  OrderInfo queryOrderInfo(const OrderRef& orderRef) override;
+  OrderInfo queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) override;
 
   InitiatedWithdrawInfo launchWithdraw(MonetaryAmount grossAmount, Wallet&& wallet) override;
 

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -279,8 +279,8 @@ Deposits KucoinPrivate::queryRecentDeposits(const DepositsConstraints& depositsC
 
 PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount volume, MonetaryAmount price,
                                          const TradeInfo& tradeInfo) {
-  const CurrencyCode fromCurrencyCode(tradeInfo.fromCur());
-  const CurrencyCode toCurrencyCode(tradeInfo.toCur());
+  const CurrencyCode fromCurrencyCode(tradeInfo.tradeContext.fromCur());
+  const CurrencyCode toCurrencyCode(tradeInfo.tradeContext.toCur());
 
   PlaceOrderInfo placeOrderInfo(OrderInfo(TradedAmounts(fromCurrencyCode, toCurrencyCode)), OrderId("UndefinedId"));
 
@@ -289,7 +289,7 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
     return placeOrderInfo;
   }
 
-  const Market m = tradeInfo.m;
+  const Market m = tradeInfo.tradeContext.m;
 
   bool isTakerStrategy = tradeInfo.options.isTakerStrategy(_exchangePublic.exchangeInfo().placeSimulateRealOrder());
 
@@ -330,22 +330,22 @@ PlaceOrderInfo KucoinPrivate::placeOrder(MonetaryAmount from, MonetaryAmount vol
   return placeOrderInfo;
 }
 
-OrderInfo KucoinPrivate::cancelOrder(const OrderRef& orderRef) {
-  cancelOrderProcess(orderRef.id);
-  return queryOrderInfo(orderRef);
+OrderInfo KucoinPrivate::cancelOrder(OrderIdView orderId, const TradeContext& tradeContext) {
+  cancelOrderProcess(orderId);
+  return queryOrderInfo(orderId, tradeContext);
 }
 
-void KucoinPrivate::cancelOrderProcess(const OrderId& id) {
+void KucoinPrivate::cancelOrderProcess(OrderIdView id) {
   string endpoint("/api/v1/orders/");
   endpoint.append(id);
   PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kDelete, endpoint);
 }
 
-OrderInfo KucoinPrivate::queryOrderInfo(const OrderRef& orderRef) {
-  const CurrencyCode fromCurrencyCode(orderRef.fromCur());
-  const Market m = orderRef.m;
+OrderInfo KucoinPrivate::queryOrderInfo(OrderIdView orderId, const TradeContext& tradeContext) {
+  const CurrencyCode fromCurrencyCode(tradeContext.fromCur());
+  const Market m = tradeContext.m;
   string endpoint = "/api/v1/orders/";
-  endpoint.append(orderRef.id);
+  endpoint.append(orderId);
 
   json data = PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kGet, endpoint);
 

--- a/src/objects/include/orderid.hpp
+++ b/src/objects/include/orderid.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <span>
+#include <string_view>
 
 #include "cct_string.hpp"
 
 namespace cct {
 using OrderId = string;
+using OrderIdView = std::string_view;
 using OrderIds = std::span<const OrderId>;
 }  // namespace cct


### PR DESCRIPTION
Avoid storing reference inside an object (OrderRef) which has been removed.
Changed `userRef` used by Kraken as a 32 bits integer (as it is in Kraken REST API documentation).