### PR TITLE
Improve withdraw algorithm checks to alternatively check receiver even if we did not found sent confirmation

### DIFF
--- a/src/api-objects/include/recentdeposit.hpp
+++ b/src/api-objects/include/recentdeposit.hpp
@@ -10,10 +10,10 @@ class RecentDeposit {
  public:
   using RecentDepositVector = SmallVector<RecentDeposit, 4>;
 
-  RecentDeposit(MonetaryAmount amount, TimePoint timepoint) : _amount(amount), _timepoint(timepoint) {}
+  RecentDeposit(MonetaryAmount amount, TimePoint timePoint) : _amount(amount), _timePoint(timePoint) {}
 
   MonetaryAmount amount() const { return _amount; }
-  TimePoint timePoint() const { return _timepoint; }
+  TimePoint timePoint() const { return _timePoint; }
 
   /// Select the RecentDeposit among given ones which is the closest to 'this' object.
   /// It may reorder the given vector but will not modify objects themselves.
@@ -24,6 +24,6 @@ class RecentDeposit {
 
  private:
   MonetaryAmount _amount;
-  TimePoint _timepoint;
+  TimePoint _timePoint;
 };
 }  // namespace cct


### PR DESCRIPTION
Also fix minor bug in `RecentDeposit::selectClosestRecentDeposit` algorithm, and make sure that its unit tests code coverage is full.