### PR TITLE
Allow CCT_DATA_DIR environment variable to be read at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(CCT_ENABLE_ASAN "Compile with AddressSanitizer" ${CCT_ASAN_BUILD})
 option(CCT_ENABLE_CLANG_TIDY "Compile with clang-tidy checks" OFF)
 option(CCT_BUILD_PROMETHEUS_FROM_SRC "Fetch and build from prometheus-cpp sources" OFF)
 
-set(CCT_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/data" CACHE PATH "Needed data directory for coincenter")
+set(CCT_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/data" CACHE PATH "Needed data directory for coincenter. Can also be overriden at runtime with this environment variable")
 
 if(EXISTS ${CCT_DATA_DIR})
   message(STATUS "Using Data directory ${CCT_DATA_DIR}")

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -6,6 +6,12 @@ At this step, `coincenter` is built. To execute properly, it needs read/write ac
 - `secret`: contains all sensitive information and data such as secrets and deposit addresses. Do not share or publish this folder!
 - `static`: contains data which is not supposed to be updated regularly, typically loaded once at start up of `coincenter` and not updated automatically. `exchangeconfig.json` contains various options which can control general behavior of `coincenter`. If none is found, a default one will be generated automatically, which you can later on update according to your needs. `generalconfig.json` contains general options independent from exchanges (such as logging, fiat converter).
 
+This directory is set according to these rules, by decreasing priority:
+
+- `--data` or `-d` option from the command line
+- or from `CCT_DATA_DIR` environment variable if it is set at runtime
+- or defaults to the default data directory chosen at build time from `CCT_DATA_DIR` environment variable
+
 ## Important files
 
 ### secret/secret.json

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -19,6 +19,8 @@
 
 namespace cct {
 
+std::string_view SelectDefaultDataDir() noexcept;
+
 struct CoincenterCmdLineOptions {
   static constexpr std::string_view kDefaultMonitoringIPAddress = "0.0.0.0";  // in Docker, localhost does not work
   static constexpr int kDefaultMonitoringPort = 9091;                         // Prometheus default push port
@@ -116,9 +118,9 @@ struct CoincenterCmdLineOptions {
   static constexpr std::string_view kMonitoringIP =
       JoinStringView_v<kMonitoringIP1, CoincenterCmdLineOptions::kDefaultMonitoringIPAddress, CharToStringView_v<')'>>;
 
-  static void PrintVersion(std::string_view programName);
+  static void PrintVersion(std::string_view programName) noexcept;
 
-  std::string_view dataDir = kDefaultDataDir;
+  std::string_view dataDir = SelectDefaultDataDir();
 
   std::string_view apiOutputType;
   std::string_view logConsole;

--- a/src/engine/src/coincenteroptions.cpp
+++ b/src/engine/src/coincenteroptions.cpp
@@ -1,5 +1,6 @@
 #include "coincenteroptions.hpp"
 
+#include <cstdlib>
 #include <iostream>
 
 #include "cct_const.hpp"
@@ -8,7 +9,15 @@
 
 namespace cct {
 
-void CoincenterCmdLineOptions::PrintVersion(std::string_view programName) {
+std::string_view SelectDefaultDataDir() noexcept {
+  const char *pDataDirEnvValue = std::getenv("CCT_DATA_DIR");
+  if (pDataDirEnvValue != nullptr) {
+    return pDataDirEnvValue;
+  }
+  return kDefaultDataDir;
+}
+
+void CoincenterCmdLineOptions::PrintVersion(std::string_view programName) noexcept {
   std::cout << programName << " version " << CCT_VERSION << std::endl;
   std::cout << "compiled with " << CCT_COMPILER_VERSION << " on " << __DATE__ << " at " << __TIME__ << std::endl;
   std::cout << "              " << GetCurlVersionInfo() << std::endl;


### PR DESCRIPTION
Data directory is now set according to these rules, by decreasing priority:

- `--data` or `-d` option from the command line
- or from `CCT_DATA_DIR` environment variable if it is set at runtime
- or defaults to the default data directory chosen at build time from `CCT_DATA_DIR` environment variable