### PR TITLE
Automatic synchronization of timestamps for Binance private API

### DIFF
--- a/src/tech/include/timestring.hpp
+++ b/src/tech/include/timestring.hpp
@@ -25,7 +25,7 @@ string ToString(TimePoint timePoint, const char* format = kTimeYearToSecondSpace
 TimePoint FromString(std::string_view timeStr, const char* format = kTimeYearToSecondSpaceSeparatedFormat);
 
 /// Create a Nonce as the number of milliseconds since Epoch time in string format.
-Nonce Nonce_TimeSinceEpochInMs(int64_t msDelay = 0);
+Nonce Nonce_TimeSinceEpochInMs(Duration msDelay = Duration{});
 
 /// Create a Nonce in literal format.
 /// Example: '2021-06-01T14:44:13'

--- a/src/tech/src/timestring.cpp
+++ b/src/tech/src/timestring.cpp
@@ -41,13 +41,13 @@ TimePoint FromString(std::string_view timeStr, const char* format) {
   return Clock::from_time_t(std::mktime(&utc));  // TODO: fix issue of local time switch
 }
 
-Nonce Nonce_TimeSinceEpochInMs(int64_t msDelay) {
+Nonce Nonce_TimeSinceEpochInMs(Duration msDelay) {
   const auto nowTime = Clock::now();
   // The return type of 'count()' is platform dependent. Let's cast it to 'int64_t' which is enough to hold a number of
   // milliseconds from epoch
-  int64_t msSinceEpoch =
-      static_cast<int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(nowTime.time_since_epoch()).count());
-  return ToString(msSinceEpoch + msDelay);
+  int64_t msSinceEpoch = static_cast<int64_t>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(nowTime.time_since_epoch() + msDelay).count());
+  return ToString(msSinceEpoch);
 }
 
 }  // namespace cct

--- a/src/tech/test/timestring_test.cpp
+++ b/src/tech/test/timestring_test.cpp
@@ -17,6 +17,14 @@ TEST(TimeStringTest, TimeSinceEpoch) {
   EXPECT_LT(FromString<uint64_t>(n1), FromString<uint64_t>(n2));
 }
 
+TEST(TimeStringTest, TimeSinceEpochDelay) {
+  Nonce n1 = Nonce_TimeSinceEpochInMs(std::chrono::seconds(1));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  Nonce n2 = Nonce_TimeSinceEpochInMs();
+  EXPECT_GT(n1, n2);
+  EXPECT_GT(FromString<uint64_t>(n1), FromString<uint64_t>(n2));
+}
+
 TEST(TimeStringTest, LiteralDate) {
   Nonce n1 = Nonce_LiteralDate(kTimeYearToSecondSpaceSeparatedFormat);
   std::this_thread::sleep_for(std::chrono::milliseconds(1020));


### PR DESCRIPTION
Sometimes Binance returns a timestamp synchronization error - it's very sensitive in this aspect even if the local time is very close to the real time.

This PR dynamically fixes the synchronization by introducing delays in the timestamp given to Binance private API queries until the error disappears. It is able to fix at most as 1 min +/- delay in less than 20 steps.