### PR TITLE
[Code refactoring] Optimize CachedResult for key absence

### DIFF
--- a/src/tech/include/cachedresultvault.hpp
+++ b/src/tech/include/cachedresultvault.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 
@@ -38,18 +39,14 @@ class CachedResultVaultT {
 
   void freezeAll() {
     if (!_allFrozen) {
-      for (CachedResultBase<DurationT> *p : _cachedResults) {
-        p->freeze();
-      }
+      std::ranges::for_each(_cachedResults, [](CachedResultBase<DurationT> *p) { p->freeze(); });
       _allFrozen = true;
     }
   }
 
   void unfreezeAll() noexcept {
     if (_allFrozen) {
-      for (CachedResultBase<DurationT> *p : _cachedResults) {
-        p->unfreeze();
-      }
+      std::ranges::for_each(_cachedResults, [](CachedResultBase<DurationT> *p) { p->unfreeze(); });
       _allFrozen = false;
     }
   }

--- a/src/tech/test/cachedresult_test.cpp
+++ b/src/tech/test/cachedresult_test.cpp
@@ -37,9 +37,9 @@ constexpr SteadyClock::duration kCacheTime = milliseconds(10);
 constexpr auto kCacheExpireTime = kCacheTime + milliseconds(2);
 
 template <class T, class... FuncTArgs>
-using CachedResultSteadyClock = CachedResultT<SteadyClock, T, FuncTArgs...>;
+using CachedResultSteadyClock = details::CachedResultImpl<SteadyClock, T, FuncTArgs...>;
 
-using CachedResultOptionsSteadyClock = CachedResultOptionsT<SteadyClock::duration>;
+using CachedResultOptionsSteadyClock = details::CachedResultOptionsT<SteadyClock::duration>;
 
 using CachedResultVaultSteadyClock = CachedResultVaultT<SteadyClock::duration>;
 


### PR DESCRIPTION
When `CachedResult` is used without a key, no `std::unordered_map` is used and result data is stored inline and directly accessible.