### PR TITLE
Huobi - fix exception when parsing chain names

### DIFF
--- a/src/api/exchanges/include/huobipublicapi.hpp
+++ b/src/api/exchanges/include/huobipublicapi.hpp
@@ -166,6 +166,8 @@ class HuobiPublic : public ExchangePublic {
 
   WithdrawParams getWithdrawParams(CurrencyCode cur);
 
+  bool shouldDiscardChain(CurrencyCode cur, const json& chainDetail) const;
+
   const ExchangeInfo& _exchangeInfo;
   CurlHandle _curlHandle;
   CurlHandle _healthCheckCurlHandle;

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -10,6 +10,8 @@
 #include "cct_format.hpp"
 #include "cct_hash.hpp"
 #include "cct_invalid_argument_exception.hpp"
+#include "cct_string.hpp"
+#include "toupperlower.hpp"
 
 namespace cct {
 
@@ -154,6 +156,24 @@ class CurrencyCode {
     string s;
     appendStr(s);
     return s;
+  }
+
+  /// Return true if this currency code acronym is equal to given string.
+  /// Comparison is case insensitive.
+  constexpr bool iequal(std::string_view curStr) const {
+    if (curStr.size() > kMaxLen) {
+      return false;
+    }
+    for (uint32_t charPos = 0; charPos < kMaxLen; ++charPos) {
+      char c = (*this)[charPos];
+      if (c == CurrencyCodeBase::kFirstAuthorizedLetter) {
+        return curStr.size() == charPos;
+      }
+      if (curStr.size() == charPos || c != toupper(curStr[charPos])) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Append currency string representation to given string.

--- a/src/objects/test/currencycode_test.cpp
+++ b/src/objects/test/currencycode_test.cpp
@@ -77,6 +77,22 @@ TEST(CurrencyCodeTest, InvalidString) {
   EXPECT_THROW(CurrencyCode("invchar~"), invalid_argument);
 }
 
+TEST(CurrencyCodeTest, IEqual) {
+  static_assert(CurrencyCode("XRP").iequal("xrP"));
+  EXPECT_TRUE(CurrencyCode("eur").iequal("EUR"));
+  EXPECT_TRUE(CurrencyCode("eur").iequal("Eur"));
+  EXPECT_TRUE(CurrencyCode("BABYDOGE").iequal("babyDoge"));
+  EXPECT_TRUE(CurrencyCode("1INCH").iequal("1INCH"));
+
+  static_assert(!CurrencyCode("XRP").iequal("XRG"));
+  EXPECT_FALSE(CurrencyCode("eur").iequal("FUR"));
+  EXPECT_FALSE(CurrencyCode("eur").iequal("EUH"));
+  EXPECT_FALSE(CurrencyCode("BABYDOGE").iequal("babyoge"));
+  EXPECT_FALSE(CurrencyCode("BABYDOGE").iequal("babyDog"));
+  EXPECT_FALSE(CurrencyCode("inch").iequal("1INCH"));
+  EXPECT_FALSE(CurrencyCode("1inc").iequal("1INCH"));
+}
+
 TEST(CurrencyCodeTest, Size) {
   EXPECT_EQ(0U, CurrencyCode("").size());
   EXPECT_EQ(1U, CurrencyCode("1").size());


### PR DESCRIPTION
Do not create a `CurrencyCode` from a chainName as its length can exceed `CurrencyCode`'s limit and it's not necessary for string comparison.