### PR TITLE
Stop using deprecated functions from OpenSSL 3

### DIFF
--- a/src/api/common/CMakeLists.txt
+++ b/src/api/common/CMakeLists.txt
@@ -44,4 +44,13 @@ add_common_test(
   test/exchangepublicapi_test.cpp
 )
 
+add_unit_test(
+  ssl_sha_test
+  src/ssl_sha.cpp
+  test/ssl_sha_test.cpp
+  LIBRARIES
+  coincenter_apicommon
+  OpenSSL::SSL
+)
+
 

--- a/src/api/common/include/ssl_sha.hpp
+++ b/src/api/common/include/ssl_sha.hpp
@@ -1,25 +1,26 @@
 #pragma once
 
-#include <array>
 #include <climits>
+#include <cstdint>
 #include <span>
 #include <string_view>
 
+#include "cct_fixedcapacityvector.hpp"
 #include "cct_string.hpp"
 
 namespace cct::ssl {
 
 std::string_view GetOpenSSLVersion();
 
-//------------------------------------------------------------------------------
-// helper function to compute SHA256:
-using Sha256 = std::array<char, 256 / CHAR_BIT>;
+/// @brief Append Sha256 computed from 'data' to 'str'
+void AppendSha256(std::string_view data, string &str);
 
-Sha256 ComputeSha256(std::string_view data);
+/// @brief Helper type containing the number of bytes of the SHA
+enum class ShaType : int16_t { kSha256 = 256 / CHAR_BIT, kSha512 = 512 / CHAR_BIT };
 
-enum class ShaType { kSha256, kSha512 };
+using Md = FixedCapacityVector<char, static_cast<int16_t>(ShaType::kSha512)>;
 
-string ShaBin(ShaType shaType, std::string_view data, std::string_view secret);
+Md ShaBin(ShaType shaType, std::string_view data, std::string_view secret);
 
 string ShaHex(ShaType shaType, std::string_view data, std::string_view secret);
 

--- a/src/api/common/test/ssl_sha_test.cpp
+++ b/src/api/common/test/ssl_sha_test.cpp
@@ -1,0 +1,105 @@
+
+#include "ssl_sha.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+namespace cct::ssl {
+TEST(SSLTest, Version) { EXPECT_NE(GetOpenSSLVersion(), ""); }
+
+TEST(SSLTest, AppendSha256) {
+  string str("test");
+  AppendSha256("thisNonce0123456789Data", str);
+
+  static constexpr char kExpectedData[] = {116,  101,  115, 116,  -98,  74,   -90, 56, -41, 61,   -33, 98,
+                                           -108, -110, -41, -82,  -110, -102, -80, 85, 127, -112, -55, -116,
+                                           38,   36,   10,  -104, -37,  93,   105, 14, 73,  99,   98,  95};
+  EXPECT_TRUE(std::equal(str.begin(), str.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaBin256) {
+  auto actual = ShaBin(ShaType::kSha256, "data1234", "secret1234");
+  static constexpr char kExpectedData[] = {11,  -51, -56,  -21,  -101, 61,   35,  28, 86,  97,  -50,
+                                           -8,  47,  -113, -13,  -107, -100, -93, 27, 71,  101, -128,
+                                           -65, 101, -110, -123, 38,   73,   77,  73, -10, -39};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaBin512) {
+  auto actual = ShaBin(ShaType::kSha512, "data1234", "secret1234");
+  static constexpr char kExpectedData[] = {-22, 39,  95,   -39, -44,  39,  97,   -40, 29,   -120, -125, 84,  -112,
+                                           -5,  69,  -111, 3,   -109, 86,  54,   -31, 44,   -55,  56,   111, 85,
+                                           87,  22,  -61,  82,  89,   52,  105,  2,   -89,  -76,  63,   4,   95,
+                                           124, -24, 93,   -46, -104, -87, -110, -80, -77,  -66,  -43,  26,  126,
+                                           114, 101, -68,  -66, 75,   -62, -93,  -77, -124, 78,   -121, -96};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaHex256) {
+  auto actual = ShaHex(ShaType::kSha256, "data1234", "secret1234");
+  static constexpr char kExpectedData[] = {48, 98, 99, 100, 99, 56,  101, 98, 57, 98,  51, 100, 50,  51,  49,  99,
+                                           53, 54, 54, 49,  99, 101, 102, 56, 50, 102, 56, 102, 102, 51,  57,  53,
+                                           57, 99, 97, 51,  49, 98,  52,  55, 54, 53,  56, 48,  98,  102, 54,  53,
+                                           57, 50, 56, 53,  50, 54,  52,  57, 52, 100, 52, 57,  102, 54,  100, 57};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaHex512) {
+  auto actual = ShaHex(ShaType::kSha512, "data1234", "secret1234");
+  static constexpr char kExpectedData[] = {
+      101, 97,  50, 55, 53,  102, 100, 57,  100, 52,  50,  55,  54, 49,  100, 56,  49, 100, 56,  56, 56, 51,
+      53,  52,  57, 48, 102, 98,  52,  53,  57,  49,  48,  51,  57, 51,  53,  54,  51, 54,  101, 49, 50, 99,
+      99,  57,  51, 56, 54,  102, 53,  53,  53,  55,  49,  54,  99, 51,  53,  50,  53, 57,  51,  52, 54, 57,
+      48,  50,  97, 55, 98,  52,  51,  102, 48,  52,  53,  102, 55, 99,  101, 56,  53, 100, 100, 50, 57, 56,
+      97,  57,  57, 50, 98,  48,  98,  51,  98,  101, 100, 53,  49, 97,  55,  101, 55, 50,  54,  53, 98, 99,
+      98,  101, 52, 98, 99,  50,  97,  51,  98,  51,  56,  52,  52, 101, 56,  55,  97, 48};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaDigest256) {
+  auto actual = ShaDigest(ShaType::kSha256, "data1234");
+  static constexpr char kExpectedData[] = {102, 50, 102, 100, 97,  57, 98, 98,  53, 49,  49,  56,  100, 100, 53, 97,
+                                           51,  50, 57,  55,  100, 50, 56, 97,  52, 55,  50,  57,  51,  102, 49, 50,
+                                           51,  97, 49,  51,  50,  54, 50, 57,  48, 101, 102, 51,  100, 55,  48, 49,
+                                           53,  57, 55,  101, 57,  51, 56, 102, 99, 53,  48,  102, 48,  57,  57, 57};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaDigest512) {
+  auto actual = ShaDigest(ShaType::kSha512, "data1234");
+  static constexpr char kExpectedData[] = {
+      99,  97,  97,  48,  50,  55, 54,  50,  57, 52,  98,  54,  49, 53,  48,  50,  51, 100, 57,  55,  50, 54,
+      48,  52,  55,  53,  50,  54, 98,  49,  50, 52,  102, 100, 99, 100, 51,  49,  98, 100, 97,  101, 97, 56,
+      100, 102, 54,  54,  101, 48, 101, 54,  97, 101, 101, 102, 48, 101, 48,  102, 57, 54,  100, 54,  52, 55,
+      50,  49,  99,  100, 100, 57, 54,  102, 50, 52,  48,  54,  48, 102, 101, 49,  56, 102, 52,  52,  50, 100,
+      54,  57,  100, 98,  54,  99, 56,  53,  56, 49,  53,  51,  52, 57,  102, 50,  52, 101, 99,  100, 99, 48,
+      100, 97,  51,  51,  51,  53, 48,  49,  56, 51,  53,  98,  53, 52,  51,  102, 54, 53};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaDigest256Multiple) {
+  static const string kData[] = {"data1234", "anotherString5_-", "5_0(7)fbBBBb334G;"};
+
+  auto actual = ShaDigest(ShaType::kSha256, kData);
+  static constexpr char kExpectedData[] = {53,  53, 100, 98, 52,  97,  49, 97,  50,  99, 52, 52, 52, 99,  97, 57,
+                                           100, 57, 97,  52, 48,  99,  51, 52,  101, 97, 50, 99, 53, 98,  97, 51,
+                                           100, 54, 55,  50, 102, 100, 51, 102, 100, 98, 51, 54, 52, 100, 98, 50,
+                                           101, 49, 97,  56, 53,  54,  99, 48,  100, 53, 52, 98, 49, 101, 51, 50};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+
+TEST(SSLTest, ShaDigest512Multiple) {
+  static const string kData[] = {"data1234", "anotherString5_-", "5_0(7)fbBBBb334G;"};
+
+  auto actual = ShaDigest(ShaType::kSha512, kData);
+  static constexpr char kExpectedData[] = {
+      101, 56,  101, 55,  54,  98,  100, 56, 57, 53, 100, 53, 54, 99,  50,  54,  48, 56,  50, 57,  53,  97,
+      100, 98,  100, 48,  55,  102, 51,  56, 49, 54, 99,  55, 99, 101, 101, 98,  54, 48,  53, 52,  100, 98,
+      54,  98,  56,  102, 97,  52,  51,  57, 48, 56, 102, 54, 54, 48,  100, 49,  57, 101, 98, 51,  99,  55,
+      48,  56,  54,  49,  100, 57,  49,  51, 98, 97, 57,  53, 56, 54,  54,  54,  52, 53,  53, 48,  57,  98,
+      100, 99,  102, 57,  54,  52,  55,  55, 49, 55, 48,  56, 97, 55,  50,  102, 52, 54,  52, 101, 56,  50,
+      51,  102, 57,  54,  98,  53,  50,  51, 52, 99, 98,  48, 51, 56,  100, 53,  55, 56};
+  EXPECT_TRUE(std::equal(actual.begin(), actual.end(), std::begin(kExpectedData), std::end(kExpectedData)));
+}
+}  // namespace cct::ssl

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -25,10 +25,9 @@ string PrivateSignature(const APIKey& apiKey, string data, const Nonce& nonce, s
   // concatenate nonce and postdata and compute SHA256
   string noncePostData(nonce.begin(), nonce.end());
   noncePostData.append(postdata);
-  ssl::Sha256 nonce_postdata = ssl::ComputeSha256(noncePostData);
 
   // concatenate path and nonce_postdata (path + ComputeSha256(nonce + postdata))
-  data.append(nonce_postdata.begin(), nonce_postdata.end());
+  ssl::AppendSha256(noncePostData, data);
 
   // and compute HMAC
   return B64Encode(ssl::ShaBin(ssl::ShaType::kSha512, data, B64Decode(apiKey.privateKey())));

--- a/src/tech/include/codec.hpp
+++ b/src/tech/include/codec.hpp
@@ -1,15 +1,20 @@
 #pragma once
 
 #include <span>
-#include <string_view>
 
 #include "cct_string.hpp"
 
 namespace cct {
 
+// const char * arguments are deleted because it would construct into a span including the unwanted null
+// terminating character. Use span directly, or string / string_view instead.
+
 string BinToHex(std::span<const unsigned char> bindata);
+string BinToHex(const char *) = delete;
 
-string B64Encode(std::string_view bindata);
+string B64Encode(std::span<const char> bindata);
+string B64Encode(const char *) = delete;
 
-string B64Decode(std::string_view ascdata);
+string B64Decode(std::span<const char> ascdata);
+string B64Decode(const char *) = delete;
 }  // namespace cct

--- a/src/tech/src/codec.cpp
+++ b/src/tech/src/codec.cpp
@@ -12,34 +12,34 @@ string BinToHex(std::span<const unsigned char> bindata) {
   static constexpr const char* const kHexits = "0123456789abcdef";
   const int sz = static_cast<int>(bindata.size());
   string ret(2 * sz, '\0');
-  for (int i = 0; i < sz; ++i) {
-    ret[i * 2] = kHexits[bindata[i] >> 4];
-    ret[(i * 2) + 1] = kHexits[bindata[i] & 0x0F];
+  for (int charPos = 0; charPos < sz; ++charPos) {
+    ret[charPos * 2] = kHexits[bindata[charPos] >> 4];
+    ret[(charPos * 2) + 1] = kHexits[bindata[charPos] & 0x0F];
   }
   return ret;
 }
 
-string B64Encode(std::string_view bindata) {
-  const ::std::size_t binlen = bindata.size();
+string B64Encode(std::span<const char> bindata) {
+  const auto binlen = bindata.size();
   // Use = signs so the end is properly padded.
   string retval((((binlen + 2) / 3) * 4), '=');
   std::size_t outpos = 0;
-  int bits_collected = 0;
+  int bitsCollected = 0;
   unsigned int accumulator = 0;
 
   static constexpr const char* const kB64Table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
   for (char ch : bindata) {
     accumulator = (accumulator << 8) | (ch & 0xffu);
-    bits_collected += 8;
-    while (bits_collected >= 6) {
-      bits_collected -= 6;
-      retval[outpos++] = kB64Table[(accumulator >> bits_collected) & 0x3fu];
+    bitsCollected += 8;
+    while (bitsCollected >= 6) {
+      bitsCollected -= 6;
+      retval[outpos++] = kB64Table[(accumulator >> bitsCollected) & 0x3fu];
     }
   }
-  if (bits_collected > 0) {  // Any trailing bits that are missing.
-    assert(bits_collected < 6);
-    accumulator <<= 6 - bits_collected;
+  if (bitsCollected > 0) {  // Any trailing bits that are missing.
+    assert(bitsCollected < 6);
+    accumulator <<= 6 - bitsCollected;
     retval[outpos++] = kB64Table[accumulator & 0x3fu];
   }
   assert(retval.empty() || outpos >= (retval.size() - 2));
@@ -47,9 +47,9 @@ string B64Encode(std::string_view bindata) {
   return retval;
 }
 
-string B64Decode(std::string_view ascdata) {
+string B64Decode(std::span<const char> ascdata) {
   string retval;
-  int bits_collected = 0;
+  int bitsCollected = 0;
   unsigned int accumulator = 0;
 
   static constexpr char kReverseTable[] = {
@@ -68,10 +68,10 @@ string B64Decode(std::string_view ascdata) {
       throw invalid_argument("This contains characters not legal in a base64 encoded string.");
     }
     accumulator = (accumulator << 6) | kReverseTable[static_cast<unsigned char>(ch)];
-    bits_collected += 6;
-    if (bits_collected >= 8) {
-      bits_collected -= 8;
-      retval.push_back(static_cast<char>((accumulator >> bits_collected) & 0xffu));
+    bitsCollected += 6;
+    if (bitsCollected >= 8) {
+      bitsCollected -= 8;
+      retval.push_back(static_cast<char>((accumulator >> bitsCollected) & 0xffu));
     }
   }
   return retval;

--- a/src/tech/test/codec_test.cpp
+++ b/src/tech/test/codec_test.cpp
@@ -2,22 +2,29 @@
 
 #include <gtest/gtest.h>
 
+#include <string_view>
+
 namespace cct {
 
-TEST(Base64, EncodeEmpty) { EXPECT_EQ(B64Encode(""), ""); }
-TEST(Base64, Encode1) { EXPECT_EQ(B64Encode("f"), "Zg=="); }
-TEST(Base64, Encode2) { EXPECT_EQ(B64Encode("fo"), "Zm8="); }
-TEST(Base64, Encode3) { EXPECT_EQ(B64Encode("foo"), "Zm9v"); }
-TEST(Base64, Encode4) { EXPECT_EQ(B64Encode("foob"), "Zm9vYg=="); }
-TEST(Base64, Encode5) { EXPECT_EQ(B64Encode("fooba"), "Zm9vYmE="); }
-TEST(Base64, Encode6) { EXPECT_EQ(B64Encode("foobar"), "Zm9vYmFy"); }
+TEST(Base64, EncodeEmpty) { EXPECT_EQ(B64Encode(std::string_view("")), ""); }
+TEST(Base64, Encode1) { EXPECT_EQ(B64Encode(std::string_view("f")), "Zg=="); }
+TEST(Base64, Encode2) { EXPECT_EQ(B64Encode(std::string_view("fo")), "Zm8="); }
+TEST(Base64, Encode3) { EXPECT_EQ(B64Encode(std::string_view("foo")), "Zm9v"); }
+TEST(Base64, Encode4) { EXPECT_EQ(B64Encode(std::string_view("foob")), "Zm9vYg=="); }
+TEST(Base64, Encode5) { EXPECT_EQ(B64Encode(std::string_view("fooba")), "Zm9vYmE="); }
+TEST(Base64, Encode6) { EXPECT_EQ(B64Encode(std::string_view("foobar")), "Zm9vYmFy"); }
+TEST(Base64, Encode7) { EXPECT_EQ(B64Encode(std::string_view("foobarz")), "Zm9vYmFyeg=="); }
+TEST(Base64, Encode8) { EXPECT_EQ(B64Encode(std::string_view("foobarzY")), "Zm9vYmFyelk="); }
+TEST(Base64, Encode9) { EXPECT_EQ(B64Encode(std::string_view("foobarzYg")), "Zm9vYmFyelln"); }
 
-TEST(Base64, DecodeEmpty) { EXPECT_EQ(B64Decode(""), ""); }
-TEST(Base64, Decode1) { EXPECT_EQ(B64Decode("Zg=="), "f"); }
-TEST(Base64, Decode2) { EXPECT_EQ(B64Decode("Zm8="), "fo"); }
-TEST(Base64, Decode3) { EXPECT_EQ(B64Decode("Zm9v"), "foo"); }
-TEST(Base64, Decode4) { EXPECT_EQ(B64Decode("Zm9vYg=="), "foob"); }
-TEST(Base64, Decode5) { EXPECT_EQ(B64Decode("Zm9vYmE="), "fooba"); }
-TEST(Base64, Decode6) { EXPECT_EQ(B64Decode("Zm9vYmFy"), "foobar"); }
-
+TEST(Base64, DecodeEmpty) { EXPECT_EQ(B64Decode(std::string_view("")), ""); }
+TEST(Base64, Decode1) { EXPECT_EQ(B64Decode(std::string_view("Zg==")), "f"); }
+TEST(Base64, Decode2) { EXPECT_EQ(B64Decode(std::string_view("Zm8=")), "fo"); }
+TEST(Base64, Decode3) { EXPECT_EQ(B64Decode(std::string_view("Zm9v")), "foo"); }
+TEST(Base64, Decode4) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYg==")), "foob"); }
+TEST(Base64, Decode5) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYmE=")), "fooba"); }
+TEST(Base64, Decode6) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYmFy")), "foobar"); }
+TEST(Base64, Decode7) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYmFyeg==")), "foobarz"); }
+TEST(Base64, Decode8) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYmFyelk=")), "foobarzY"); }
+TEST(Base64, Decode9) { EXPECT_EQ(B64Decode(std::string_view("Zm9vYmFyelln")), "foobarzYg"); }
 }  // namespace cct

--- a/src/tools/src/curlhandle.cpp
+++ b/src/tools/src/curlhandle.cpp
@@ -48,11 +48,11 @@ void CurlSetLogIfError(CURL *curl, CURLoption curlOption, T value) {
 }  // namespace
 
 string GetCurlVersionInfo() {
-  const curl_version_info_data *curlVersionInfo = curl_version_info(CURLVERSION_NOW);
+  const curl_version_info_data &curlVersionInfo = *curl_version_info(CURLVERSION_NOW);
   string curlVersionInfoStr("curl ");
-  curlVersionInfoStr.append(curlVersionInfo->version);
-  curlVersionInfoStr.append(" ssl ").append(curlVersionInfo->ssl_version);
-  curlVersionInfoStr.append(" libz ").append(curlVersionInfo->libz_version);
+  curlVersionInfoStr.append(curlVersionInfo.version);
+  curlVersionInfoStr.append(" ssl ").append(curlVersionInfo.ssl_version);
+  curlVersionInfoStr.append(" libz ").append(curlVersionInfo.libz_version);
   return curlVersionInfoStr;
 }
 

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -62,4 +62,6 @@ TEST_F(TestCurlHandle, ProxyMockTest) {
     EXPECT_EQ(out, "POOL_LEFT");
   }
 }
+
+TEST_F(TestCurlHandle, CurlVersion) { EXPECT_NE(GetCurlVersionInfo(), string()); }
 }  // namespace cct


### PR DESCRIPTION
Fix deprecation warnings that appears since upgrade to OpenSSL 3.
Add unit test for `ssl_sha.cpp`.