### PR TITLE
Add retry mechanism to requests

### DIFF
--- a/src/api/common/test/fiatconverter_test.cpp
+++ b/src/api/common/test/fiatconverter_test.cpp
@@ -44,7 +44,7 @@ std::string_view CurlHandle::query([[maybe_unused]] std::string_view endpoint, c
   json jsonData;
 
   // Rates
-  std::string_view marketStr = opts.getPostData().get("q");
+  std::string_view marketStr = opts.postData().get("q");
   std::string_view fromCurrency = marketStr.substr(0, 3);
   std::string_view targetCurrency = marketStr.substr(4);
   double rate = 0;

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -176,7 +176,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
       std::this_thread::sleep_for(sleepingTime);
       sleepingTime = (3 * sleepingTime) / 2;
     }
-    SetNonceAndSignature(apiKey, opts.getPostData(), queryDelay);
+    SetNonceAndSignature(apiKey, opts.mutablePostData(), queryDelay);
     ret = json::parse(curlHandle.query(endpoint, opts));
 
     auto codeIt = ret.find("code");

--- a/src/api/exchanges/src/bithumbprivateapi.cpp
+++ b/src/api/exchanges/src/bithumbprivateapi.cpp
@@ -102,7 +102,7 @@ void SetHttpHeaders(CurlOptions& opts, const APIKey& apiKey, std::string_view si
 }
 
 json PrivateQueryProcess(CurlHandle& curlHandle, const APIKey& apiKey, std::string_view endpoint, CurlOptions& opts) {
-  auto strDataAndNoncePair = GetStrData(endpoint, opts.getPostData().str());
+  auto strDataAndNoncePair = GetStrData(endpoint, opts.postData().str());
 
   string signature = B64Encode(ssl::ShaHex(ssl::ShaType::kSha512, strDataAndNoncePair.first, apiKey.privateKey()));
 

--- a/src/api/exchanges/src/krakenprivateapi.cpp
+++ b/src/api/exchanges/src/krakenprivateapi.cpp
@@ -84,9 +84,9 @@ std::pair<json, KrakenErrorEnum> PrivateQuery(CurlHandle& curlHandle, const APIK
   CurlOptions opts(HttpRequestType::kPost, std::forward<CurlPostDataT>(curlPostData));
 
   Nonce nonce = Nonce_TimeSinceEpochInMs();
-  opts.getPostData().append("nonce", nonce);
+  opts.mutablePostData().append("nonce", nonce);
   opts.appendHttpHeader("API-Key", apiKey.key());
-  opts.appendHttpHeader("API-Sign", PrivateSignature(apiKey, path, nonce, opts.getPostData().str()));
+  opts.appendHttpHeader("API-Sign", PrivateSignature(apiKey, path, nonce, opts.postData().str()));
 
   json response = json::parse(curlHandle.query(method, opts));
   Duration sleepingTime = curlHandle.minDurationBetweenQueries();
@@ -104,8 +104,8 @@ std::pair<json, KrakenErrorEnum> PrivateQuery(CurlHandle& curlHandle, const APIK
 
     // We need to update the nonce
     nonce = Nonce_TimeSinceEpochInMs();
-    opts.getPostData().set("nonce", nonce);
-    opts.setHttpHeader("API-Sign", PrivateSignature(apiKey, path, nonce, opts.getPostData().str()));
+    opts.mutablePostData().set("nonce", nonce);
+    opts.setHttpHeader("API-Sign", PrivateSignature(apiKey, path, nonce, opts.postData().str()));
     response = json::parse(curlHandle.query(method, opts));
   }
   KrakenErrorEnum err = KrakenErrorEnum::kNoError;

--- a/src/api/exchanges/src/kucoinprivateapi.cpp
+++ b/src/api/exchanges/src/kucoinprivateapi.cpp
@@ -90,7 +90,7 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
   auto errCodeIt = ret.find("code");
   if (errCodeIt != ret.end() && errCodeIt->get<std::string_view>() != kStatusCodeOK) {
     auto msgIt = ret.find("msg");
-    std::string_view msg = msgIt == ret.end() ? "" : msgIt->get<std::string_view>();
+    std::string_view msg = msgIt == ret.end() ? std::string_view() : msgIt->get<std::string_view>();
     if (requestType == HttpRequestType::kDelete) {
       log::warn("Kucoin error {}:'{}' bypassed, object probably disappeared correctly",
                 errCodeIt->get<std::string_view>(), msg);

--- a/src/api/exchanges/src/upbitprivateapi.cpp
+++ b/src/api/exchanges/src/upbitprivateapi.cpp
@@ -74,8 +74,8 @@ json PrivateQuery(CurlHandle& curlHandle, const APIKey& apiKey, HttpRequestType 
                           .set_payload_claim("access_key", jwt::claim(std::string(apiKey.key())))
                           .set_payload_claim("nonce", jwt::claim(std::string(Nonce_TimeSinceEpochInMs())));
 
-  if (!opts.getPostData().empty()) {
-    string queryHash = ssl::ShaDigest(ssl::ShaType::kSha512, opts.getPostData().str());
+  if (!opts.postData().empty()) {
+    string queryHash = ssl::ShaDigest(ssl::ShaType::kSha512, opts.postData().str());
 
     jsonWebToken.set_payload_claim("query_hash", jwt::claim(std::string(queryHash)))
         .set_payload_claim("query_hash_alg", jwt::claim(std::string("SHA512")));
@@ -605,6 +605,7 @@ InitiatedWithdrawInfo UpbitPrivate::launchWithdraw(MonetaryAmount grossAmount, W
   if (destinationWallet.hasTag()) {
     withdrawPostData.append("secondary_address", destinationWallet.tag());
   }
+
   json result =
       PrivateQuery(_curlHandle, _apiKey, HttpRequestType::kPost, "/v1/withdraws/coin", std::move(withdrawPostData));
   return {std::move(destinationWallet), std::move(result["uuid"].get_ref<string&>()), grossAmount};

--- a/src/http-request/include/curlhandle.hpp
+++ b/src/http-request/include/curlhandle.hpp
@@ -3,7 +3,6 @@
 #include <map>
 #include <string_view>
 #include <type_traits>
-#include <utility>
 
 #include "besturlpicker.hpp"
 #include "cct_string.hpp"
@@ -51,22 +50,18 @@ class CurlHandle {
   /// The pointed memory is valid until a next call to 'query'.
   std::string_view query(std::string_view endpoint, const CurlOptions &opts);
 
-  /// Same as 'query' except that internal memory buffer is immediately freed after the query.
-  /// This can be useful for rare queries with very large responses for instance.
-  string queryRelease(std::string_view endpoint, const CurlOptions &opts);
-
   std::string_view getNextBaseUrl() const { return _bestUrlPicker.getNextBaseURL(); }
 
   Duration minDurationBetweenQueries() const { return _minDurationBetweenQueries; }
 
   /// Instead of actually performing real calls, instructs this CurlHandle to
   /// return hardcoded responses (in values of given map) based on query endpoints with appended options (in key of
-  /// given map) This should be used only for tests purposes, as the search for the matching query is of linear
+  /// given map).
+  /// This should be used only for tests purposes, as the search for the matching query is of linear
   /// complexity in a flat key value string.
   void setOverridenQueryResponses(const std::map<string, string> &queryResponsesMap);
 
-  // CurlHandle is trivially relocatable
-  using trivially_relocatable = std::true_type;
+  using trivially_relocatable = is_trivially_relocatable<string>::type;
 
  private:
   void setUpProxy(const char *proxyUrl, bool reset);

--- a/src/http-request/include/curlmetrics.hpp
+++ b/src/http-request/include/curlmetrics.hpp
@@ -11,6 +11,7 @@ using MetricKeyPerRequestType = std::map<HttpRequestType, MetricKey>;
 struct CurlMetrics {
   static const MetricKeyPerRequestType kNbRequestsKeys;
   static const MetricKeyPerRequestType kRequestDurationKeys;
+  static const MetricKeyPerRequestType kNbRequestErrorKeys;
 };
 
 }  // namespace cct

--- a/src/http-request/include/httprequesttype.hpp
+++ b/src/http-request/include/httprequesttype.hpp
@@ -6,10 +6,10 @@
 #include "unreachable.hpp"
 
 namespace cct {
-enum class HttpRequestType : int8_t { kGet, kPost, kDelete };
+enum class HttpRequestType : int8_t { kGet, kPut, kPost, kDelete };
 
-static constexpr HttpRequestType kAllHttpRequestsTypes[] = {HttpRequestType::kGet, HttpRequestType::kPost,
-                                                            HttpRequestType::kDelete};
+static constexpr HttpRequestType kHttpRequestTypes[] = {HttpRequestType::kGet, HttpRequestType::kPost,
+                                                        HttpRequestType::kPut, HttpRequestType::kDelete};
 
 constexpr std::string_view ToString(HttpRequestType requestType) {
   switch (requestType) {
@@ -17,6 +17,8 @@ constexpr std::string_view ToString(HttpRequestType requestType) {
       return "GET";
     case HttpRequestType::kPost:
       return "POST";
+    case HttpRequestType::kPut:
+      return "PUT";
     case HttpRequestType::kDelete:
       return "DELETE";
     default:

--- a/src/http-request/include/invariant-request-retry.hpp
+++ b/src/http-request/include/invariant-request-retry.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include "cct_exception.hpp"
+#include "cct_json.hpp"
+#include "cct_log.hpp"
+#include "cct_type_traits.hpp"
+#include "curlhandle.hpp"
+#include "curloptions.hpp"
+#include "timedef.hpp"
+#include "unreachable.hpp"
+
+namespace cct {
+
+struct QueryRetryPolicy {
+  enum class TooManyFailuresPolicy : int8_t { kReturnEmpty, kThrowException };
+
+  Duration initialRetryDelay{TimeInMs(500)};
+  float exponentialBackoff{2};
+  int16_t nbMaxRetries{5};
+  TooManyFailuresPolicy tooManyFailuresPolicy{TooManyFailuresPolicy::kReturnEmpty};
+};
+
+/// Utility class to factorize basic retry mechanism around curlHandle query.
+/// Request options remain constant during calls.
+class InvariantRequestRetry {
+ public:
+  InvariantRequestRetry(CurlHandle &curlHandle, std::string_view endpoint, CurlOptions curlOptions,
+                        QueryRetryPolicy queryRetryPolicy = QueryRetryPolicy())
+      : _curlHandle(curlHandle),
+        _endpoint(endpoint),
+        _curlOptions(std::move(curlOptions)),
+        _queryRetryPolicy(queryRetryPolicy) {}
+
+  enum class Status : int8_t { kResponseError, kResponseOK };
+
+  /// Perform the query at most _nbMaxRetries + 1 times with an exponential backoff delay as long as
+  /// responseStatus(jsonResponse) returns kResponseError.
+  /// responseStatus should be a functor taking a single json by const reference argument, returning Status::kResponseOK
+  /// if success, Status::kResponseError in case of error.
+  template <class ResponseStatusT>
+  json queryJson(ResponseStatusT responseStatus) {
+    decltype(_queryRetryPolicy.nbMaxRetries) nbRetries = 0;
+    auto sleepingTime = _queryRetryPolicy.initialRetryDelay;
+    json ret;
+
+    do {
+      if (nbRetries != 0) {
+        log::warn("Got query error: '{}', retry {}/{} after {} ms", ret.dump(), nbRetries,
+                  _queryRetryPolicy.nbMaxRetries, std::chrono::duration_cast<TimeInMs>(sleepingTime).count());
+        std::this_thread::sleep_for(sleepingTime);
+        sleepingTime *= _queryRetryPolicy.exponentialBackoff;
+      }
+      ret = json::parse(_curlHandle.query(_endpoint, _curlOptions));
+    } while (responseStatus(ret) == Status::kResponseError && ++nbRetries <= _queryRetryPolicy.nbMaxRetries);
+
+    if (nbRetries > _queryRetryPolicy.nbMaxRetries) {
+      switch (_queryRetryPolicy.tooManyFailuresPolicy) {
+        case QueryRetryPolicy::TooManyFailuresPolicy::kReturnEmpty:
+          log::error("Too many query errors, returning empty result");
+          ret = json::object();
+          break;
+        case QueryRetryPolicy::TooManyFailuresPolicy::kThrowException:
+          throw exception("Too many query errors");
+        default:
+          unreachable();
+      }
+    }
+
+    return ret;
+  }
+
+  using trivially_relocatable = is_trivially_relocatable<CurlOptions>::type;
+
+ private:
+  CurlHandle &_curlHandle;
+  std::string_view _endpoint;
+  CurlOptions _curlOptions;
+  QueryRetryPolicy _queryRetryPolicy;
+};
+}  // namespace cct

--- a/src/http-request/src/curlmetrics.cpp
+++ b/src/http-request/src/curlmetrics.cpp
@@ -8,7 +8,7 @@ namespace {
 
 MetricKeyPerRequestType DefineTypes(MetricKey &requestCountKey) {
   MetricKeyPerRequestType ret;
-  for (HttpRequestType requestType : kAllHttpRequestsTypes) {
+  for (HttpRequestType requestType : kHttpRequestTypes) {
     requestCountKey.set("type", ToString(requestType));
     ret.insert_or_assign(requestType, requestCountKey);
   }
@@ -25,8 +25,14 @@ MetricKeyPerRequestType CreateRequestDurationMetricKeys() {
   return DefineTypes(requestCountKey);
 }
 
+MetricKeyPerRequestType CreateNbRequestErrorsMetricKeys() {
+  MetricKey requestCountKey = CreateMetricKey("http_request_error_count", "Counter of http request errors");
+  return DefineTypes(requestCountKey);
+}
+
 }  // namespace
 
 const MetricKeyPerRequestType CurlMetrics::kNbRequestsKeys = CreateNbRequestsMetricKeys();
 const MetricKeyPerRequestType CurlMetrics::kRequestDurationKeys = CreateRequestDurationMetricKeys();
+const MetricKeyPerRequestType CurlMetrics::kNbRequestErrorKeys = CreateNbRequestErrorsMetricKeys();
 }  // namespace cct

--- a/src/http-request/test/curlhandle_test.cpp
+++ b/src/http-request/test/curlhandle_test.cpp
@@ -48,10 +48,7 @@ class TestCurlHandle : public ::testing::Test {
   CurlHandle handle{kTestUrl};
 };
 
-TEST_F(TestCurlHandle, BasicCurlTest) {
-  EXPECT_EQ(handle.query("", kVerboseHttpGetOptions), "POOL_UP");
-  EXPECT_EQ(handle.queryRelease("", kVerboseHttpGetOptions), "POOL_UP");
-}
+TEST_F(TestCurlHandle, BasicCurlTest) { EXPECT_EQ(handle.query("", kVerboseHttpGetOptions), "POOL_UP"); }
 
 TEST_F(TestCurlHandle, ProxyMockTest) {
   if (IsProxyAvailable()) {

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -32,21 +32,23 @@ namespace {
 /// Theorem 15
 constexpr int kNbMaxDoubleDecimals = std::numeric_limits<double>::max_digits10;
 
-constexpr bool IsNotSpace(char ch) { return ch != ' '; }
-constexpr bool IsNotZero(char ch) { return ch != '0'; }
-
 constexpr void RemovePrefixSpaces(std::string_view &str) {
-  str.remove_prefix(std::ranges::find_if(str, IsNotSpace) - str.begin());
+  str.remove_prefix(std::ranges::find_if(str, [](char ch) { return ch != ' '; }) - str.begin());
 }
 constexpr void RemoveTrailingSpaces(std::string_view &str) {
-  str.remove_suffix(std::ranges::find_if(std::ranges::reverse_view(str), IsNotSpace) - std::ranges::rbegin(str));
+  str.remove_suffix(std::ranges::find_if(std::ranges::reverse_view(str), [](char ch) { return ch != ' '; }) -
+                    std::ranges::rbegin(str));
 }
 constexpr void RemoveTrailingZeros(std::string_view &str) {
-  str.remove_suffix(std::ranges::find_if(std::ranges::reverse_view(str), IsNotZero) - std::ranges::rbegin(str));
+  str.remove_suffix(std::ranges::find_if(std::ranges::reverse_view(str), [](char ch) { return ch != '0'; }) -
+                    std::ranges::rbegin(str));
 }
 
 inline int ParseNegativeChar(std::string_view &amountStr) {
   int negMult = 1;
+  if (amountStr.empty()) {
+    return negMult;
+  }
   RemovePrefixSpaces(amountStr);
   if (amountStr.front() < '0') {
     static_assert('-' < '0' && '+' < '0' && '.' < '0' && ' ' < '0');

--- a/src/objects/test/marketorderbook_test.cpp
+++ b/src/objects/test/marketorderbook_test.cpp
@@ -24,9 +24,6 @@ TEST(MarketOrderBookTest, Basic) { EXPECT_TRUE(MarketOrderBook(Market("ETH", "EU
 
 class MarketOrderBookTestCase1 : public ::testing::Test {
  protected:
-  void SetUp() override {}
-  void TearDown() override {}
-
   MarketOrderBook marketOrderBook{
       Market("ETH", "EUR"),
       std::array<OrderBookLine, 6>{

--- a/src/objects/test/monetaryamount_test.cpp
+++ b/src/objects/test/monetaryamount_test.cpp
@@ -242,6 +242,8 @@ TEST(MonetaryAmountTest, StringConstructor) {
   EXPECT_EQ(MonetaryAmount("05AUD"), MonetaryAmount(5, "AUD"));
   EXPECT_EQ(MonetaryAmount("746REPV2"), MonetaryAmount("746", "REPV2"));
 
+  EXPECT_EQ(MonetaryAmount("", "EUR"), MonetaryAmount(0, "EUR"));
+
   EXPECT_THROW(MonetaryAmount("usdt"), invalid_argument);
   EXPECT_NO_THROW(MonetaryAmount("usdt", MonetaryAmount::IfNoAmount::kNoThrow));
 }


### PR DESCRIPTION
Factorize retry mechanism code into a class that is used by public API exchanges. Also add internal curl request retries.
Also, instead of throwing an exception after too many failed queries, we return an empty json instead and the code can deal with it without crashing. This makes `coincenter` more robust for long-term running in case of connection disruptions.