### PR TITLE
Dropped support for GCC 10 and clang 13

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,46 +1,37 @@
 ---
 Checks: "-*,\
-bugprone-*,\
--bugprone-easily-swappable-parameters,\
--bugprone-implicit-widening-of-multiplication-result,\
--bugprone-macro-parentheses,\
--bugprone-misplaced-widening-cast,\
--bugprone-narrowing-conversions,\
--bugprone-too-small-loop-variable,\
-google-readability-casting,\
-misc-*,\
--misc-no-recursion,\
--misc-non-private-member-variables-in-classes,\
--misc-static-assert,\
-modernize-*,\
--modernize-avoid-c-arrays,\
--modernize-return-braced-init-list,\
--modernize-use-nodiscard,\
--modernize-use-noexcept,\
--modernize-use-trailing-return-type,\
--modernize-use-transparent-functors,\
-performance-*,\
--performance-move-const-arg,\
-readability-*,\
--readability-function-cognitive-complexity,\
--readability-function-size,\
--readability-identifier-naming,\
--readability-implicit-bool-conversion,\
--readability-inconsistent-declaration-parameter-name,\
--readability-magic-numbers,\
--readability-named-parameter,\
--readability-qualified-auto,\
--readability-redundant-declaration,\
--readability-redundant-member-init,\
--readability-suspicious-call-argument,\
--readability-uppercase-literal-suffix,\
-"
+  bugprone-*,\
+  -bugprone-implicit-widening-of-multiplication-result,\
+  -bugprone-misplaced-widening-cast,\
+  -bugprone-narrowing-conversions,\
+  -bugprone-too-small-loop-variable,\
+  google-readability-casting,\
+  misc-*,\
+  -misc-no-recursion,\
+  -misc-non-private-member-variables-in-classes,\
+  modernize-*,\
+  -modernize-avoid-c-arrays,\
+  -modernize-return-braced-init-list,\
+  -modernize-use-nodiscard,\
+  -modernize-use-noexcept,\
+  -modernize-use-trailing-return-type,\
+  performance-*,\
+  readability-*,\
+  -readability-function-cognitive-complexity,\
+  -readability-identifier-naming,\
+  -readability-magic-numbers,\
+  -readability-qualified-auto,\
+  -readability-uppercase-literal-suffix,\
+  "
 HeaderFilterRegex: 'Source/cm[^/]*\.(h|hxx|cxx)$'
 CheckOptions:
-  - key:   modernize-use-default-member-init.UseAssignment
-    value: '1'
-  - key:   modernize-use-equals-default.IgnoreMacros
-    value: '0'
-  - key:   modernize-use-auto.MinTypeNameLength
-    value: '80'
-...
+  - key: modernize-use-equals-default.IgnoreMacros
+    value: "0"
+  - key: modernize-use-auto.MinTypeNameLength
+    value: "20"
+  - key: performance-move-const-arg.CheckTriviallyCopyableMove
+    value: "false"
+  - key: readability-identifier-length.MinimumParameterNameLength
+    value: "2"
+  - key: readability-identifier-length.MinimumVariableNameLength
+    value: "2"

--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,1 +1,3 @@
 **/json.hpp
