### PR TITLE
Fix wrong display of Monitoring options in help output

### DIFF
--- a/src/engine/include/coincentercommand.hpp
+++ b/src/engine/include/coincentercommand.hpp
@@ -78,9 +78,9 @@ class CoincenterCommand {
   ExchangeNames _exchangeNames;
   SpecialOptions _specialOptions;
   MonetaryAmount _amount;
-  int _n = -1;
   Market _market;
   CurrencyCode _cur1, _cur2;
+  int _n = -1;
   CoincenterCommandType _type;
   bool _isPercentageAmount = false;
   bool _withBalanceInUse = false;

--- a/src/engine/include/coincenteroptions.hpp
+++ b/src/engine/include/coincenteroptions.hpp
@@ -439,7 +439,7 @@ struct CoincenterAllowedOptions {
         "Prints withdraw fees of given currency on all supported exchanges,"
         " or only for the list of specified ones if provided (comma separated)."},
        &OptValueType::withdrawFee},
-      {{{"Monitoring", 60},
+      {{{"Monitoring", 70},
         "--monitoring",
         "",
         "Progressively send metrics to external instance provided that it's correctly set up "


### PR DESCRIPTION
Fix the `--help` output by grouping the Monitoring options within the same group.