### PR TITLE
Fix asan error in a log in main when an exception is raised as LoggingInfo loggers have been destroyed at this point

### DIFF
--- a/src/engine/include/commandlineoptionsparser.hpp
+++ b/src/engine/include/commandlineoptionsparser.hpp
@@ -60,9 +60,7 @@ class CommandLineOptionsParser : private OptValueType {
     const int vargvSize = static_cast<int>(vargv.size());
     for (int idxOpt = 0; idxOpt < vargvSize; ++idxOpt) {
       const char* argStr = vargv[idxOpt];
-      const bool knownOption =
-          std::ranges::any_of(_opts, [argStr](const auto& opt) { return opt.first.matches(argStr); });
-      if (!knownOption) {
+      if (std::ranges::none_of(_opts, [argStr](const auto& opt) { return opt.first.matches(argStr); })) {
         throw invalid_argument("Unrecognized command-line option {}", argStr);
       }
 

--- a/src/main/src/main.cpp
+++ b/src/main/src/main.cpp
@@ -20,8 +20,7 @@ int main(int argc, const char* argv[]) {
   } catch (const cct::invalid_argument& e) {
     cct::log::critical("Invalid argument: {}", e.what());
     return EXIT_FAILURE;
-  } catch (const std::exception& e) {
-    cct::log::critical("Exception: {}", e.what());
+  } catch ([[maybe_unused]] const std::exception& e) {
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/src/main/src/processcommandsfromcli.cpp
+++ b/src/main/src/processcommandsfromcli.cpp
@@ -33,9 +33,13 @@ void ProcessCommandsFromCLI(std::string_view programName, const CoincenterComman
                             const CoincenterCmdLineOptions &cmdLineOptions) {
   json generalConfigData = LoadGeneralConfigAndOverrideOptionsFromCLI(cmdLineOptions);
 
+  // Create LoggingInfo first as it is a RAII structure re-initializing spdlog loggers.
+  // It will be held by GeneralConfig and then itself by CoincenterInfo though.
+  LoggingInfo loggingInfo(static_cast<const json &>(generalConfigData["log"]));
+
   Duration fiatConversionQueryRate = ParseDuration(generalConfigData["fiatConversion"]["rate"].get<std::string_view>());
 
-  GeneralConfig generalConfig(LoggingInfo(static_cast<const json &>(generalConfigData["log"])), fiatConversionQueryRate,
+  GeneralConfig generalConfig(std::move(loggingInfo), fiatConversionQueryRate,
                               ApiOutputTypeFromString(generalConfigData["apiOutputType"].get<std::string_view>()));
 
   LoadConfiguration loadConfiguration(cmdLineOptions.dataDir, LoadConfiguration::ExchangeConfigFileType::kProd);
@@ -43,17 +47,23 @@ void ProcessCommandsFromCLI(std::string_view programName, const CoincenterComman
   CoincenterInfo coincenterInfo(settings::RunMode::kProd, loadConfiguration, std::move(generalConfig),
                                 CoincenterCommands::CreateMonitoringInfo(programName, cmdLineOptions));
 
-  ExchangeSecretsInfo exchangesSecretsInfo;
-  if (cmdLineOptions.nosecrets) {
-    StringOptionParser anyParser(*cmdLineOptions.nosecrets);
+  try {
+    ExchangeSecretsInfo exchangesSecretsInfo;
+    if (cmdLineOptions.nosecrets) {
+      StringOptionParser anyParser(*cmdLineOptions.nosecrets);
 
-    exchangesSecretsInfo = ExchangeSecretsInfo(anyParser.getExchanges());
+      exchangesSecretsInfo = ExchangeSecretsInfo(anyParser.getExchanges());
+    }
+
+    Coincenter coincenter(coincenterInfo, exchangesSecretsInfo);
+
+    coincenter.process(coincenterCommands);
+
+    coincenter.updateFileCaches();  // Write potentially updated cache data on disk at end of program
+  } catch (const exception &e) {
+    // Log exception here as LoggingInfo is still configured at this point (will be destroyed immediately afterwards)
+    log::critical("Exception: {}", e.what());
+    throw e;
   }
-
-  Coincenter coincenter(coincenterInfo, exchangesSecretsInfo);
-
-  coincenter.process(coincenterCommands);
-
-  coincenter.updateFileCaches();  // Write potentially updated cache data on disk at end of program
 }
 }  // namespace cct

--- a/src/objects/include/logginginfo.hpp
+++ b/src/objects/include/logginginfo.hpp
@@ -11,8 +11,8 @@ namespace cct {
 /// @brief Singleton encapsulating loggers lifetime and set-up.
 class LoggingInfo {
  public:
-  static constexpr int kDefaultNbMaxFiles = 10;
   static constexpr int64_t kDefaultFileSizeInBytes = 5 * 1024 * 1024;
+  static constexpr int32_t kDefaultNbMaxFiles = 10;
   static constexpr char const *const kOutputLoggerName = "output";
 
   /// Creates a default logging info, with level 'info' on standard output.
@@ -30,7 +30,7 @@ class LoggingInfo {
 
   int64_t maxFileSizeInBytes() const { return _maxFileSizeInBytes; }
 
-  int maxNbFiles() const { return _maxNbFiles; }
+  int32_t maxNbFiles() const { return _maxNbFiles; }
 
   log::level::level_enum logConsole() const { return LevelFromPos(_logLevelConsolePos); }
   log::level::level_enum logFile() const { return LevelFromPos(_logLevelFilePos); }
@@ -48,7 +48,7 @@ class LoggingInfo {
   }
 
   int64_t _maxFileSizeInBytes = kDefaultFileSizeInBytes;
-  int _maxNbFiles = kDefaultNbMaxFiles;
+  int32_t _maxNbFiles = kDefaultNbMaxFiles;
   int8_t _logLevelConsolePos = PosFromLevel(log::level::info);
   int8_t _logLevelFilePos = PosFromLevel(log::level::off);
   bool _destroyLoggers = true;

--- a/src/tools/test/curlhandle_test.cpp
+++ b/src/tools/test/curlhandle_test.cpp
@@ -30,14 +30,13 @@ TEST_F(KrakenBaseCurlHandle, QueryKrakenTime) {
   CurlOptions opts = kVerboseHttpGetOptions;
   opts.appendHttpHeader("MyHeaderIsVeryLongToAvoidSSO", "Val1");
 
-  string s = handle.query("/public/Time", opts);
-  EXPECT_TRUE(s.find("unixtime") != string::npos);
+  EXPECT_TRUE(handle.query("/public/Time", opts).find("unixtime") != string::npos);
 }
 
 TEST_F(KrakenBaseCurlHandle, QueryKrakenSystemStatus) {
-  string s = handle.query("/public/SystemStatus", kVerboseHttpGetOptions);
-  EXPECT_TRUE(s.find("online") != string::npos || s.find("maintenance") != string::npos ||
-              s.find("cancel_only") != string::npos || s.find("post_only") != string::npos);
+  string str = handle.query("/public/SystemStatus", kVerboseHttpGetOptions);
+  EXPECT_TRUE(str.find("online") != string::npos || str.find("maintenance") != string::npos ||
+              str.find("cancel_only") != string::npos || str.find("post_only") != string::npos);
 }
 
 class TestCurlHandle : public ::testing::Test {


### PR DESCRIPTION
In `main.cpp`, there was a catch of `std::exception` (mother class of `cct::exception`) along with a log which is called after `spdlog::drop_all()` is called (in destructor of `LoggingInfo`).

However, we should not call any log once `drop_all` has been called. Doing so is a memory corruption.

This PR moves this log within the lifetime of the `LoggingInfo` to fix the issue.