+
+*/_deps/*

--- a/.github/workflows/ubuntu-clang-tidy.yml
+++ b/.github/workflows/ubuntu-clang-tidy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [clang++-13]
+        clang-version: [14]
         buildmode: [Debug]
 
     steps:
@@ -23,16 +23,11 @@ jobs:
         run: |
           sudo apt update && sudo apt install libcurl4-gnutls-dev ninja-build
 
-      - name: Install clang
+      - name: Install clang (with clang-tidy)
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 13
-
-      - name: Install clang-tidy
-        run: |
-          sudo apt install clang-tidy-13
-          sudo ln -sf /usr/bin/clang-tidy-13 /usr/bin/clang-tidy
+          sudo ./llvm.sh ${{matrix.clang-version}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -40,7 +35,9 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCCT_ENABLE_CLANG_TIDY=ON -GNinja
+        run: |
+          clang-tidy --dump-config
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${{matrix.buildmode}} -DCMAKE_CXX_COMPILER=clang++-${{matrix.clang-version}} -DCCT_ENABLE_CLANG_TIDY=ON -DCCT_ENABLE_ASAN=OFF -GNinja
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu-monitoring.yml
+++ b/.github/workflows/ubuntu-monitoring.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++-10]
+        compiler: [g++-11]
         buildmode: [Debug]
         build-prometheus-from-source: [0, 1]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,10 +42,25 @@ docker run --mount type=bind,source=<path-to-data-dir-on-host>,target=/app/data 
 
 ## Prerequisites
 
+This is a **C++20** project.
+
+It's still currently (as of beginning of 2023) not fully supported by any compiler (although GCC is very close, see [here](https://en.cppreference.com/w/cpp/compiler_support)).
+
+But they have partial support which is sufficient to build `coincenter`.
+
+The following compilers are known to compile `coincenter` (and are tested in the CI):
+
+- **GCC** version >= 11
+- **Clang** version >= 14
+- **MSVC** version >= 19.30
+
+Other compilers have not been tested.
+
+In addition, the basic minimum requirements are:
+
 - **Git**
-- **C++** compiler supporting C++20 (gcc >= 10, clang >= 13, MSVC >= 19.30).
 - **CMake** >= 3.15
-- **curl** >= 7.58.0 (it may work with an earlier version, it's just the minimum tested)
+- **curl** >= 7.58.0 (it may work with an earlier version, it's just the minimum tested on **Ubuntu 18**)
 - **openssl** >= 1.1.0
 
 ### Linux
@@ -53,17 +68,18 @@ docker run --mount type=bind,source=<path-to-data-dir-on-host>,target=/app/data 
 #### Debian / Ubuntu
 
 ```
-sudo apt update && sudo apt install libcurl4-gnutls-dev libssl-dev cmake g++-10
+sudo apt update && sudo apt install libcurl4-gnutls-dev libssl-dev cmake g++-11
 ```
 
 #### Alpine
 
 With `ninja` generator for instance:
+
 ```
 sudo apk update && sudo apk upgrade && sudo apk add g++ libc-dev curl-dev cmake ninja git linux-headers
 ```
 
-You can refer to the provided `Dockerfile` for more information.
+You can refer to the provided [Dockerfile](Dockerfile) for more information.
 
 ### Windows
 
@@ -80,7 +96,7 @@ Then, locate where curl is installed (by default, should be in `C:\ProgramData\c
 ### External libraries
 
 `coincenter` uses various external open source libraries.
-In all cases, they do not need to be installed. If they are not found at configure time, `cmake` will fetch sources and compile them automatically. 
+In all cases, they do not need to be installed. If they are not found at configure time, `cmake` will fetch sources and compile them automatically.
 If you are building frequently `coincenter` you can install them to speed up its compilation.
 
 | Library                                                        | Description                                        | License              |
@@ -94,14 +110,9 @@ If you are building frequently `coincenter` you can install them to speed up its
 
 ### With cmake
 
-This is a **C++20** project.
+This project can be easily built with [cmake](https://cmake.org/).
 
-The following compilers and their versions have been tested (and are tested in the CI):
- - GCC version >= 10
- - Clang version >= 13
- - MSVC version >= 19.30
-
-Other compilers have not been tested yet.
+The minimum tested version is cmake `3.15`.
 
 #### cmake build options
 
@@ -113,6 +124,7 @@ Other compilers have not been tested yet.
 | `CCT_ENABLE_CLANG_TIDY` | `ON` if Debug mode and `clang-tidy` is found in `PATH` | Compile with clang-tidy checks                  |
 
 Example on Linux: to compile it in `Release` mode and `ninja` generator
+
 ```
 mkdir -p build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release .. && ninja
 ```
@@ -124,6 +136,7 @@ On Windows, you can use your preferred IDE to build `coincenter` (**Visual Studi
 **coincenter** can also be used as a sub project, such as a trading bot for instance. It is the case by default if built as a sub-module in `cmake`.
 
 To build your `cmake` project with **coincenter** library, you can do it with `FetchContent`:
+
 ```
 include(FetchContent)
 
@@ -135,14 +148,16 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(coincenter)
 ```
+
 Then, a static library named `coincenter` is defined and you can link it as usual:
+
 ```
 target_link_libraries(<MyProgram> PRIVATE coincenter)
 ```
 
 ### Build with monitoring support
 
-You can build `coincenter` with [prometheus-cpp](https://github.com/jupp0r/prometheus-cpp) if needed. 
+You can build `coincenter` with [prometheus-cpp](https://github.com/jupp0r/prometheus-cpp) if needed.
 If you have it installed on your machine, `cmake` will link coincenter with it. Otherwise you can still activate `cmake` flag `CCT_BUILD_PROMETHEUS_FROM_SRC` (default to OFF) to build it automatically from sources with `FetchContent`.
 
 ### With Docker

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -71,7 +71,7 @@ std::optional<MonetaryAmount> ExchangePublic::convert(MonetaryAmount a, Currency
 
 namespace {
 
-// Optimized struct containing a currency and a reverse bool to keep market directionnality information
+// Optimized struct containing a currency and a reverse bool to keep market directionality information
 struct CurrencyDir {
 #ifndef CCT_AGGR_INIT_CXX20
   CurrencyDir(CurrencyCode c, bool b) : cur(c), isLastRealMarketReversed(b) {}

--- a/src/engine/src/queryresultprinter.cpp
+++ b/src/engine/src/queryresultprinter.cpp
@@ -904,11 +904,7 @@ void QueryResultPrinter::printTable(const SimpleTable &t) const {
     *_pOs << std::endl;
   } else {
     // logger library automatically adds a newline as suffix
-#ifdef CCT_STRINGSTREAM_HAS_VIEW
     _outputLogger->info(ss.view());
-#else
-    _outputLogger->info(ss.str());
-#endif
   }
 }
 

--- a/src/engine/test/queryresultprinter_test.cpp
+++ b/src/engine/test/queryresultprinter_test.cpp
@@ -19,30 +19,18 @@ class QueryResultPrinterTest : public ExchangesBaseTest {
 
   void SetUp() override { ss.clear(); }
 
-#ifdef CCT_STRINGSTREAM_HAS_VIEW
   void expectNoStr() const { EXPECT_TRUE(ss.view().empty()); }
-#else
-  void expectNoStr() const { EXPECT_TRUE(ss.str().empty()); }
-#endif
 
   void expectStr(std::string_view expected) const {
     ASSERT_FALSE(expected.empty());
     expected.remove_prefix(1);  // skip first newline char of expected string
-#ifdef CCT_STRINGSTREAM_HAS_VIEW
     EXPECT_EQ(ss.view(), expected);
-#else
-    EXPECT_EQ(ss.str(), expected);
-#endif
   }
 
   void expectJson(std::string_view expected) const {
     ASSERT_FALSE(expected.empty());
     expected.remove_prefix(1);  // skip first newline char of expected string
-#ifdef CCT_STRINGSTREAM_HAS_VIEW
     EXPECT_EQ(json::parse(ss.view()), json::parse(expected));
-#else
-    EXPECT_EQ(json::parse(ss.str()), json::parse(expected));
-#endif
   }
 
   std::ostringstream ss;

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -158,12 +158,7 @@ MonetaryAmount::MonetaryAmount(double amount, CurrencyCode currencyCode) : _curW
   std::stringstream amtBuf;
   amtBuf << std::setprecision(kNbMaxDoubleDecimals) << std::fixed << amount;
   int8_t nbDecimals;
-#ifdef CCT_STRINGSTREAM_HAS_VIEW
   std::string_view strView = amtBuf.view();
-#else
-  auto str = amtBuf.str();
-  std::string_view strView = str;
-#endif
   const int negMult = ParseNegativeChar(strView);
 
   std::tie(_amount, nbDecimals) = AmountIntegralFromStr(strView, true);

--- a/src/tech/include/cct_config.hpp
+++ b/src/tech/include/cct_config.hpp
@@ -64,8 +64,3 @@
 // https://stackoverflow.com/questions/70260994/automatic-template-deduction-c20-with-aggregate-type
 #define CCT_AGGR_INIT_CXX20
 #endif
-
-#if defined(CCT_MSVC) || (defined(CCT_GCC) && CCT_GCC >= 110000)
-// std::stringstream::view is not yet implemented for many compilers.
-#define CCT_STRINGSTREAM_HAS_VIEW
-#endif


### PR DESCRIPTION
`coincenter` will now require gcc >= 11 or clang >= 14.