### PR TITLE
Simplify centralized trade algorithm

### DIFF
--- a/src/api/common/include/exchangeprivateapi.hpp
+++ b/src/api/common/include/exchangeprivateapi.hpp
@@ -156,7 +156,7 @@ class ExchangePrivate : public ExchangeBase {
   virtual ReceivedWithdrawInfo isWithdrawReceived(const InitiatedWithdrawInfo &initiatedWithdrawInfo,
                                                   const SentWithdrawInfo &sentWithdrawInfo);
 
-  TradedAmounts marketTrade(MonetaryAmount from, const TradeOptions &options, Market mk);
+  TradedAmounts marketTrade(MonetaryAmount from, const TradeOptions &tradeOptions, Market mk);
 
   ExchangePublic &_exchangePublic;
   CachedResultVault &_cachedResultVault{_exchangePublic._cachedResultVault};

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -69,8 +69,8 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, std::string_view
   }
   if (errorIt != ret.end() && !errorIt->empty()) {
     std::string_view msg = errorIt->front().get<std::string_view>();
-    if (method.ends_with("CancelOrder") && msg == "EOrder:Unknown order") {
-      log::warn("Unknown order from Kraken CancelOrder. Assuming closed order");
+    if (method.ends_with("CancelOrder") && msg.ends_with("Unknown order")) {
+      log::warn("No data for order, probably expired");
       ret = json::parse(R"({" error ":[]," result ":{" count ":1}})");
     } else {
       log::error("Full Kraken json error: '{}'", ret.dump());

--- a/src/tech/src/unitsparser.cpp
+++ b/src/tech/src/unitsparser.cpp
@@ -10,8 +10,8 @@ int64_t ParseNumberOfBytes(std::string_view sizeStr) {
   if (endPos == std::string_view::npos) {
     endPos = sizeStr.size();
   }
-  int64_t v = FromString<int64_t>(std::string_view(sizeStr.begin(), sizeStr.begin() + endPos));
-  if (v < 0) {
+  int64_t nbBytes = FromString<int64_t>(std::string_view(sizeStr.begin(), sizeStr.begin() + endPos));
+  if (nbBytes < 0) {
     throw exception("Number of bytes cannot be negative");
   }
   int64_t multiplier = 1;
@@ -40,7 +40,7 @@ int64_t ParseNumberOfBytes(std::string_view sizeStr) {
     }
   }
 
-  return v * multiplier;
+  return nbBytes * multiplier;
 }
 
 }  // namespace cct

--- a/src/tech/test/flatkeyvaluestring_test.cpp
+++ b/src/tech/test/flatkeyvaluestring_test.cpp
@@ -95,8 +95,8 @@ TEST(FlatKeyValueStringTest, WithNullTerminatingCharAsSeparator) {
   EXPECT_EQ(kvPairs.str(), std::string_view("tata:abc\0huhu:haha\0&newField:&&newValue&&"sv));
 
   int kvPairPos = 0;
-  for (const auto &[k, v] : kvPairs) {
-    const char *kvPairPtr = k.data();
+  for (const auto &[key, val] : kvPairs) {
+    const char *kvPairPtr = key.data();
     switch (kvPairPos++) {
       case 0:
         ASSERT_STREQ(kvPairPtr, "tata:abc");
@@ -137,40 +137,40 @@ TEST_F(CurlOptionsCase1, Get) {
 }
 
 TEST_F(CurlOptionsCase1, Iterator) {
-  int i = 0;
-  for (const auto &[k, v] : kvPairs) {
-    switch (i++) {
+  int itPos = 0;
+  for (const auto &[key, val] : kvPairs) {
+    switch (itPos++) {
       case 0:
-        EXPECT_EQ(k, "units");
-        EXPECT_EQ(v, "0.11176");
+        EXPECT_EQ(key, "units");
+        EXPECT_EQ(val, "0.11176");
         break;
       case 1:
-        EXPECT_EQ(k, "price");
-        EXPECT_EQ(v, "357.78");
+        EXPECT_EQ(key, "price");
+        EXPECT_EQ(val, "357.78");
         break;
       case 2:
-        EXPECT_EQ(k, "777");
-        EXPECT_EQ(v, "encoredutravail?");
+        EXPECT_EQ(key, "777");
+        EXPECT_EQ(val, "encoredutravail?");
         break;
       case 3:
-        EXPECT_EQ(k, "hola");
-        EXPECT_EQ(v, "quetal");
+        EXPECT_EQ(key, "hola");
+        EXPECT_EQ(val, "quetal");
         break;
       case 4:
-        EXPECT_EQ(k, "array1");
-        EXPECT_EQ(v, "val1,,");
+        EXPECT_EQ(key, "array1");
+        EXPECT_EQ(val, "val1,,");
         break;
       case 5:
-        EXPECT_EQ(k, "array2");
-        EXPECT_EQ(v, ",val1,val2,value,");
+        EXPECT_EQ(key, "array2");
+        EXPECT_EQ(val, ",val1,val2,value,");
         break;
       case 6:
-        EXPECT_EQ(k, "emptyArray");
-        EXPECT_EQ(v, ",");
+        EXPECT_EQ(key, "emptyArray");
+        EXPECT_EQ(val, ",");
         break;
     }
   }
-  EXPECT_EQ(i, 7);
+  EXPECT_EQ(itPos, 7);
 }
 
 TEST_F(CurlOptionsCase1, ConvertToJson) {
@@ -209,8 +209,8 @@ TEST_F(CurlOptionsCase1, ConvertToJson) {
 TEST_F(CurlOptionsCase1, AppendIntegralValues) {
   kvPairs.append("price1", 1957386078376L);
   EXPECT_EQ(kvPairs.get("price1"), "1957386078376");
-  int8_t s = -116;
-  kvPairs.append("testu", s);
+  int8_t val = -116;
+  kvPairs.append("testu", val);
   EXPECT_EQ(kvPairs.get("testu"), "-116");
 }
 
@@ -223,8 +223,8 @@ TEST_F(CurlOptionsCase1, SetIntegralValues) {
   EXPECT_EQ(
       kvPairs.str(),
       "units=0.11176&price=357.78&777=-666&hola=quetal&array1=val1,,&array2=,val1,val2,value,&emptyArray=,&price1=42");
-  int8_t s = -116;
-  kvPairs.set("testu", s);
+  int8_t val = -116;
+  kvPairs.set("testu", val);
   EXPECT_EQ(kvPairs.get("testu"), "-116");
 }
 


### PR DESCRIPTION
- Only one call of `placeOrderProcess` in the loop.
- Only one call of `computeAvgOrderPrice` in the loop.
- Other code cleanups (less variables, possibility to set `minTimeBetweenPriceUpdates` to max without bug)
- Addition of unit tests covering emergency timeout actions