### PR TITLE
Possibility to configure activation of exchange

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -88,6 +88,16 @@ As an example, consider this file:
 
 ```json
 {
+  "general" : {
+    "default": {
+      "enabled": true
+    },
+    "exchange": {
+      "kucoin": {
+        "enabled": false
+      }
+    }
+  },
   "asset": {
     "default": {
       "withdrawExclude": "BTC"
@@ -128,6 +138,7 @@ Refer to the hardcoded default json example as a model in case of doubt.
 
 | Module      | Name                               | Value                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                              |
 | ----------- | ---------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| *general*   | **enabled**                        | Boolean (`true` or `false`)                                                    | If not enabled, no query will be made for this exchange.                                                                                                                                                                                                                                                                                                                                                                 |
 | *asset*     | **allExclude**                     | Array of coin acronyms (ex: `["EUR", "AUD"]`)                                  | Exclude coins with these acronym from `coincenter`                                                                                                                                                                                                                                                                                                                                                                       |
 | *asset*     | **withdrawExclude**                | Array of coin acronyms (ex: `["BTC", "ETC"]`)                                  | Make these coins unavailable for withdraw                                                                                                                                                                                                                                                                                                                                                                                |
 | *asset*     | **preferredPaymentCurrencies**     | Ordered array of coin acronyms (ex: `["USDT", "BTC"]`)                         | Coins that can be used for smart buy and sell as base payment currency. They should be ordered by decreasing priority.                                                                                                                                                                                                                                                                                                   |

--- a/src/schema/include/exchange-config.hpp
+++ b/src/schema/include/exchange-config.hpp
@@ -7,6 +7,7 @@
 #include "cct_fixedcapacityvector.hpp"
 #include "cct_string.hpp"
 #include "exchange-asset-config.hpp"
+#include "exchange-general-config.hpp"
 #include "exchange-query-config.hpp"
 #include "exchange-tradefees-config.hpp"
 #include "exchange-withdraw-config.hpp"
@@ -26,6 +27,7 @@ struct ExchangeConfigPart {
 };
 
 struct AllExchangeConfigsOptional {
+  ExchangeConfigPart<ExchangeGeneralConfigOptional> general;
   ExchangeConfigPart<ExchangeAssetConfig> asset;
   ExchangeConfigPart<ExchangeQueryConfigOptional> query;
   ExchangeConfigPart<ExchangeTradeFeesConfigOptional> tradeFees;
@@ -35,6 +37,7 @@ struct AllExchangeConfigsOptional {
 }  // namespace details
 
 struct ExchangeConfig {
+  ExchangeGeneralConfig general;
   ExchangeAssetConfig asset;
   ExchangeQueryConfig query;
   ExchangeTradeFeesConfig tradeFees;

--- a/src/schema/include/exchange-general-config.hpp
+++ b/src/schema/include/exchange-general-config.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <type_traits>
+
+#include "optional-or-type.hpp"
+
+namespace cct::schema {
+
+namespace details {
+template <bool Optional>
+struct ExchangeGeneralConfig {
+  template <class T, std::enable_if_t<std::is_same_v<T, ExchangeGeneralConfig<true>> && !Optional, bool> = true>
+  void mergeWith(const T &other) {
+    if (other.enabled) {
+      enabled = *other.enabled;
+    }
+  }
+
+  optional_or_t<bool, Optional> enabled{true};
+};
+
+using ExchangeGeneralConfigOptional = ExchangeGeneralConfig<true>;
+
+}  // namespace details
+
+using ExchangeGeneralConfig = details::ExchangeGeneralConfig<false>;
+
+}  // namespace cct::schema

--- a/src/schema/src/exchange-config-default.hpp
+++ b/src/schema/src/exchange-config-default.hpp
@@ -7,6 +7,11 @@ namespace cct {
 struct ExchangeConfigDefault {
   static constexpr std::string_view kProd = R"(
 {
+  "general": {
+    "default": {
+      "enabled": true
+    }
+  },
   "asset": {
     "default": {
       "allExclude": [],

--- a/src/schema/src/exchange-config.cpp
+++ b/src/schema/src/exchange-config.cpp
@@ -56,6 +56,12 @@ void AllExchangeConfigs::mergeWith(schema::details::AllExchangeConfigsOptional &
       return pair.first == exchangeNameEnum;
     };
 
+    exchangeConfig.general.mergeWith(other.general.def);
+    auto generalIt = std::ranges::find_if(other.general.exchange, matchExchangeIt);
+    if (generalIt != other.general.exchange.end()) {
+      exchangeConfig.general.mergeWith(generalIt->second);
+    }
+
     exchangeConfig.asset.mergeWith(other.asset.def);
     auto assetIt = std::ranges::find_if(other.asset.exchange, matchExchangeIt);
     if (assetIt != other.asset.exchange.end()) {


### PR DESCRIPTION
By default, all exchanges are enabled. But it's possible to disable exchanges in the `exchangeconfig.json` now.