### PR TITLE
Shrink acronym prefixes to support long Arbitrum and Optimism Bithumb acronyms

### DIFF
--- a/data/static/currency_prefix_translator.json
+++ b/data/static/currency_prefix_translator.json
@@ -1,0 +1,5 @@
+{
+    "ARBITRUM": "ARB/",
+    "OPTIMISM": "OPT/",
+    "BSC": "BSC/"
+}

--- a/src/api-objects/src/apikeysprovider.cpp
+++ b/src/api-objects/src/apikeysprovider.cpp
@@ -3,9 +3,9 @@
 #include <iterator>
 
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "cct_log.hpp"
+#include "file.hpp"
 
 namespace cct::api {
 namespace {
@@ -89,7 +89,7 @@ APIKeysProvider::APIKeysMap APIKeysProvider::ParseAPIKeys(std::string_view dataD
     std::string_view secretFileName = GetSecretFileName(runMode);
     File secretsFile(dataDir, File::Type::kSecret, secretFileName,
                      runMode == settings::RunMode::kProd ? File::IfError::kNoThrow : File::IfError::kThrow);
-    json jsonData = secretsFile.readJson();
+    json jsonData = secretsFile.readAllJson();
     for (auto& [publicExchangeName, keyObj] : jsonData.items()) {
       const auto& exchangesWithoutSecrets = exchangeSecretsInfo.exchangesWithoutSecrets();
       if (std::ranges::find(exchangesWithoutSecrets, ExchangeName(publicExchangeName)) !=

--- a/src/api/common/src/cryptowatchapi.cpp
+++ b/src/api/common/src/cryptowatchapi.cpp
@@ -3,11 +3,11 @@
 #include <cctype>
 
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "curloptions.hpp"
+#include "file.hpp"
 #include "timedef.hpp"
 #include "toupperlower.hpp"
 
@@ -41,7 +41,7 @@ CryptowatchAPI::CryptowatchAPI(const CoincenterInfo& config, settings::RunMode r
       _supportedExchanges(CachedResultOptions(std::chrono::hours(96), _cachedResultVault), _curlHandle),
       _allPricesCache(CachedResultOptions(std::chrono::seconds(30), _cachedResultVault), _curlHandle) {
   if (loadFromFileCacheAtInit) {
-    json data = GetFiatCacheFile(_coincenterInfo.dataDir()).readJson();
+    json data = GetFiatCacheFile(_coincenterInfo.dataDir()).readAllJson();
     if (!data.empty()) {
       int64_t timeEpoch = data["timeepoch"].get<int64_t>();
       auto& fiatsFile = data["fiats"];
@@ -115,7 +115,7 @@ json CryptowatchAPI::AllPricesFunc::operator()() {
 
 void CryptowatchAPI::updateCacheFile() const {
   File fiatsCacheFile = GetFiatCacheFile(_coincenterInfo.dataDir());
-  json data = fiatsCacheFile.readJson();
+  json data = fiatsCacheFile.readAllJson();
   auto fiatsPtrLastUpdatedTimePair = _fiatsCache.retrieve();
   auto timeEpochIt = data.find("timeepoch");
   if (timeEpochIt != data.end()) {

--- a/src/api/exchanges/src/krakenpublicapi.cpp
+++ b/src/api/exchanges/src/krakenpublicapi.cpp
@@ -6,12 +6,12 @@
 #include "cct_cctype.hpp"
 #include "cct_const.hpp"
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "cryptowatchapi.hpp"
 #include "curloptions.hpp"
+#include "file.hpp"
 #include "timedef.hpp"
 
 namespace cct::api {
@@ -90,7 +90,7 @@ KrakenPublic::KrakenPublic(const CoincenterInfo& config, FiatConverter& fiatConv
                                                 exchangeInfo().getAPICallUpdateFrequency(kLastPrice)),
                                        _cachedResultVault),
                    _tradableCurrenciesCache, _curlHandle) {
-  json data = GetKrakenWithdrawInfoFile(_coincenterInfo.dataDir()).readJson();
+  json data = GetKrakenWithdrawInfoFile(_coincenterInfo.dataDir()).readAllJson();
   if (!data.empty()) {
     Duration withdrawDataRefreshTime = exchangeInfo().getAPICallUpdateFrequency(kWithdrawalFees);
     TimePoint lastUpdatedTime(std::chrono::seconds(data["timeepoch"].get<int64_t>()));

--- a/src/api/exchanges/src/upbitpublicapi.cpp
+++ b/src/api/exchanges/src/upbitpublicapi.cpp
@@ -4,12 +4,12 @@
 #include <cassert>
 
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "cct_log.hpp"
 #include "coincenterinfo.hpp"
 #include "curloptions.hpp"
 #include "fiatconverter.hpp"
+#include "file.hpp"
 #include "stringhelpers.hpp"
 
 namespace cct::api {
@@ -134,7 +134,7 @@ MarketSet UpbitPublic::MarketsFunc::operator()() {
 WithdrawalFeeMap UpbitPublic::WithdrawalFeesFunc::operator()() {
   WithdrawalFeeMap ret;
   File withdrawFeesFile(_dataDir, File::Type::kStatic, "withdrawfees.json", File::IfError::kThrow);
-  json jsonData = withdrawFeesFile.readJson();
+  json jsonData = withdrawFeesFile.readAllJson();
   for (const auto& [coin, value] : jsonData[_name].items()) {
     CurrencyCode coinAcro(coin);
     MonetaryAmount ma(value.get<std::string_view>(), coinAcro);

--- a/src/iotools/include/file.hpp
+++ b/src/iotools/include/file.hpp
@@ -2,21 +2,21 @@
 
 #include "cct_json.hpp"
 #include "cct_string.hpp"
+#include "reader.hpp"
+#include "writer.hpp"
 
 namespace cct {
 
-class File {
+class File : public Reader, public Writer {
  public:
   enum class Type : int8_t { kCache, kSecret, kStatic };
   enum class IfError : int8_t { kThrow, kNoThrow };
 
   File(std::string_view dataDir, Type type, std::string_view name, IfError ifError);
 
-  string read() const;
+  string readAll() const override;
 
-  json readJson() const;
-
-  void write(const json &data) const;
+  int write(const json &data) const override;
 
  private:
   string _filePath;

--- a/src/iotools/include/reader.hpp
+++ b/src/iotools/include/reader.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "cct_json.hpp"
+#include "cct_string.hpp"
+
+namespace cct {
+
+class Reader {
+ public:
+  // Read all content and return a string of it.
+  virtual string readAll() const { return {}; }
+
+  // Read all content, and constructs a json object from it.
+  json readAllJson() const;
+
+  virtual ~Reader() = default;
+};
+
+}  // namespace cct

--- a/src/iotools/include/reader_mock.hpp
+++ b/src/iotools/include/reader_mock.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "reader.hpp"
+
+namespace cct {
+
+class MockReader : public Reader {
+ public:
+  MOCK_METHOD(string, readAll, (), (const override));
+};
+
+}  // namespace cct

--- a/src/iotools/include/writer.hpp
+++ b/src/iotools/include/writer.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "cct_json.hpp"
+
+namespace cct {
+
+class Writer {
+ public:
+  // Write json and return number of bytes written
+  virtual int write([[maybe_unused]] const json &data) const { return 0; }
+
+  virtual ~Writer() = default;
+};
+
+}  // namespace cct

--- a/src/iotools/include/writer_mock.hpp
+++ b/src/iotools/include/writer_mock.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "writer.hpp"
+
+namespace cct {
+
+class MockWriter : public Writer {
+ public:
+  MOCK_METHOD(int, write, (const json &), (const override));
+};
+
+}  // namespace cct

--- a/src/iotools/src/reader.cpp
+++ b/src/iotools/src/reader.cpp
@@ -1,0 +1,13 @@
+#include "reader.hpp"
+
+namespace cct {
+
+json Reader::readAllJson() const {
+  string dataS = readAll();
+  if (dataS.empty()) {
+    dataS = "{}";
+  }
+  return json::parse(std::move(dataS));
+}
+
+}  // namespace cct

--- a/src/main/src/processcommandsfromcli.cpp
+++ b/src/main/src/processcommandsfromcli.cpp
@@ -3,6 +3,7 @@
 #include "coincenter.hpp"
 #include "coincenterinfo.hpp"
 #include "durationstring.hpp"
+#include "file.hpp"
 #include "generalconfig.hpp"
 #include "loadconfiguration.hpp"
 #include "logginginfo.hpp"
@@ -44,9 +45,18 @@ void ProcessCommandsFromCLI(std::string_view programName, const CoincenterComman
 
   LoadConfiguration loadConfiguration(cmdLineOptions.dataDir, LoadConfiguration::ExchangeConfigFileType::kProd);
 
+  auto dataDir = loadConfiguration.dataDir();
+
   try {
+    File currencyAcronymsTranslatorFile(dataDir, File::Type::kStatic, "currencyacronymtranslator.json",
+                                        File::IfError::kThrow);
+    File stableCoinsFile(dataDir, File::Type::kStatic, "stablecoins.json", File::IfError::kThrow);
+    File currencyPrefixesTranslatorFile(dataDir, File::Type::kStatic, "currency_prefix_translator.json",
+                                        File::IfError::kThrow);
+
     CoincenterInfo coincenterInfo(settings::RunMode::kProd, loadConfiguration, std::move(generalConfig),
-                                  CoincenterCommands::CreateMonitoringInfo(programName, cmdLineOptions));
+                                  CoincenterCommands::CreateMonitoringInfo(programName, cmdLineOptions),
+                                  currencyAcronymsTranslatorFile, stableCoinsFile, currencyPrefixesTranslatorFile);
 
     ExchangeSecretsInfo exchangesSecretsInfo;
     if (cmdLineOptions.noSecrets) {

--- a/src/objects/CMakeLists.txt
+++ b/src/objects/CMakeLists.txt
@@ -17,6 +17,15 @@ add_unit_test(
 )
 
 add_unit_test(
+    coincenterinfo_test
+    test/coincenterinfo_test.cpp
+    LIBRARIES
+    coincenter_objects
+    DEFINITIONS
+    CCT_DISABLE_SPDLOG
+)
+
+add_unit_test(
     currencycode_test
     test/currencycode_test.cpp
     LIBRARIES

--- a/src/objects/include/currencycode.hpp
+++ b/src/objects/include/currencycode.hpp
@@ -49,11 +49,11 @@ struct CurrencyCodeBase {
     for (char ch : acronym) {
       if (ch >= 'a') {
         if (ch > 'z') {
-          throw invalid_argument("Unexpected char in acronym");
+          throw invalid_argument("Unexpected char '{}' in acronym '{}'", ch, acronym);
         }
         ch -= 'a' - 'A';
       } else if (ch <= kFirstAuthorizedLetter || ch > kLastAuthorizedLetter) {
-        throw invalid_argument("Unexpected char in acronym");
+        throw invalid_argument("Unexpected char '{}' in acronym '{}'", ch, acronym);
       }
 
       ret |= static_cast<uint64_t>(ch - kFirstAuthorizedLetter) << (kNbBitsNbDecimals + kNbBitsChar * --charPos);

--- a/src/objects/src/exchangeinfoparser.cpp
+++ b/src/objects/src/exchangeinfoparser.cpp
@@ -1,9 +1,9 @@
 #include "exchangeinfoparser.hpp"
 
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_log.hpp"
 #include "exchangeinfodefault.hpp"
+#include "file.hpp"
 #include "loadconfiguration.hpp"
 #include "unreachable.hpp"
 
@@ -15,7 +15,7 @@ json LoadExchangeConfigData(const LoadConfiguration& loadConfiguration) {
       std::string_view filename = loadConfiguration.exchangeConfigFile();
       File exchangeConfigFile(loadConfiguration.dataDir(), File::Type::kStatic, filename, File::IfError::kNoThrow);
       json jsonData = ExchangeInfoDefault::Prod();
-      json exchangeConfigJsonData = exchangeConfigFile.readJson();
+      json exchangeConfigJsonData = exchangeConfigFile.readAllJson();
       if (exchangeConfigJsonData.empty()) {
         // Create a file with default values. User can then update them as he wishes.
         log::warn("No {} file found. Creating a default one which can be updated freely at your convenience", filename);

--- a/src/objects/src/fiatconverter.cpp
+++ b/src/objects/src/fiatconverter.cpp
@@ -1,10 +1,10 @@
 #include "fiatconverter.hpp"
 
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_json.hpp"
 #include "coincenterinfo.hpp"
 #include "curloptions.hpp"
+#include "file.hpp"
 
 namespace cct {
 namespace {
@@ -14,7 +14,7 @@ string LoadCurrencyConverterAPIKey(std::string_view dataDir) {
   // example http://free.currconv.com/api/v7/currencies?apiKey=b25453de7984135a084b
   static constexpr std::string_view kThirdPartySecretFileName = "thirdparty_secret.json";
   File thirdPartySecret(dataDir, File::Type::kSecret, kThirdPartySecretFileName, File::IfError::kNoThrow);
-  json data = thirdPartySecret.readJson();
+  json data = thirdPartySecret.readAllJson();
   if (data.empty() || data["freecurrencyconverter"].get<std::string_view>() == kDefaultCommunityKey) {
     log::warn("Unable to find custom Free Currency Converter key in {}", kThirdPartySecretFileName);
     log::warn("If you want to use extensively coincenter, please create your own key by going to");
@@ -43,7 +43,7 @@ FiatConverter::FiatConverter(const CoincenterInfo& coincenterInfo, Duration rate
       _apiKey(LoadCurrencyConverterAPIKey(coincenterInfo.dataDir())),
       _dataDir(coincenterInfo.dataDir()) {
   File ratesCacheFile = GetRatesCacheFile(_dataDir);
-  json data = ratesCacheFile.readJson();
+  json data = ratesCacheFile.readAllJson();
   _pricesMap.reserve(data.size());
   for (const auto& [marketStr, rateAndTimeData] : data.items()) {
     double rate = rateAndTimeData["rate"];

--- a/src/objects/src/generalconfig.cpp
+++ b/src/objects/src/generalconfig.cpp
@@ -1,6 +1,6 @@
 #include "generalconfig.hpp"
 
-#include "cct_file.hpp"
+#include "file.hpp"
 
 namespace cct {
 
@@ -26,7 +26,7 @@ json GeneralConfig::LoadFile(std::string_view dataDir) {
 }
 )"_json;
   json jsonData = kDefaultGeneralConfig;
-  json generalConfigJsonData = generalConfigFile.readJson();
+  json generalConfigJsonData = generalConfigFile.readAllJson();
   if (generalConfigJsonData.empty()) {
     // Create a file with default values. User can then update them as he wishes.
     log::warn("No {} file found. Creating a default one which can be updated freely at your convenience",

--- a/src/objects/src/wallet.cpp
+++ b/src/objects/src/wallet.cpp
@@ -2,8 +2,8 @@
 
 #include "cct_const.hpp"
 #include "cct_exception.hpp"
-#include "cct_file.hpp"
 #include "cct_log.hpp"
+#include "file.hpp"
 
 namespace cct {
 
@@ -20,7 +20,7 @@ bool Wallet::ValidateWallet(WalletCheck walletCheck, const ExchangeName &exchang
     return true;
   }
   File depositAddressesFile = GetDepositAddressesFile(walletCheck.dataDir());
-  json data = depositAddressesFile.readJson();
+  json data = depositAddressesFile.readAllJson();
   if (!data.contains(exchangeName.name())) {
     log::warn("No deposit addresses found in {} for {}", kDepositAddressesFileName, exchangeName);
     return false;

--- a/src/objects/test/coincenterinfo_test.cpp
+++ b/src/objects/test/coincenterinfo_test.cpp
@@ -1,0 +1,70 @@
+#include "coincenterinfo.hpp"
+
+#include "reader_mock.hpp"
+#include "writer_mock.hpp"
+
+namespace cct {
+namespace {
+const string kAcronyms(R"json(
+    {
+        "XBT": "BTC",
+        "ZEUR": "EUR"
+    })json");
+
+const string kPrefixes(R"json(
+    {
+        "ARBITRUM": "ARB/",
+        "ARBITRO": "ARO/",
+        "OPTIMISM": "OPT/"
+    })json");
+}  // namespace
+
+class CoincenterInfoTest : public ::testing::Test {
+ protected:
+  LoadConfiguration loadConfiguration{kDefaultDataDir, LoadConfiguration::ExchangeConfigFileType::kTest};
+  MockReader currencyAcronymsReader;
+  MockReader stableCoinsReader;
+  MockReader currencyPrefixesReader;
+
+  CoincenterInfo createCoincenterInfo() const {
+    return CoincenterInfo(settings::RunMode::kTest, loadConfiguration, GeneralConfig(), MonitoringInfo(),
+                          currencyAcronymsReader, stableCoinsReader, currencyPrefixesReader);
+  }
+};
+
+TEST_F(CoincenterInfoTest, AcronymTestNoData) {
+  EXPECT_CALL(currencyAcronymsReader, readAll()).WillOnce(testing::Return(""));
+  EXPECT_CALL(stableCoinsReader, readAll()).WillOnce(testing::Return(""));
+  EXPECT_CALL(currencyPrefixesReader, readAll()).WillOnce(testing::Return(""));
+
+  auto coincenterInfo = createCoincenterInfo();
+
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("BTC"), CurrencyCode("BTC"));
+}
+
+TEST_F(CoincenterInfoTest, AcronymTestNoPrefix) {
+  EXPECT_CALL(currencyAcronymsReader, readAll()).WillOnce(testing::Return(kAcronyms));
+  EXPECT_CALL(stableCoinsReader, readAll()).WillOnce(testing::Return(""));
+  EXPECT_CALL(currencyPrefixesReader, readAll()).WillOnce(testing::Return(""));
+
+  auto coincenterInfo = createCoincenterInfo();
+
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("XBT"), CurrencyCode("BTC"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("ZJPY"), CurrencyCode("ZJPY"));
+}
+
+TEST_F(CoincenterInfoTest, AcronymTestWithPrefix) {
+  EXPECT_CALL(currencyAcronymsReader, readAll()).WillOnce(testing::Return(kAcronyms));
+  EXPECT_CALL(stableCoinsReader, readAll()).WillOnce(testing::Return(""));
+  EXPECT_CALL(currencyPrefixesReader, readAll()).WillOnce(testing::Return(kPrefixes));
+
+  auto coincenterInfo = createCoincenterInfo();
+
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("xbt"), CurrencyCode("BTC"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("zeur"), CurrencyCode("EUR"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("ARBITRUM test"), CurrencyCode("ARB/TEST"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("arbitrum/btc"), CurrencyCode("ARB/BTC"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("optimismETH"), CurrencyCode("OPT/ETH"));
+  EXPECT_EQ(coincenterInfo.standardizeCurrencyCode("ARBItata"), CurrencyCode("ARBITATA"));
+}
+}  // namespace cct

--- a/src/objects/test/exchangeinfo_test.cpp
+++ b/src/objects/test/exchangeinfo_test.cpp
@@ -15,9 +15,6 @@ constexpr std::string_view kExchangeNameTest = kSupportedExchanges[0];
 
 class ExchangeInfoTest : public ::testing::Test {
  protected:
-  void SetUp() override {}
-  void TearDown() override {}
-
   LoadConfiguration loadConfiguration{kDefaultDataDir, LoadConfiguration::ExchangeConfigFileType::kTest};
   ExchangeInfoMap exchangeInfoMap{ComputeExchangeInfoMap(LoadExchangeConfigData(loadConfiguration))};
   ExchangeInfo exchangeInfo{exchangeInfoMap.at(kExchangeNameTest)};


### PR DESCRIPTION
In the get Balance from `Bithumb`, it now returns special currency acronyms with `optimism` and `arbitrum`. Introduce a standard way (inter exchange) to translate these as "ARB/" and "OPT/" to make it possible to create a `CurrencyCode`.