### PR TITLE
[Bithumb API] - Support integral values for 'status' return code

### DIFF
--- a/src/api/exchanges/include/bithumbpublicapi.hpp
+++ b/src/api/exchanges/include/bithumbpublicapi.hpp
@@ -26,7 +26,11 @@ class CommonAPI;
 class BithumbPublic : public ExchangePublic {
  public:
   static constexpr std::string_view kExchangeName = "bithumb";
-  static constexpr std::string_view kStatusOKStr = "0000";
+  static constexpr auto kStatusOK = 0;
+  static constexpr auto kStatusUnexpectedError = -1;
+  static constexpr auto kStatusNotPresentError = -2;
+
+  static int64_t StatusCodeFromJsonResponse(const json& jsonResponse);
 
   BithumbPublic(const CoincenterInfo& config, FiatConverter& fiatConverter, CommonAPI& commonAPI);
 

--- a/src/engine/src/coincenter.cpp
+++ b/src/engine/src/coincenter.cpp
@@ -103,6 +103,7 @@ int Coincenter::process(const CoincenterCommands &coincenterCommands) {
   TimePoint lastCommandTime;
   for (int repeatPos = 0; repeatPos != nbRepeats && g_signalStatus == 0; ++repeatPos) {
     const auto earliestTimeNextCommand = lastCommandTime + repeatTime;
+
     lastCommandTime = Clock::now();
 
     if (earliestTimeNextCommand > lastCommandTime) {


### PR DESCRIPTION
When service is not available, it's possible to have '503' returned as integral instead of string.