### PR TITLE
Extract some objects creation functions from main to make code usable as external library

### DIFF
--- a/src/engine/include/coincentercommands.hpp
+++ b/src/engine/include/coincentercommands.hpp
@@ -21,9 +21,6 @@ class CoincenterCommands {
 
   static CoincenterCmdLineOptions ParseOptions(int argc, const char *argv[]);
 
-  static MonitoringInfo CreateMonitoringInfo(std::string_view programName,
-                                             const CoincenterCmdLineOptions &cmdLineOptions);
-
   /// @brief Set this CoincenterCommands from given command line options.
   /// @return false if only help or version is asked, true otherwise
   bool setFromOptions(const CoincenterCmdLineOptions &cmdLineOptions);

--- a/src/engine/include/coincenterinfo_create.hpp
+++ b/src/engine/include/coincenterinfo_create.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string_view>
+
+#include "coincenterinfo.hpp"
+#include "coincenteroptions.hpp"
+#include "exchangesecretsinfo.hpp"
+#include "runmodes.hpp"
+
+namespace cct {
+CoincenterInfo CoincenterInfo_Create(std::string_view programName, const CoincenterCmdLineOptions &cmdLineOptions,
+                                     settings::RunMode runMode);
+
+ExchangeSecretsInfo ExchangeSecretsInfo_Create(const CoincenterCmdLineOptions &cmdLineOptions);
+
+}  // namespace cct

--- a/src/engine/src/coincentercommands.cpp
+++ b/src/engine/src/coincentercommands.cpp
@@ -29,13 +29,6 @@ CoincenterCmdLineOptions CoincenterCommands::ParseOptions(int argc, const char *
   return parsedOptions;
 }
 
-MonitoringInfo CoincenterCommands::CreateMonitoringInfo(std::string_view programName,
-                                                        const CoincenterCmdLineOptions &cmdLineOptions) {
-  return {cmdLineOptions.useMonitoring,      programName,
-          cmdLineOptions.monitoringAddress,  cmdLineOptions.monitoringPort,
-          cmdLineOptions.monitoringUsername, cmdLineOptions.monitoringPassword};
-}
-
 namespace {
 std::pair<OrdersConstraints, ExchangeNames> ParseOrderRequest(const CoincenterCmdLineOptions &cmdLineOptions,
                                                               std::string_view orderRequestStr) {

--- a/src/engine/src/coincenterinfo_create.cpp
+++ b/src/engine/src/coincenterinfo_create.cpp
@@ -1,0 +1,72 @@
+#include "coincenterinfo_create.hpp"
+
+#include "durationstring.hpp"
+#include "file.hpp"
+#include "stringoptionparser.hpp"
+
+namespace cct {
+
+namespace {
+json LoadGeneralConfigAndOverrideOptionsFromCLI(const CoincenterCmdLineOptions &cmdLineOptions) {
+  json generalConfigData = GeneralConfig::LoadFile(cmdLineOptions.dataDir);
+
+  // Override general config options from CLI
+  if (!cmdLineOptions.apiOutputType.empty()) {
+    generalConfigData["apiOutputType"] = cmdLineOptions.apiOutputType;
+  }
+  if (!cmdLineOptions.logConsole.empty()) {
+    generalConfigData["log"]["console"] = string(cmdLineOptions.logConsole);
+  }
+  if (!cmdLineOptions.logFile.empty()) {
+    generalConfigData["log"]["file"] = string(cmdLineOptions.logFile);
+  }
+
+  return generalConfigData;
+}
+
+MonitoringInfo MonitoringInfo_Create(std::string_view programName, const CoincenterCmdLineOptions &cmdLineOptions) {
+  return {cmdLineOptions.useMonitoring,      programName,
+          cmdLineOptions.monitoringAddress,  cmdLineOptions.monitoringPort,
+          cmdLineOptions.monitoringUsername, cmdLineOptions.monitoringPassword};
+}
+
+}  // namespace
+
+CoincenterInfo CoincenterInfo_Create(std::string_view programName, const CoincenterCmdLineOptions &cmdLineOptions,
+                                     settings::RunMode runMode) {
+  json generalConfigData = LoadGeneralConfigAndOverrideOptionsFromCLI(cmdLineOptions);
+
+  Duration fiatConversionQueryRate = ParseDuration(generalConfigData["fiatConversion"]["rate"].get<std::string_view>());
+  ApiOutputType apiOutputType = ApiOutputTypeFromString(generalConfigData["apiOutputType"].get<std::string_view>());
+
+  // Create LoggingInfo first as it is a RAII structure re-initializing spdlog loggers.
+  // It will be held by GeneralConfig and then itself by CoincenterInfo though.
+  LoggingInfo loggingInfo(static_cast<const json &>(generalConfigData["log"]));
+
+  GeneralConfig generalConfig(std::move(loggingInfo), fiatConversionQueryRate, apiOutputType);
+
+  LoadConfiguration loadConfiguration(cmdLineOptions.dataDir, LoadConfiguration::ExchangeConfigFileType::kProd);
+
+  auto dataDir = loadConfiguration.dataDir();
+
+  File currencyAcronymsTranslatorFile(dataDir, File::Type::kStatic, "currencyacronymtranslator.json",
+                                      File::IfError::kThrow);
+  File stableCoinsFile(dataDir, File::Type::kStatic, "stablecoins.json", File::IfError::kThrow);
+  File currencyPrefixesTranslatorFile(dataDir, File::Type::kStatic, "currency_prefix_translator.json",
+                                      File::IfError::kThrow);
+
+  return CoincenterInfo(runMode, loadConfiguration, std::move(generalConfig),
+                        MonitoringInfo_Create(programName, cmdLineOptions), currencyAcronymsTranslatorFile,
+                        stableCoinsFile, currencyPrefixesTranslatorFile);
+}
+
+ExchangeSecretsInfo ExchangeSecretsInfo_Create(const CoincenterCmdLineOptions &cmdLineOptions) {
+  if (cmdLineOptions.noSecrets) {
+    StringOptionParser anyParser(*cmdLineOptions.noSecrets);
+
+    return ExchangeSecretsInfo(anyParser.getExchanges());
+  }
+  return {};
+}
+
+}  // namespace cct

--- a/src/main/src/processcommandsfromcli.cpp
+++ b/src/main/src/processcommandsfromcli.cpp
@@ -1,75 +1,20 @@
 #include "processcommandsfromcli.hpp"
 
 #include "coincenter.hpp"
-#include "coincenterinfo.hpp"
+#include "coincenterinfo_create.hpp"
 #include "curlhandle.hpp"
-#include "durationstring.hpp"
-#include "file.hpp"
-#include "generalconfig.hpp"
-#include "loadconfiguration.hpp"
-#include "logginginfo.hpp"
-#include "stringoptionparser.hpp"
 
 namespace cct {
 
-namespace {
-json LoadGeneralConfigAndOverrideOptionsFromCLI(const CoincenterCmdLineOptions &cmdLineOptions) {
-  json generalConfigData = GeneralConfig::LoadFile(cmdLineOptions.dataDir);
-
-  // Override general config options from CLI
-  if (!cmdLineOptions.apiOutputType.empty()) {
-    generalConfigData["apiOutputType"] = cmdLineOptions.apiOutputType;
-  }
-  if (!cmdLineOptions.logConsole.empty()) {
-    generalConfigData["log"]["console"] = string(cmdLineOptions.logConsole);
-  }
-  if (!cmdLineOptions.logFile.empty()) {
-    generalConfigData["log"]["file"] = string(cmdLineOptions.logFile);
-  }
-
-  return generalConfigData;
-}
-}  // namespace
-
 void ProcessCommandsFromCLI(std::string_view programName, const CoincenterCommands &coincenterCommands,
                             const CoincenterCmdLineOptions &cmdLineOptions, settings::RunMode runMode) {
-  json generalConfigData = LoadGeneralConfigAndOverrideOptionsFromCLI(cmdLineOptions);
-
-  Duration fiatConversionQueryRate = ParseDuration(generalConfigData["fiatConversion"]["rate"].get<std::string_view>());
-  ApiOutputType apiOutputType = ApiOutputTypeFromString(generalConfigData["apiOutputType"].get<std::string_view>());
-
-  // Create LoggingInfo first as it is a RAII structure re-initializing spdlog loggers.
-  // It will be held by GeneralConfig and then itself by CoincenterInfo though.
-  LoggingInfo loggingInfo(static_cast<const json &>(generalConfigData["log"]));
-
-  GeneralConfig generalConfig(std::move(loggingInfo), fiatConversionQueryRate, apiOutputType);
-
-  LoadConfiguration loadConfiguration(cmdLineOptions.dataDir, LoadConfiguration::ExchangeConfigFileType::kProd);
-
-  auto dataDir = loadConfiguration.dataDir();
-
-  File currencyAcronymsTranslatorFile(dataDir, File::Type::kStatic, "currencyacronymtranslator.json",
-                                      File::IfError::kThrow);
-  File stableCoinsFile(dataDir, File::Type::kStatic, "stablecoins.json", File::IfError::kThrow);
-  File currencyPrefixesTranslatorFile(dataDir, File::Type::kStatic, "currency_prefix_translator.json",
-                                      File::IfError::kThrow);
-
   // Should be outside the try / catch as it holds the RAII object managing the Logging (LoggingInfo)
-  CoincenterInfo coincenterInfo(runMode, loadConfiguration, std::move(generalConfig),
-                                CoincenterCommands::CreateMonitoringInfo(programName, cmdLineOptions),
-                                currencyAcronymsTranslatorFile, stableCoinsFile, currencyPrefixesTranslatorFile);
-
-  ExchangeSecretsInfo exchangesSecretsInfo;
-  if (cmdLineOptions.noSecrets) {
-    StringOptionParser anyParser(*cmdLineOptions.noSecrets);
-
-    exchangesSecretsInfo = ExchangeSecretsInfo(anyParser.getExchanges());
-  }
+  CoincenterInfo coincenterInfo = CoincenterInfo_Create(programName, cmdLineOptions, runMode);
 
   CurlInitRAII curlInitRAII;  // Should be before any curl query
 
   try {
-    Coincenter coincenter(coincenterInfo, exchangesSecretsInfo);
+    Coincenter coincenter(coincenterInfo, ExchangeSecretsInfo_Create(cmdLineOptions));
 
     int nbCommandsProcessed = coincenter.process(coincenterCommands);
 


### PR DESCRIPTION
This can prevent code duplication for programs extending `coincenter`.