### PR TITLE
Fix clang-tidy IWYU checks with pragmas

### DIFF
--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,6 +1,3 @@
-**/json.hpp
-
-# Ignore all protobuf/gRPC generated source files
-**/*.pb.cc
+*json.hpp
 
 */_deps/*

--- a/src/api/common/src/exchangepublicapi.cpp
+++ b/src/api/common/src/exchangepublicapi.cpp
@@ -16,6 +16,7 @@
 #include "cct_allocator.hpp"
 #include "cct_exception.hpp"
 #include "cct_flatset.hpp"
+#include "cct_log.hpp"
 #include "cct_smallset.hpp"
 #include "cct_smallvector.hpp"
 #include "cct_vector.hpp"

--- a/src/api/common/src/fiatconverter.cpp
+++ b/src/api/common/src/fiatconverter.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "cct_json.hpp"
+#include "cct_log.hpp"
 #include "cct_string.hpp"
 #include "coincenterinfo.hpp"
 #include "curloptions.hpp"

--- a/src/api/common/src/ssl_sha.cpp
+++ b/src/api/common/src/ssl_sha.cpp
@@ -4,6 +4,7 @@
 #include <openssl/hmac.h>
 #include <openssl/opensslv.h>
 #include <openssl/sha.h>
+#include <openssl/types.h>
 
 #include <algorithm>
 #include <array>

--- a/src/api/exchanges/src/binanceprivateapi.cpp
+++ b/src/api/exchanges/src/binanceprivateapi.cpp
@@ -21,6 +21,7 @@
 #include "cachedresult.hpp"
 #include "cct_exception.hpp"
 #include "cct_json.hpp"
+#include "cct_log.hpp"
 #include "cct_smallvector.hpp"
 #include "cct_string.hpp"
 #include "closed-order.hpp"

--- a/src/main/src/processcommandsfromcli.cpp
+++ b/src/main/src/processcommandsfromcli.cpp
@@ -3,6 +3,7 @@
 #include <string_view>
 
 #include "cct_exception.hpp"
+#include "cct_log.hpp"
 #include "coincenter-commands-processor.hpp"
 #include "coincenter.hpp"
 #include "coincenterinfo.hpp"

--- a/src/objects/src/monetaryamount.cpp
+++ b/src/objects/src/monetaryamount.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <cmath>
 #include <compare>
-#include <concepts>
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
@@ -15,13 +14,13 @@
 #include <ranges>
 #include <sstream>
 #include <string_view>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 
 #include "cct_config.hpp"
 #include "cct_exception.hpp"
 #include "cct_invalid_argument_exception.hpp"
+#include "cct_log.hpp"
 #include "currencycode.hpp"
 #include "ipow.hpp"
 #include "ndigits.hpp"

--- a/src/serialization/CMakeLists.txt
+++ b/src/serialization/CMakeLists.txt
@@ -29,7 +29,15 @@ if(CCT_ENABLE_PROTO)
     TARGET coincenter_serialization
     IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/proto"
     PROTOC_OUT_DIR "${PROTO_BINARY_DIR}"
+    OUT_VAR PROTO_GENERATED_FILES
   )
+
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27.0")
+    set_source_files_properties(${PROTO_GENERATED_FILES}
+      PROPERTIES
+      SKIP_LINTING ON
+    )
+  endif()
 
   add_unit_test(
     continuous-iterator_test

--- a/src/tech/include/cct_log.hpp
+++ b/src/tech/include/cct_log.hpp
@@ -5,7 +5,7 @@
 #ifdef CCT_DISABLE_SPDLOG
 #include <string_view>
 #else
-#include <spdlog/spdlog.h>
+#include <spdlog/spdlog.h>  // IWYU pragma: export
 #endif
 
 namespace cct {


### PR DESCRIPTION
- Remove false positive reports from clang-tidy for `cct_log.hpp`
- Do not lint protobuf generated files
